### PR TITLE
(SIMP-1526) Rework auditd syslog message dropping

### DIFF
--- a/CHANGELOG
+++ b/CHANGELOG
@@ -1,6 +1,8 @@
-* Mon Sep 26 2016 Jeanne Greulich<jeanne.greulich@onxypoint.com> - 5.1.0-0
+* Mon Sep 26 2016 Jeanne Greulich, Liz Nemsick - 5.1.0-0
 - Allow user to specify syslog facility and priority for audit record
   messages.
+- Allow user to enable/disable audit record syslog messaging independent
+  of the presence of forwarding logging servers.
 
 * Mon Aug 29 2016 Ralph Wright <ralph.wright@onyxpoint.com> - 5.0.4-0
 - Added booleans to toggle sections of audit rules.

--- a/manifests/config/audisp/syslog.pp
+++ b/manifests/config/audisp/syslog.pp
@@ -1,23 +1,33 @@
 # == Class auditd::config::audisp::syslog
 #
 # This class utilizes rsyslog to send all audit records to syslog.
-# This will definitely increase the volume of log messages passing out of your
-# system and you should probably ensure that they are encrypted using the
-# stunnel module.
+#
+# This capability is most useful for forwarding audit records to
+# remote servers as syslog messages, since these records are already
+# persisted locally in audit logs.  For most sites, however, using
+# this capability for all audit records can quickly overwhelm host
+# and/or network resources, especially if the messages are forwarded
+# to multiple remote syslog servers or (inadvertently) persisted
+# locally. Site-specific, rsyslog actions to implement filtering will
+# likely be required to reduce this message traffic.
+#
+# As a precaution, to prevent the above overload scenario, this class,
+# by default, inserts a rsyslog action to drop these messages, prior to
+# forwarding to remote syslog servers or writing to local syslog files.
+# You can disable this drop behavior via configuration, but are strongly
+# advised to apply appropriate syslog message filtering before doing so.
+# We also recommend you ensure any forwarded, audit messages are
+# encrypted using the stunnel module, due to the nature of the
+# information carried by these messages.
 #
 # == Parameters
 #
-# [*log_server*]
-#   The server to which to send the logs.
-#
-# [*encrypt_logs*]
-#   If set to 'true', this will send the logs to
-#   127.0.0.1:$encrypted_port.
-#
-#   This expects an stunnel type setup.
-#
-# [*encrypted_port*]
-#   The port to which to send the logs on localhost.
+# [*drop_audit_logs*]
+#   Type:  Boolean
+#   Default:  true
+#     When set to false, auditd records will be forwarded to remote
+#     servers and/or written to local syslog files, as directed by the
+#     site rsyslog configuration.
 #
 # [*priority*]
 #   Type:  String
@@ -37,11 +47,11 @@
 #     are allowed.
 #
 class auditd::config::audisp::syslog (
-  $log_servers = hiera('log_servers',[]),
+  $drop_audit_logs = true,
   $priority = "LOG_INFO",
   $facility = ""
 ) {
-  validate_array($log_servers)
+  validate_bool($drop_audit_logs)
   validate_array_member($priority, ['LOG_DEBUG', 'LOG_INFO',
     'LOG_NOTICE', 'LOG_WARNING', 'LOG_ERR', 'LOG_CRIT', 'LOG_ALERT',
     'LOG_EMERG'])
@@ -50,9 +60,10 @@ class auditd::config::audisp::syslog (
     'LOG_LOCAL2', 'LOG_LOCAL3', 'LOG_LOCAL4', 'LOG_LOCAL5', 'LOG_LOCAL6',
     'LOG_LOCAL7'])
 
