### PR TITLE
(SIMP-2475) Update auditd base rules

### DIFF
--- a/CHANGELOG
+++ b/CHANGELOG
@@ -1,3 +1,8 @@
+* Tue Jan 12 2017 Trevor Vaughan <tvaughan@onyxpoint.com> - 7.0.0-0
+- In response to the DISA STIG Requirements
+  - Added 'open_by_handle_at' to the 'access' key
+  - Added watches for /varlog/faillock and /var/log/tallylock
+
 * Mon Dec 26 2016 Ralph Wright <rwright@onyxpoint.com> - 7.0.0-0
 * Mon Dec 26 2016 Trevor Vaughan <tvaughan@onyxpoint.com> - 7.0.0-0
 - Refactor to work in Puppet 4 Changes

--- a/CHANGELOG
+++ b/CHANGELOG
@@ -1,7 +1,9 @@
 * Tue Jan 12 2017 Trevor Vaughan <tvaughan@onyxpoint.com> - 7.0.0-0
 - In response to the DISA STIG Requirements
   - Added 'open_by_handle_at' to the 'access' key
-  - Added watches for /varlog/faillock and /var/log/tallylock
+  - Added watches on /varlog/faillock and /var/log/tallylock
+  - Added watches on /usr/sbin/insmod and /bin/kmod
+  - Added permissions modification notification for 'chmod'
 
 * Mon Dec 26 2016 Ralph Wright <rwright@onyxpoint.com> - 7.0.0-0
 * Mon Dec 26 2016 Trevor Vaughan <tvaughan@onyxpoint.com> - 7.0.0-0

--- a/templates/rule_profiles/simp/base.erb
+++ b/templates/rule_profiles/simp/base.erb
@@ -29,9 +29,9 @@
 # CCE-27184-1
 # CCE-27185-8
 <%   if @hardwaremodel.eql?("x86_64") -%>
--a always,exit -F arch=b64 -S chown -S fchmod -S fchmodat -S fchown -S fchownat -S lchown -S setxattr -S lsetxattr -S fsetxattr -S removexattr -S lremovexattr -S fremovexattr -k <%= @audit_permissions_tag %>
+-a always,exit -F arch=b64 -S chown -S chmod -S fchmod -S fchmodat -S fchown -S fchownat -S lchown -S setxattr -S lsetxattr -S fsetxattr -S removexattr -S lremovexattr -S fremovexattr -k <%= @audit_permissions_tag %>
 <%   end -%>
--a always,exit -F arch=b32 -S chown -S fchmod -S fchmodat -S fchown -S fchownat -S lchown -S setxattr -S lsetxattr -S fsetxattr -S removexattr -S lremovexattr -S fremovexattr -k <%= @audit_permissions_tag %>
+-a always,exit -F arch=b32 -S chown -S chmod -S fchmod -S fchmodat -S fchown -S fchownat -S lchown -S setxattr -S lsetxattr -S fsetxattr -S removexattr -S lremovexattr -S fremovexattr -k <%= @audit_permissions_tag %>
 <% end -%>
 
 <% if @audit_su_root_activity -%>
@@ -72,6 +72,8 @@
 <% if @audit_kernel_modules -%>
 ## Audit the loading and unloading of kernel modules.
 # CCE-26611-4
+-w /usr/sbin/insmod -p x -k modules
+-w /bin/kmod -p x -k modules
 -w /sbin/insmod -p x -k modules
 -w /sbin/rmmod -p x -k modules
 -w /sbin/modprobe -p x -k modules

--- a/templates/rule_profiles/simp/base.erb
+++ b/templates/rule_profiles/simp/base.erb
@@ -3,11 +3,11 @@
 # CCE-26712-0
 # CCE-26651-0
 <%   if @hardwaremodel.eql?("x86_64") -%>
