### PR TITLE
(SIMP-1862) Add auditd drop rule for crond

### DIFF
--- a/CHANGELOG
+++ b/CHANGELOG
@@ -1,5 +1,6 @@
 * Fri Dec 09 2016 Nick Markowski <nmarkowski@keywcorp.com> - 7.0.0-0
 - Updated global catalysts
+- Added a drop rule for crond events
 
 * Tue Nov 22 2016 Liz Nemsick <lnemsick.simp@gmail.com> - 6.0.0-0
 - Update version to reflect SIMP6 dependencies

--- a/manifests/config/audit_profiles/simp.pp
+++ b/manifests/config/audit_profiles/simp.pp
@@ -37,6 +37,7 @@ class auditd::config::audit_profiles::simp (
   Boolean  $ignore_errors                          = true,
   Boolean  $ignore_anonymous                       = true,
   Boolean  $ignore_system_services                 = true,
+  Boolean  $ignore_crond                           = true,
   Boolean  $audit_unsuccessful_file_operations     = true,
   String   $audit_unsuccessful_file_operations_tag = 'access',
   Boolean  $audit_permissions                      = true,

--- a/spec/classes/config/audit_profiles/simp_spec.rb
+++ b/spec/classes/config/audit_profiles/simp_spec.rb
@@ -78,6 +78,13 @@ describe 'auditd::config::audit_profiles::simp' do
               %r(^-a\s+exit,never\s+-F\s+auid=-1$)
             )
           }
+          
+          it {
+            # Dropping Logs from crond
+            is_expected.to contain_file('/etc/audit/rules.d/05_default_drop.rules').with_content(
+              %r(^-a\s+never,user\s+-F\s+subj_type=crond_t$)
+            )
+          }
 
           if ['RedHat','CentOS'].include?(facts[:operatingsystem]) &&
              (facts[:operatingsystemmajrelease].to_s < '7')

--- a/templates/rule_profiles/simp/default_drop.erb
+++ b/templates/rule_profiles/simp/default_drop.erb
@@ -8,4 +8,8 @@
 # that just makes for more processing time.
 -a exit,never -F auid!=0 -F auid<<%= @uid_min %>
 <% end -%>
-
+<% if @ignore_crond -%>
+# Drop events related to cron jobs.  It creates a lot of logs that are not
+# usually useful
+-a never,user -F subj_type=crond_t
+<% end -%>


### PR DESCRIPTION
- Added a rule to drop audit logs written because of a cron job
- Added corresponding spec test

SIMP-1862 #close