### PR TITLE
(SIMP-2558) Changed the default failure to printk

### DIFF
--- a/CHANGELOG
+++ b/CHANGELOG
@@ -1,3 +1,8 @@
+* Thu Feb 22 2017 Trevor Vaughan <tvaughan@onyxpoint.com> - 7.0.1-0
+- Changed auditd::failure_mode to '1' by default since the compliant audit
+  rules were causing routine system restarts. The new value will default to
+  sending printk messages when the buffer is full.
+
 * Tue Jan 12 2017 Trevor Vaughan <tvaughan@onyxpoint.com> - 7.0.0-0
 - In response to the DISA STIG Requirements
   - Added 'open_by_handle_at' to the 'access' key

--- a/manifests/init.pp
+++ b/manifests/init.pp
@@ -88,7 +88,7 @@ class auditd (
   Auditd::DiskFullAction              $disk_full_action        = 'SUSPEND',
   Auditd::DiskErrorAction             $disk_error_action       = 'SUSPEND',
   Integer[0]                          $buffer_size             = 16384,
-  Integer[0]                          $failure_mode            = 2,
+  Integer[0]                          $failure_mode            = 1,
   Integer[0]                          $rate                    = 0,
   Boolean                             $immutable               = false,
   Enum['basic','aggressive','insane'] $root_audit_level        = 'basic',

--- a/metadata.json
+++ b/metadata.json
@@ -1,6 +1,6 @@
 {
   "name": "simp-auditd",
-  "version": "7.0.0",
+  "version": "7.0.1",
   "author": "SIMP Team",
   "summary": "A SIMP puppet module for managing auditd and audispd",
   "license": "Apache-2.0",
@@ -49,11 +49,7 @@
   "requirements": [
     {
       "name": "puppet",
-      "version_requirement": "4.x"
-    },
-    {
-      "name": "pe",
-      "version_requirement": ">= 2016.2.0"
+      "version_requirement": ">= 4.6.0 < 5.0.0"
     }
   ],
   "data_provider": "hiera"

--- a/spec/classes/config/audit_profiles/simp_spec.rb
+++ b/spec/classes/config/audit_profiles/simp_spec.rb
@@ -47,7 +47,7 @@ describe 'auditd::config::audit_profiles::simp' do
           it {
             # Setting the failure mode
             is_expected.to contain_file('/etc/audit/rules.d/00_head.rules').with_content(
-              %r(^-f\s+2$)
+              %r(^-f\s+1$)
             )
           }
 


### PR DESCRIPTION
The default failure state for auditd was to panic the system. However,
with the required audit rules for chmod and chown, this was routinely
overflowing the large log buffer that we had put in place.

Instead of arbitrarily increasing the log buffer, we opted to change
the failure state to logging printk messages until we can figure out
how to properly eliminate this failure case.

SIMP-2558 #close