### PR TITLE
(SIMP-2727) Change rules to always,exit

### DIFF
--- a/CHANGELOG
+++ b/CHANGELOG
@@ -2,6 +2,7 @@
 - Changed auditd::failure_mode to '1' by default since the compliant audit
   rules were causing routine system restarts. The new value will default to
   sending printk messages when the buffer is full.
+- Changed all rules that were exit,always to be always,exit
 
 * Tue Jan 12 2017 Trevor Vaughan <tvaughan@onyxpoint.com> - 7.0.0-0
 - In response to the DISA STIG Requirements

--- a/templates/rule_profiles/simp/base.erb
+++ b/templates/rule_profiles/simp/base.erb
@@ -106,10 +106,10 @@
 # CCE-27169-2
 # CCE-27170-0
 <%   if @hardwaremodel.eql?("x86_64") -%>
--a exit,always -F arch=b32 -S adjtimex -S stime -S clock_settime -S settimeofday -k <%= @audit_time_tag %>
--a exit,always -F arch=b64 -S adjtimex -S clock_settime -S settimeofday -k <%= @audit_time_tag %>
+-a always,exit -F arch=b32 -S adjtimex -S stime -S clock_settime -S settimeofday -k <%= @audit_time_tag %>
+-a always,exit -F arch=b64 -S adjtimex -S clock_settime -S settimeofday -k <%= @audit_time_tag %>
 <%   else -%>
--a exit,always -S adjtimex -S stime -S clock_settime -S settimeofday -k <%= @audit_time_tag %>
+-a always,exit -S adjtimex -S stime -S clock_settime -S settimeofday -k <%= @audit_time_tag %>
 <%   end -%>
 
 # CCE-27172-6
@@ -145,7 +145,7 @@
 <% if @audit_umask -%>
 # audit umask changes.
 # This is uselessly noisy.
--a exit,always -S umask -k <%= @audit_umask_tag %>
+-a always,exit -S umask -k <%= @audit_umask_tag %>
 <% end -%>
 
 <% if @audit_local_account -%>
@@ -264,10 +264,10 @@
 <% end -%>
 <% if @audit_ptrace -%>
 <%   if @hardwaremodel.eql?("x86_64") -%>
--a exit,always -F arch=b32 -S ptrace -k <%= @audit_ptrace_tag %>
--a exit,always -F arch=b64 -S ptrace -k <%= @audit_ptrace_tag %>
+-a always,exit -F arch=b32 -S ptrace -k <%= @audit_ptrace_tag %>
+-a always,exit -F arch=b64 -S ptrace -k <%= @audit_ptrace_tag %>
 <%   else -%>
--a exit,always -S ptrace -k <%= @audit_ptrace_tag %>
+-a always,exit -S ptrace -k <%= @audit_ptrace_tag %>
 <%   end -%>
 <% end -%>
 <% if @audit_personality -%>


### PR DESCRIPTION
Some audit rules were incorrectly listed as exit,always. They are now
set to always,exit.

SIMP-2727 #close