### PR TITLE
(SIMP-2939) SIMP audit profile file paths

### DIFF
--- a/CHANGELOG
+++ b/CHANGELOG
@@ -1,3 +1,7 @@
+* Mon Mar 27 2017 Nicholas Hughes <nicholasmhughes@github.com> - 7.0.1-0
+- Audit kernel module tools from /usr/bin as well as /bin and /sbin
+- Correct auditing /var/log/tallylock, it should have been /var/log/tallylog
+
 * Thu Feb 22 2017 Trevor Vaughan <tvaughan@onyxpoint.com> - 7.0.1-0
 - Changed auditd::failure_mode to '1' by default since the compliant audit
   rules were causing routine system restarts. The new value will default to

--- a/manifests/init.pp
+++ b/manifests/init.pp
@@ -117,18 +117,18 @@ class auditd (
     include '::auditd::config'
     include '::auditd::service'
 
-    Class['::auditd::install'] ->
-    Class['::auditd::config']  ~>
-    Class['::auditd::service'] ->
-    Class['::auditd']
+    Class['::auditd::install']
+    -> Class['::auditd::config']
+    ~> Class['::auditd::service']
+    -> Class['::auditd']
 
     Class['::auditd::install'] -> Class['::auditd::config::grub']
 
     if $syslog {
       include '::auditd::config::logging'
 
-      Class['::auditd::config::logging'] ~>
-      Class['::auditd::service']
+      Class['::auditd::config::logging']
+      ~> Class['::auditd::service']
     }
   }
   else {

--- a/templates/rule_profiles/simp/base.erb
+++ b/templates/rule_profiles/simp/base.erb
@@ -87,6 +87,8 @@
 ## Audit the loading and unloading of kernel modules.
 # CCE-26611-4
 -w /usr/sbin/insmod -p x -k modules
+-w /usr/sbin/rmmod -p x -k modules
+-w /usr/sbin/modprobe -p x -k modules
 -w /bin/kmod -p x -k modules
 -w /sbin/insmod -p x -k modules
 -w /sbin/rmmod -p x -k modules
@@ -177,7 +179,7 @@
 -w /var/log/btmp -p wa -k <%= @audit_session_files_tag %>
 -w /var/log/wtmp -p wa -k <%= @audit_session_files_tag %>
 -w /var/log/faillock -p wa -k <%= @audit_session_files_tag %>
--w /var/log/tallylock -p wa -k <%= @audit_session_files_tag %>
+-w /var/log/tallylog -p wa -k <%= @audit_session_files_tag %>
 <% end -%>
 
 <% if @audit_sudoers -%>


### PR DESCRIPTION
https://simp-project.atlassian.net/browse/SIMP-2939

I believe this line in the base.erb:
`-w /var/log/tallylock -p wa -k <%= @audit_session_files_tag %>`
should be:
`-w /var/log/tallylog -p wa -k <%= @audit_session_files_tag %>`

...and while insmod has both the /usr/sbin and /sbin paths listed, rmmod and modprobe do not, which causes some security scans to fail. For good measure, need to add:
```
-w /usr/sbin/rmmod -p x -k modules
-w /usr/sbin/modprobe -p x -k modules
```