### PR TITLE
(SIMP-1239) Fix for strict_variables failure

### DIFF
--- a/CHANGELOG
+++ b/CHANGELOG
@@ -1,3 +1,6 @@
+* Tue Jul 26 2016 Lucas Yamanishi <lucas.yamanishi@onyxpoint.com> - 5.0.3-0
+- Fix for strict_variables failure
+
 * Wed Jul 06 2016 Nick Markowski <nmarkowski@keywcorp.com> - 5.0.2-0
 - Added a default audit rule for 'renameat', per CCE-26651-0.
 - Added an auditd_version fact.

--- a/manifests/init.pp
+++ b/manifests/init.pp
@@ -142,24 +142,15 @@ class auditd (
   validate_array_member($name_format,['NONE','HOSTNAME','FQD','NUMERIC','USER'],'i')
   validate_integer($max_log_file)
   validate_integer($space_left)
-  if (versioncmp($::auditd_version,'2.4.1') >= 0) {
-    validate_array_member($space_left_action,['IGNORE','SYSLOG','ROTATE','EMAIL','EXEC','SUSPEND','SINGLE','HALT'],'i')
-  }
-  else {
-    validate_array_member($space_left_action,['IGNORE','SYSLOG','EMAIL','EXEC','SUSPEND','SINGLE','HALT'],'i')
-  }
   validate_integer($admin_space_left)
-  if (versioncmp($::auditd_version,'2.4.1') >= 0) {
-    validate_array_member($admin_space_left_action,['IGNORE','SYSLOG','ROTATE','EMAIL','EXEC','SUSPEND','SINGLE','HALT'],'i')
-  }
-  else {
-    validate_array_member($admin_space_left_action,['IGNORE','SYSLOG','EMAIL','EXEC','SUSPEND','SINGLE','HALT'],'i')
-  }
-  if (versioncmp($::auditd_version, '2.4.1') >= 0) {
-    validate_array_member($disk_full_action,['IGNORE','SYSLOG','ROTATE','EXEC','SUSPEND','SINGLE','HALT'],'i')
-  }
-  else {
-    validate_array_member($disk_full_action,['IGNORE','SYSLOG','EXEC','SUSPEND','SINGLE','HALT'],'i')
+  if defined('$::auditd_version') and (versioncmp($::auditd_version,'2.4.1') >= 0) {
+    validate_array_member($space_left_action, ['IGNORE','SYSLOG','ROTATE','EMAIL','EXEC','SUSPEND','SINGLE','HALT'],'i')
+    validate_array_member($admin_space_left_action, ['IGNORE','SYSLOG','ROTATE','EMAIL','EXEC','SUSPEND','SINGLE','HALT'],'i')
+    validate_array_member($disk_full_action, ['IGNORE','SYSLOG','ROTATE','EXEC','SUSPEND','SINGLE','HALT'],'i')
+  } else {
+    validate_array_member($space_left_action, ['IGNORE','SYSLOG','EMAIL','EXEC','SUSPEND','SINGLE','HALT'],'i')
+    validate_array_member($admin_space_left_action, ['IGNORE','SYSLOG','EMAIL','EXEC','SUSPEND','SINGLE','HALT'],'i')
+    validate_array_member($disk_full_action, ['IGNORE','SYSLOG','EXEC','SUSPEND','SINGLE','HALT'],'i')
   }
   validate_array_member($disk_error_action,['IGNORE','SYSLOG','EXEC','SUSPEND','SINGLE','HALT'],'i')
   validate_integer($buffer_size)

--- a/metadata.json
+++ b/metadata.json
@@ -1,6 +1,6 @@
 {
   "name": "simp-auditd",
-  "version": "5.0.2",
+  "version": "5.0.3",
   "author": "simp",
   "summary": "A SIMP puppet module for managing auditd and audispd",
   "license": "Apache-2.0",


### PR DESCRIPTION
Use `defined()` to test for `undef` state on `$::auditd_version`.  Previously the null case was not checked, causing compilation to fail if strict variable checking was enabled.