### PR TITLE
(SIMP-2007)Change log facility of audit dispatcher

### DIFF
--- a/CHANGELOG
+++ b/CHANGELOG
@@ -5,6 +5,7 @@
   of the presence of forwarding logging servers.
 - Added a file resource to detect and fix incorrect permissions on the
   /var/log/audit/audit.log file.
+- Changed default log facility to local5.
 
 * Mon Aug 29 2016 Ralph Wright <ralph.wright@onyxpoint.com> - 5.0.4-0
 - Added booleans to toggle sections of audit rules.

--- a/manifests/config/audisp/syslog.pp
+++ b/manifests/config/audisp/syslog.pp
@@ -49,7 +49,7 @@
 class auditd::config::audisp::syslog (
   $drop_audit_logs = true,
   $priority = "LOG_INFO",
-  $facility = ""
+  $facility = "LOG_LOCAL5"
 ) {
   validate_bool($drop_audit_logs)
   validate_array_member($priority, ['LOG_DEBUG', 'LOG_INFO',

--- a/spec/classes/config/audisp/syslog_spec.rb
+++ b/spec/classes/config/audisp/syslog_spec.rb
@@ -25,7 +25,7 @@ active = yes
 direction = out
 path = builtin_syslog
 type = builtin
-args = LOG_INFO 
+args = LOG_INFO LOG_LOCAL5
 format = string
 EOM
           }


### PR DESCRIPTION
- Changed the default facility to local5.
- Logs will now be picked up by our default security_relevant_logs
  string.
- Updated spec test.

SIMP-2007 #close