### PR TITLE
(SIMP-2550) Split auditd permissions rules

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,10 +1,13 @@
-#  PE/SIMP versions
-#  app    pup  ruby
-# 2015.2  4.3  2.1.7
-# 2015.3  4.3  2.1.8
-# 2016.1  4.4  2.1.9
-# 2016.2  4.5  2.1.9
-# S6.0.0  4.7  2.1.9
+# The testing matrix considers ruby/puppet versions supported by SIMP and PE:
+# ------------------------------------------------------------------------------
+#  release    pup   ruby      eol
+# PE 2015.2   4.2   2.1.7  2017-03-17
+# PE 2015.3   4.3   2.1.8  2017-03-17
+# PE 2016.1   4.4   2.1.9  2017-03-17 (yes: all three EOL on the same day!)
+# PE 2016.2   4.5   2.1.9  2017-04-30
+# PE 2016.4   4.7   2.1.9  TBD (LTS)
+# PE 2016.5   4.8   2.1.9  TBD
+# SIMP6.0.0   4.8   2.1.9  TBD
 ---
 language: ruby
 sudo: false
@@ -22,19 +25,17 @@ rvm:
 env:
   global:
     - STRICT_VARIABLES=yes
-    - TRUSTED_NODE_DATA=yes
   matrix:
+    - PUPPET_VERSION="~> 4.8.2"
     - PUPPET_VERSION="~> 4.7.0"
     - PUPPET_VERSION="~> 4.5.0"
-    - PUPPET_VERSION="~> 3.8.0"
     - PUPPET_VERSION="~> 4.4.0"
     - PUPPET_VERSION="~> 4.3.0"
-    - PUPPET_VERSION="~> 3.8.0" FUTURE_PARSER=yes
+    - PUPPET_VERSION="~> 4.2.0"
 matrix:
   fast_finish: true
   allow_failures:
     - env: PUPPET_VERSION="~> 4.5.0"
-    - env: PUPPET_VERSION="~> 3.8.0"
     - env: PUPPET_VERSION="~> 4.4.0"
     - env: PUPPET_VERSION="~> 4.3.0"
-    - env: PUPPET_VERSION="~> 3.8.0" FUTURE_PARSER=yes
+    - env: PUPPET_VERSION="~> 4.2.0"

--- a/.travis.yml
+++ b/.travis.yml
@@ -3,7 +3,7 @@
 #  release    pup   ruby      eol
 # PE 2015.2   4.2   2.1.7  2017-03-17
 # PE 2015.3   4.3   2.1.8  2017-03-17
-# PE 2016.1   4.4   2.1.9  2017-03-17 (yes: all three EOL on the same day!)
+# PE 2016.1   4.4   2.1.9  2017-03-17 (yes: all three EOL on the same day)
 # PE 2016.2   4.5   2.1.9  2017-04-30
 # PE 2016.4   4.7   2.1.9  TBD (LTS)
 # PE 2016.5   4.8   2.1.9  TBD

--- a/CHANGELOG
+++ b/CHANGELOG
@@ -5,6 +5,8 @@
   - Added watches on /usr/sbin/insmod and /bin/kmod
   - Added permissions modification notification for 'chmod'
 - Renamed auditd::add_rules to auditd::rule
+- Split the audit permissions rules into separate lines
+- Disabled chmod auditing by default
 
 * Mon Dec 26 2016 Ralph Wright <rwright@onyxpoint.com> - 7.0.0-0
 * Mon Dec 26 2016 Trevor Vaughan <tvaughan@onyxpoint.com> - 7.0.0-0

--- a/manifests/config/audit_profiles/simp.pp
+++ b/manifests/config/audit_profiles/simp.pp
@@ -38,8 +38,10 @@
 # @param ignore_system_services
 # @param audit_unsuccessful_file_operations
 # @param audit_unsuccessful_file_operations_tag
-# @param audit_permissions
-# @param audit_permissions_tag
+# @param audit_chown
+# @param audit_chown_tag
+# @param audit_chmod
+# @param audit_chmod_tag
 # @param audit_su_root_activity
 # @param audit_su_root_activity_tag
 # @param audit_suid_sgid
