### PR TITLE
(SIMP-2320) Fix Auditd Acceptance tests

### DIFF
--- a/spec/acceptance/suites/default/00_base_spec.rb
+++ b/spec/acceptance/suites/default/00_base_spec.rb
@@ -7,7 +7,8 @@ describe 'auditd class' do
     {
       'pki::cacerts_sources'    => ['file:///etc/pki/simp-testing/pki/cacerts'] ,
       'pki::private_key_source' => "file:///etc/pki/simp-testing/pki/private/%{fqdn}.pem",
-      'pki::public_key_source'  => "file:///etc/pki/simp-testing/pki/public/%{fqdn}.pub"
+      'pki::public_key_source'  => "file:///etc/pki/simp-testing/pki/public/%{fqdn}.pub",
+      'simp_options::syslog'    => true
     }
   }
 


### PR DESCRIPTION
Set 'simp_options::syslog' to true so that the audit dispatcher
feature is tested and the test passes again.

SIMP-2320 #close