### PR TITLE
(SIMP-1735) Updated version of Compliance Markup for SIMP 6

### DIFF
--- a/build/rpm_metadata/requires
+++ b/build/rpm_metadata/requires
@@ -3,8 +3,8 @@ Requires: pupmod-herculesteam-augeasproviders_grub < 3.0.0-0
 Requires: pupmod-herculesteam-augeasproviders_grub >= 2.3.1-0
 Requires: pupmod-puppetlabs-stdlib < 5.0.0-0
 Requires: pupmod-puppetlabs-stdlib >= 4.9.0-0
-Requires: pupmod-simp-compliance_markup < 2.0.0-0
-Requires: pupmod-simp-compliance_markup >= 1.0.1-0
+Requires: pupmod-simp-compliance_markup >= 2.0.0-0
+Requires: pupmod-simp-compliance_markup < 3.0.0-0
 Requires: pupmod-simp-rsyslog < 6.0.0-0
 Requires: pupmod-simp-rsyslog >= 5.1.0-0
 Requires: pupmod-simp-simpcat >= 6.0.0-0


### PR DESCRIPTION
  Update the requires file for SIMP6 to point to new version of
  compliance markup

SIMP-1735  #comment