@@ -103,8 +105,12 @@ class auditd::config::audit_profiles::simp (
   Boolean                             $ignore_system_services                 = true,
   Boolean                             $audit_unsuccessful_file_operations     = true,
   String                              $audit_unsuccessful_file_operations_tag = 'access',
-  Boolean                             $audit_permissions                      = true,
-  String                              $audit_permissions_tag                  = 'perm_mod',
+  Boolean                             $audit_chown                            = true,
+  String                              $audit_chown_tag                        = 'chown',
+  Boolean                             $audit_chmod                            = false,
+  String                              $audit_chmod_tag                        = 'chmod',
+  Boolean                             $audit_attr                             = true,
+  String                              $audit_attr_tag                         = 'attr',
   Boolean                             $audit_su_root_activity                 = true,
   String                              $audit_su_root_activity_tag             = 'su-root-activity',
   Boolean                             $audit_suid_sgid                        = true,

--- a/spec/spec_helper.rb
+++ b/spec/spec_helper.rb
@@ -9,19 +9,6 @@ require 'pathname'
 fixture_path = File.expand_path(File.join(__FILE__, '..', 'fixtures'))
 module_name = File.basename(File.expand_path(File.join(__FILE__,'../..')))
 
-# Add fixture lib dirs to LOAD_PATH. Work-around for PUP-3336
-if Puppet.version < "4.0.0"
-  Dir["#{fixture_path}/modules/*/lib"].entries.each do |lib_dir|
-    $LOAD_PATH << lib_dir
-  end
-end
-
-
-if !ENV.key?( 'TRUSTED_NODE_DATA' )
-  warn '== WARNING: TRUSTED_NODE_DATA is unset, using TRUSTED_NODE_DATA=yes'
-  ENV['TRUSTED_NODE_DATA']='yes'
-end
-
 default_hiera_config =<<-EOM
 ---
 :backends:

--- a/templates/rule_profiles/simp/base.erb
+++ b/templates/rule_profiles/simp/base.erb
@@ -13,7 +13,7 @@
 -a always,exit -F perm=a -F exit=-EPERM -k <%= @audit_unsuccessful_file_operations_tag %>
 <% end -%>
 
-# Permissions auditing seperated by chown, chmod, and attr
+# Permissions auditing separated by chown, chmod, and attr
 # CCE-26280-8
 # CCE-27173-4
 # CCE-27174-2

--- a/templates/rule_profiles/simp/base.erb
+++ b/templates/rule_profiles/simp/base.erb
@@ -13,8 +13,7 @@
 -a always,exit -F perm=a -F exit=-EPERM -k <%= @audit_unsuccessful_file_operations_tag %>
 <% end -%>
 
-<% if @audit_permissions -%>
-# Permissions auditing
+# Permissions auditing seperated by chown, chmod, and attr
 # CCE-26280-8
 # CCE-27173-4
 # CCE-27174-2
@@ -29,9 +28,24 @@
 # CCE-27184-1
 # CCE-27185-8
 <%   if @hardwaremodel.eql?("x86_64") -%>
--a always,exit -F arch=b64 -S chown -S chmod -S fchmod -S fchmodat -S fchown -S fchownat -S lchown -S setxattr -S lsetxattr -S fsetxattr -S removexattr -S lremovexattr -S fremovexattr -k <%= @audit_permissions_tag %>
+<% if @audit_chown -%>
+-a always,exit -F arch=b64 -S chown -S fchown -S fchownat -S lchown -k <%= @audit_chown_tag %>
 <%   end -%>
--a always,exit -F arch=b32 -S chown -S chmod -S fchmod -S fchmodat -S fchown -S fchownat -S lchown -S setxattr -S lsetxattr -S fsetxattr -S removexattr -S lremovexattr -S fremovexattr -k <%= @audit_permissions_tag %>
+<% if @audit_chmod -%>
+-a always,exit -F arch=b64 -S chmod -S fchmod -S fchmodat -k <%= @audit_chmod_tag %>
+<%   end -%>
+<% if @audit_attr -%>
+-a always,exit -F arch=b64 -S setxattr -S lsetxattr -S fsetxattr -S removexattr -S lremovexattr -S fremovexattr -k <%= @audit_attr_tag %>
+<%   end -%>
+<%   end -%>
+<% if @audit_chown -%>
+-a always,exit -F arch=b32 -S chown -S fchown -S fchownat -S lchown -k <%= @audit_chown_tag %>
+<%   end -%>
+<% if @audit_chmod -%>
+-a always,exit -F arch=b32 -S chmod -S fchmod -S fchmodat -k <%= @audit_chmod_tag %>
+<%   end -%>
+<% if @audit_attr -%>
+-a always,exit -F arch=b32 -S setxattr -S lsetxattr -S fsetxattr -S removexattr -S lremovexattr -S fremovexattr -k <%= @audit_attr_tag %>
 <% end -%>
 
 <% if @audit_su_root_activity -%>


### PR DESCRIPTION
- Split the permissions rules into chmods, chowns, and attrs.
- Disabled chmod auditing by default

SIMP-2550 #close