### PR TITLE
(SIMP-2481) Move the audisp exec into a class

### DIFF
--- a/manifests/config/audisp/syslog.pp
+++ b/manifests/config/audisp/syslog.pp
@@ -42,6 +42,7 @@ class auditd::config::audisp::syslog (
   Auditd::LogFacility $facility        = 'LOG_LOCAL5'
 ) {
   include '::rsyslog'
+  include '::auditd::config::audisp_service'
 
   if $drop_audit_logs {
     # This will prevent audit records from being forwarded to remote

--- a/manifests/config/audisp_service.pp
+++ b/manifests/config/audisp_service.pp
@@ -1,0 +1,14 @@
+# Make sure the audispd process keeps running.
+#
+# Should only be called from audisp processing services.
+#
+class auditd::config::audisp_service {
+  assert_private()
+
+  # This is needed just in case the audit dispatcher fails at some point.
+  exec { 'Restart Audispd':
+    command => '/bin/true',
+    unless  => "/usr/bin/pgrep -f ${::auditd::dispatcher}",
+    notify  => Service[$::auditd::service_name]
+  }
+}

--- a/manifests/service.pp
+++ b/manifests/service.pp
@@ -14,13 +14,6 @@ class auditd::service {
         hasstatus  => true,
         provider   => 'redhat'
       }
-
-      # This is needed just in case the audit dispatcher fails at some point.
-      exec { 'Restart Audispd':
-        command => '/bin/true',
-        unless  => "/usr/bin/pgrep -f ${::auditd::dispatcher}",
-        notify  => Service[$::auditd::service_name]
-      }
     }
     default : {
       fail("Error: ${facts['os']['name']} is not yet supported by module '${module_name}'")

--- a/spec/classes/config/audisp/syslog_spec.rb
+++ b/spec/classes/config/audisp/syslog_spec.rb
@@ -4,18 +4,11 @@ describe 'auditd::config::audisp::syslog' do
   context 'supported operating systems' do
     on_supported_os.each do |os, facts|
       context "on #{os}" do
-        let(:facts) do
-          if ['RedHat','CentOS'].include?(facts[:operatingsystem]) && facts[:operatingsystemmajrelease].to_s < '7'
-            facts[:apache_version] = '2.2'
-            facts[:grub_version] = '0.9'
-          else
-            facts[:apache_version] = '2.4'
-            facts[:grub_version] = '2.0~beta'
-          end
-
-          facts
+        let(:pre_condition) do
+          'include "auditd"'
         end
 
+        let(:facts){ facts }
 
         context "without any parameters" do
           let(:params) {{ }}


### PR DESCRIPTION
The audisp exec was causing runs to not be idempotent if there were no
services set up to listen.

This class should be included by any audisp service that processes logs.

SIMP-2481 #close