-  if !empty($log_servers) {
-    # Note: This only happens if you are offloading your logs.
-    # Otherwise, just go look at the audit files.
+  if $drop_audit_logs {
+    # This will prevent audit records from being forwarded to remote
+    # servers and/or written to local syslog files, but you still have
+    # access to the records in the local audit log files.
     rsyslog::rule::drop { 'audispd':
       rule   => 'if $programname == \'audispd\''
     }

--- a/manifests/init.pp
+++ b/manifests/init.pp
@@ -80,8 +80,7 @@
 # [*enable_auditing*]
 #   Type: Boolean
 #   Default: +true+
-#     If true, enable auditing. In this case, this will turn the auditd class
-#     into a NOOP.
+#     If true, enable auditing. 
 #
 class auditd (
   $ignore_failures = true,
@@ -169,7 +168,7 @@ class auditd (
 
   compliance_map()
 
-  # This is done here so that theh kernel option can be properly removed if
+  # This is done here so that the kernel option can be properly removed if
   # auditing is to be disabled on the system.
   if $enable_auditing {
     if $at_boot {

--- a/spec/acceptance/suites/default/00_base_spec.rb
+++ b/spec/acceptance/suites/default/00_base_spec.rb
@@ -3,10 +3,25 @@ require 'spec_helper_acceptance'
 test_name 'auditd class'
 
 describe 'auditd class' do
+  let(:pki_hieradata) {
+    {
+      'pki::cacerts_sources'    => ['file:///etc/pki/simp-testing/pki/cacerts'] ,
+      'pki::private_key_source' => "file:///etc/pki/simp-testing/pki/private/%{fqdn}.pem",
+      'pki::public_key_source'  => "file:///etc/pki/simp-testing/pki/public/%{fqdn}.pub"
+    }
+  }
+
   let(:disable_hieradata) {
     {
       'auditd::at_boot' => false
-    }
+    }.merge(pki_hieradata)
+  }
+
+  let(:enable_audit_messages) {
+    {
+      'auditd::config::audisp::syslog::drop_audit_logs' => false,
+      'auditd::config::audisp::syslog::syslog_priority' => 'LOG_NOTICE'
+    }.merge(pki_hieradata)
   }
 
   let(:manifest) {
@@ -15,75 +30,106 @@ describe 'auditd class' do
     EOS
   }
 
+
   hosts.each do |host|
-    context 'default parameters' do
-      # Using puppet_apply as a helper
-      it 'should work with no errors' do
-        apply_manifest_on(host, manifest, :catch_failures => true)
+    context "on #{host}" do
+      context 'default parameters' do
+        # Using puppet_apply as a helper
+        it 'should work with no errors' do
+          set_hieradata_on(host, pki_hieradata)
+          apply_manifest_on(host, manifest, :catch_failures => true)
+        end
+
+        it 'should require reboot on subsequent run' do
+          result = apply_manifest_on(host, manifest, :catch_failures => true)
+          expect(result.output).to include('audit => modified')
+          # Reboot to enable auditing in the kernel
+          host.reboot
+        end
+
+        it 'should have kernel-level audit enabled on reboot' do
+          on(host, 'grep "audit=1" /proc/cmdline')
+        end
+
+        it 'should have the audit package installed' do
+          result = on(host, 'puppet resource package audit')
+          expect(result.output).to_not include("ensure => 'absent'")
+        end
+
+        it 'should activate the auditd service' do
+          result = on(host, 'puppet resource service auditd')
+          expect(result.output).to include("ensure => 'running'")
+          expect(result.output).to include("enable => 'true'")
+        end
+
+        it 'should be running the audit dispatcher' do
+          on(host, 'pgrep audispd')
+        end
+
+        it 'should restart the audit dispatcher if it is killed' do
+          on(host, 'pkill audispd')
+          apply_manifest_on(host, manifest, :catch_failures => true)
+          on(host, 'pgrep audispd')
+        end
+
+        it 'should not send audit logs to syslog' do
+          # log rotate so any audit messages present before the apply turned off
+          # audit record logging are no longer in /var/log/messages
+          on(host, 'logrotate --force /etc/logrotate.d/syslog')
+          # cause an auditable events
+          on(host,'puppet resource service crond ensure=stopped')
+          on(host,'puppet resource service crond ensure=running')
+          on(host, %(grep -qe 'audispd:.*msg=audit' /var/log/messages), :acceptable_exit_codes => [1])
+        end
       end
 
-      it 'should require reboot on subsequent run' do
-        result = apply_manifest_on(host, manifest, :catch_failures => true)
-        expect(result.output).to include('audit => modified')
+      context 'allowing audit messages' do
+        it 'should work with no errors' do
+          set_hieradata_on(host, enable_audit_messages)
+          apply_manifest_on(host, manifest, :catch_failures => true)
 
-        # Reboot to enable auditing in the kernel
-        host.reboot
+          # TODO Undo this workaround when rsyslog module is fixed.
+          # To work around a rsyslog module bug whereby the drop file is
+          # not purged when it is no longer managed, manually remove that
+          # file and then restart rsyslog to pick up the configuration change.
+          on(host,'rm -f /etc/rsyslog.simp.d/07_simp_drop_rules/audispd.conf')
+          on(host,'puppet resource service rsyslog ensure=stopped')
+          on(host,'puppet resource service rsyslog ensure=running')
+        end
+
+        it 'should send audit logs to syslog' do
+          # cause auditable events
+          on(host,'puppet resource service crond ensure=stopped')
+          on(host,'puppet resource service crond ensure=running')
+          on(host, %(grep -qe 'audispd:.*msg=audit' /var/log/messages))
+        end
       end
 
-      it 'should have kernel-level audit enabled on reboot' do
-        on(host, 'grep "audit=1" /proc/cmdline')
-      end
+      context 'disabling auditd at the kernel level' do
+        it 'should work with no errors' do
+          set_hieradata_on(host, disable_hieradata)
+          apply_manifest_on(host, manifest, :catch_failures => true)
+        end
 
-      it 'should have the audit package installed' do
-        result = on(host, 'puppet resource package audit')
-        expect(result.output).to_not include("ensure => 'absent'")
-      end
+        # Note: In SIMP, svckill will take care of actually disabling auditd if
+        # it is no longer managed. Here, we're not including svckill by default.
+        it 'should not kill the auditd service' do
+          result = on(host, 'puppet resource service auditd')
+          expect(result.output).to include("ensure => 'running'")
+          expect(result.output).to include("enable => 'true'")
+        end
 
-      it 'should activate the auditd service' do
-        result = on(host, 'puppet resource service auditd')
-        expect(result.output).to include("ensure => 'running'")
-        expect(result.output).to include("enable => 'true'")
-      end
+        it 'should require reboot on subsequent run' do
+          result = apply_manifest_on(host, manifest, :catch_failures => true)
+          expect(result.output).to include('audit => modified')
 
-      it 'should be running the audit dispatcher' do
-        on(host, 'pgrep audispd')
-      end
+          # Reboot to disable auditing in the kernel
+          host.reboot
+        end
 
-      it 'should restart the audit dispatcher if it is killed' do
-        on(host, 'pkill audispd')
-        apply_manifest_on(host, manifest, :catch_failures => true)
-        on(host, 'pgrep audispd')
-      end
-
-      it 'should send audit logs to syslog' do
-        on(host, %(grep -qe 'audispd:.*msg=audit' /var/log/messages))
-      end
-    end
-
-    context 'disabling auditd at the kernel level' do
-      it 'should work with no errors' do
-        set_hieradata_on(host, disable_hieradata)
-        apply_manifest_on(host, manifest, :catch_failures => true)
-      end
-
-      # Note: In SIMP, svckill will take care of actually disabling auditd if
-      # it is no longer managed. Here, we're not including svckill by default.
-      it 'should not kill the auditd service' do
-        result = on(host, 'puppet resource service auditd')
-        expect(result.output).to include("ensure => 'running'")
-        expect(result.output).to include("enable => 'true'")
-      end
-
-      it 'should require reboot on subsequent run' do
-        result = apply_manifest_on(host, manifest, :catch_failures => true)
-        expect(result.output).to include('audit => modified')
-
-        # Reboot to enable auditing in the kernel
-        host.reboot
-      end
-
-      it 'should have kernel-level audit disabled on reboot' do
-        on(host, 'grep "audit=0" /proc/cmdline')
+        it 'should have kernel-level audit disabled on reboot' do
+          on(host, 'grep "audit=0" /proc/cmdline')
+        end
       end
     end
   end

--- a/spec/classes/config/audisp/syslog_spec.rb
+++ b/spec/classes/config/audisp/syslog_spec.rb
@@ -16,7 +16,6 @@ describe 'auditd::config::audisp::syslog' do
           facts
         end
 
-        it { is_expected.to compile.with_all_deps }
 
         context "without any parameters" do
           let(:params) {{ }}
@@ -35,7 +34,9 @@ EOM
           it {
             is_expected.to contain_file('/etc/audisp/plugins.d/syslog.conf').with_content(expected_content)
           }
-          it { is_expected.to_not contain_rsyslog__rule__drop('audispd') }
+          it {
+            is_expected.to contain_rsyslog__rule__drop('audispd').with_rule(%r(if \$programname == 'audispd'))
+          }
         end
 
         context "when setting syslog priority and facility" do
@@ -58,19 +59,21 @@ EOM
           it {
             is_expected.to contain_file('/etc/audisp/plugins.d/syslog.conf').with_content(expected_content)
           }
-          it { is_expected.to_not contain_rsyslog__rule__drop('audispd') }
+          it {
+            is_expected.to contain_rsyslog__rule__drop('audispd').with_rule(%r(if \$programname == 'audispd'))
+          }
         end
 
-        context "when setting log servers" do
+        context "when allow audit messages" do
           let(:params) {{
-            :log_servers => ['1.2.3.4']
+            :drop_audit_logs => false
           }}
 
           it { is_expected.to compile.with_all_deps }
           it {
             is_expected.to contain_file('/etc/audisp/plugins.d/syslog.conf').with_content(%r(active = yes))
           }
-          it { is_expected.to contain_rsyslog__rule__drop('audispd').with_rule(%r(if \$programname == 'audispd')) }
+          it { is_expected.to_not contain_rsyslog__rule__drop('audispd') }
         end
 
         context "when syslog priority is invalid" do

--- a/spec/fixtures/hieradata/default.yaml
+++ b/spec/fixtures/hieradata/default.yaml
@@ -1,5 +1,4 @@
 ---
-log_server : 'syslog.bar.baz'
 client_nets :
   - 1.2.3.4
   - 5.6.7.8


### PR DESCRIPTION
Use a configuration variable to determine when to drop audit record
log messages, instead of the presence of configured syslog forwarding
servers listed in $log_servers variable.

SIMP-1526 #close