--a always,exit -F arch=b64 -S creat -S mkdir -S mknod -S link -S symlink -S mkdirat -S mknodat -S linkat -S symlinkat -S openat -S open -S close -S rename -S renameat -S truncate -S ftruncate -S rmdir -S unlink -S unlinkat -F exit=-EACCES -k <%= @audit_unsuccessful_file_operations_tag %>
--a always,exit -F arch=b64 -S creat -S mkdir -S mknod -S link -S symlink -S mkdirat -S mknodat -S linkat -S symlinkat -S openat -S open -S close -S rename -S renameat -S truncate -S ftruncate -S rmdir -S unlink -S unlinkat -F exit=-EPERM -k <%= @audit_unsuccessful_file_operations_tag %>
+-a always,exit -F arch=b64 -S creat -S mkdir -S mknod -S link -S symlink -S mkdirat -S mknodat -S linkat -S symlinkat -S openat -S open_by_handle_at -S open -S close -S rename -S renameat -S truncate -S ftruncate -S rmdir -S unlink -S unlinkat -F exit=-EACCES -k <%= @audit_unsuccessful_file_operations_tag %>
+-a always,exit -F arch=b64 -S creat -S mkdir -S mknod -S link -S symlink -S mkdirat -S mknodat -S linkat -S symlinkat -S openat -S open_by_handle_at -S open -S close -S rename -S renameat -S truncate -S ftruncate -S rmdir -S unlink -S unlinkat -F exit=-EPERM -k <%= @audit_unsuccessful_file_operations_tag %>
 <%   end -%>
--a always,exit -F arch=b32 -S creat -S mkdir -S mknod -S link -S symlink -S mkdirat -S mknodat -S linkat -S symlinkat -S openat -S open -S close -S rename -S renameat -S truncate -S ftruncate -S rmdir -S unlink -S unlinkat -F exit=-EACCES -k <%= @audit_unsuccessful_file_operations_tag %>
--a always,exit -F arch=b32 -S creat -S mkdir -S mknod -S link -S symlink -S mkdirat -S mknodat -S linkat -S symlinkat -S openat -S open -S close -S rename -S renameat -S truncate -S ftruncate -S rmdir -S unlink -S unlinkat -F exit=-EPERM -k <%= @audit_unsuccessful_file_operations_tag %>
+-a always,exit -F arch=b32 -S creat -S mkdir -S mknod -S link -S symlink -S mkdirat -S mknodat -S linkat -S symlinkat -S openat -S open_by_handle_at -S open -S close -S rename -S renameat -S truncate -S ftruncate -S rmdir -S unlink -S unlinkat -F exit=-EACCES -k <%= @audit_unsuccessful_file_operations_tag %>
+-a always,exit -F arch=b32 -S creat -S mkdir -S mknod -S link -S symlink -S mkdirat -S mknodat -S linkat -S symlinkat -S openat -S open_by_handle_at -S open -S close -S rename -S renameat -S truncate -S ftruncate -S rmdir -S unlink -S unlinkat -F exit=-EPERM -k <%= @audit_unsuccessful_file_operations_tag %>
 
 -a always,exit -F perm=a -F exit=-EACCES -k <%= @audit_unsuccessful_file_operations_tag %>
 -a always,exit -F perm=a -F exit=-EPERM -k <%= @audit_unsuccessful_file_operations_tag %>
@@ -160,6 +160,8 @@
 -w /var/run/utmp -p wa -k <%= @audit_session_files_tag %>
 -w /var/log/btmp -p wa -k <%= @audit_session_files_tag %>
 -w /var/log/wtmp -p wa -k <%= @audit_session_files_tag %>
+-w /var/log/faillock -p wa -k <%= @audit_session_files_tag %>
+-w /var/log/tallylock -p wa -k <%= @audit_session_files_tag %>
 <% end -%>
 
 <% if @audit_sudoers -%>


### PR DESCRIPTION
Per the RHEL STIG, the audit base rules have been updated to add:
* Capture of open_by_handle_at
* Watches on /var/log/faillock and /var/log/tallylock

SIMP-2475 #close
SIMP-2476 #close