### PR TITLE
Update base.erb

### DIFF
--- a/templates/rule_profiles/simp/base.erb
+++ b/templates/rule_profiles/simp/base.erb
@@ -133,8 +133,8 @@
 
 # CCE-26610-6
 -w /var/run/utmp -p wa -k session
--w /var/run/btmp -p wa -k session
--w /var/run/wtmp -p wa -k session
+-w /var/log/btmp -p wa -k session
+-w /var/log/wtmp -p wa -k session
 
 # CCE-26662-7
 -w /etc/sudoers -p wa -k CFG_sys


### PR DESCRIPTION
btmp and wtmp reside in /var/log not /var/run. Suspect copy/paste error.