### PR TITLE
(SIMP-1595) Provide complete dependency boundaries

### DIFF
--- a/build/rpm_metadata/requires
+++ b/build/rpm_metadata/requires
@@ -1,5 +1,12 @@
-Requires: pupmod-herculesteam-augeasproviders_grub
-Requires: pupmod-simp-compliance_markup
-Requires: pupmod-simp-rsyslog >= 4.1.0-10
-Requires: pupmod-simp-simpcat >= 2.0.0-0
 Obsoletes: pupmod-auditd-test >= 0.0.1
+Requires: pupmod-herculesteam-augeasproviders_grub < 3.0.0-0
+Requires: pupmod-herculesteam-augeasproviders_grub >= 2.3.1-0
+Requires: pupmod-puppetlabs-stdlib < 5.0.0-0
+Requires: pupmod-puppetlabs-stdlib >= 4.9.0-0
+Requires: pupmod-simp-compliance_markup < 2.0.0-0
+Requires: pupmod-simp-compliance_markup >= 1.0.1-0
+Requires: pupmod-simp-rsyslog < 6.0.0-0
+Requires: pupmod-simp-rsyslog >= 5.1.0-0
+Requires: pupmod-simp-simpcat >= 2.0.0-0
+Requires: pupmod-simp-simplib < 2.0.0-0
+Requires: pupmod-simp-simplib >= 1.3.1-0

--- a/metadata.json
+++ b/metadata.json
@@ -1,6 +1,6 @@
 {
   "name": "simp-auditd",
-  "version": "5.1.0",
+  "version": "5.1.1",
   "author": "simp",
   "summary": "A SIMP puppet module for managing auditd and audispd",
   "license": "Apache-2.0",
@@ -15,19 +15,23 @@
   "dependencies": [
     {
       "name": "herculesteam/augeasproviders_grub",
-      "version_requirement": ">= 2.0.1"
+      "version_requirement": ">= 2.3.1 < 3.0.0"
     },
     {
       "name": "puppetlabs/stdlib",
-      "version_requirement": ">= 4.1.0"
+      "version_requirement": ">= 4.9.0 < 5.0.0"
+    },
+    {
+      "name": "simp/rsyslog",
+      "version_requirement": ">= 5.1.0 < 6.0.0"
     },
     {
       "name": "simp/simplib",
-      "version_requirement": ">= 1.0.0"
+      "version_requirement": ">= 1.3.1 < 2.0.0"
     },
     {
       "name": "simp/compliance_markup",
-      "version_requirement": ">= 1.0.0"
+      "version_requirement": ">= 1.0.1 < 2.0.0"
     }
   ],
   "operatingsystem_support": [


### PR DESCRIPTION
Before this patch, dependencies in `metadata.json` and
`build/rpm_metadata/requires` were missing upper boundaries and often
listed inaccurate lower boundaries.  This created an extremely fragile
5.2.X/4.3.X module ecosystem on the Forge, as a major release in any
dependency would be certain to break the module.

This commit resolves the issue by introducing upper and lower boundaries
for each dependency in `metadata.json` and propagates those dependencies
to the RPM dependencies listed in `build/rpm_metadata/requires`.

The minimum version boundaries were determined from the modules as they
were checked out in `simp-core` for the latest SIMP 5.2.X/4.3.X release
(with the addition recent z-version bumps from Forge-readiness patches).

SIMP-1595 #comment Fixed `pupmod-simp-auditd`
SIMP-1638 #close