### PR TITLE
(SIMP-561) Fixed failing tests

### DIFF
--- a/.puppet-lint.rc
+++ b/.puppet-lint.rc
@@ -1,0 +1,5 @@
+--log-format="%{path}:%{line}:%{check}:%{KIND}:%{message}"
+--relative
+--no-variables_not_enclosed-check
+--no-class_inherits_from_params_class-check
+--no-80chars-check

--- a/Gemfile
+++ b/Gemfile
@@ -11,10 +11,12 @@ group :test do
   gem "rake"
   gem 'puppet', puppetversion
   gem "rspec", '< 3.2.0'
-  gem "rspec-puppet", :git => 'https://github.com/rodjek/rspec-puppet.git'
+  gem "rspec-puppet"
   gem "puppetlabs_spec_helper"
   gem "metadata-json-lint"
   gem "simp-rspec-puppet-facts"
+  # A bug the broke .ignore_paths was fixed on 30 Oct 2015:
+  gem "puppet-lint", :git => 'https://github.com/rodjek/puppet-lint.git'
 
   # simp-rake-helpers does not suport puppet 2.7.X
   if "#{ENV['PUPPET_VERSION']}".scan(/\d+/).first != '2' &&

--- a/README.md
+++ b/README.md
@@ -20,8 +20,8 @@ This module manages the Audit daemon, kernel parameters, and related subsystems.
 
 ### OS Compatibility
 This module has been tested against:
-  * Red Hat Enterprise Linux >= 6.6
-  * CentOS >= 6.6
+  * Red Hat Enterprise Linux >= 6.7
+  * CentOS >= 6.7
   * Red Hat Enterprise Linux >= 7.1
   * CentOS >= 7.0
 

--- a/Rakefile
+++ b/Rakefile
@@ -10,40 +10,17 @@ begin
 rescue LoadError
 end
 
-
-# FIXME: move all this lint logic into simp-rake-helpers
-Rake::Task[:lint].clear
-
 # Lint Material
-begin
-  require 'puppet-lint/tasks/puppet-lint'
-
-  PuppetLint.configuration.send("disable_80chars")
-  PuppetLint.configuration.send("disable_variables_not_enclosed")
-  PuppetLint.configuration.send("disable_class_parameter_defaults")
-
-  PuppetLint.configuration.relative = true
-  PuppetLint.configuration.log_format = "%{path}:%{linenumber}:%{check}:%{KIND}:%{message}"
-  #PuppetLint.configuration.fail_on_warnings = true
-
-  # Forsake support for Puppet 2.6.2 for the benefit of cleaner code.
-  # http://puppet-lint.com/checks/class_parameter_defaults/
-  PuppetLint.configuration.send('disable_class_parameter_defaults')
-  # http://puppet-lint.com/checks/class_inherits_from_params_class/
-  PuppetLint.configuration.send('disable_class_inherits_from_params_class')
-
-  exclude_paths = [
-    "bundle/**/*",
-    "pkg/**/*",
-    "dist/**/*",
-    "vendor/**/*",
-    "spec/**/*",
-  ]
-  PuppetLint.configuration.ignore_paths = exclude_paths
-  PuppetSyntax.exclude_paths = exclude_paths
-rescue LoadError
-  puts "== WARNING: Gem puppet-lint not found, lint tests cannot be run! =="
-end
+require 'puppet-lint/tasks/puppet-lint'
+exclude_paths = [
+  "bundle/**/*",
+  "pkg/**/*",
+  "dist/**/*",
+  "vendor/**/*",
+  "spec/**/*",
+]
+PuppetLint.configuration.ignore_paths = exclude_paths
+PuppetSyntax.exclude_paths = exclude_paths
 
 begin
   require 'simp/rake/pkg'

--- a/manifests/add_rules.pp
+++ b/manifests/add_rules.pp
@@ -39,6 +39,8 @@ define auditd::add_rules (
   validate_bool($absolute)
   validate_bool($prepend)
 
+  include 'auditd'
+
   if $prepend {
     $rule_id = "00.${name}.rules"
   }

--- a/manifests/config.pp
+++ b/manifests/config.pp
@@ -71,9 +71,9 @@ class auditd::config (
   }
 
   file { '/etc/audit/audit.rules':
-    owner   => 'root',
-    group   => 'root',
-    mode    => '0600'
+    owner => 'root',
+    group => 'root',
+    mode  => '0600'
   }
 
   file { '/etc/audit/auditd.conf':

--- a/manifests/params.pp
+++ b/manifests/params.pp
@@ -4,13 +4,11 @@
 # It sets variables according to platform.
 #
 class auditd::params {
-  case $::osfamily {
-    'RedHat': {
-      $package_name = 'audit'
-      $service_name = 'auditd'
-    }
-    default: {
-      fail("${::operatingsystem} not supported")
-    }
+  if $::operatingsystem in ['RedHat','CentOS'] {
+    $package_name = 'audit'
+    $service_name = 'auditd'
+  }
+  else {
+    fail("${::operatingsystem} not supported")
   }
 }

--- a/manifests/service.pp
+++ b/manifests/service.pp
@@ -18,7 +18,7 @@ class auditd::service {
       }
 
       # This is needed just in case the audit dispatcher fails at some point.
-      exec { "Restart Audispd":
+      exec { 'Restart Audispd':
         command => '/bin/true',
         unless  => "/usr/bin/pgrep -f $::auditd::dispatcher",
         notify  => Service[$::auditd::service_name]


### PR DESCRIPTION
Before this commit, auditd would cause several spec tests to fail in
pupmod-simp-common's `secure_mountpoints`.  This commit fixes those
problems, introduces a .puppet-lint.rc, and cleans up minor style
issues.

SIMP-561 #comment Fixed auditd issues that failed spec tests in common.