### PR TITLE
(SIMP-3202) audit rules not generated CentOS6

### DIFF
--- a/CHANGELOG
+++ b/CHANGELOG
@@ -1,3 +1,7 @@
+* Mon May 22 2017 Liz Nemsick <lnemsick.simp@gmail.com> - 7.0.2-0
+- Fix bug whereby audit.rules file was not being regenerated prior
+  to auditd service start in CentOS/RedHat 6.
+
 * Mon Mar 27 2017 Nicholas Hughes <nicholasmhughes@github.com> - 7.0.1-0
 - Audit kernel module tools from /usr/bin as well as /bin and /sbin
 - Correct auditing /var/log/tallylock, it should have been /var/log/tallylog

--- a/Gemfile
+++ b/Gemfile
@@ -35,11 +35,7 @@ group :development do
 end
 
 group :system_tests do
-  # This patch is required to fix Beaker's broken `aio` handling and provide support for SuSE
-  # If you want to use 'bundle update --local', comment out this line and uncomment the next line
-  # If you do this, please remember not to check in that change.
-  gem 'beaker', :git => 'https://github.com/trevor-vaughan/beaker.git', :branch => 'BKR-978-2.51.0'
-  # gem 'beaker'
+  gem 'beaker'
   gem 'beaker-rspec'
   gem 'simp-beaker-helpers', ENV.fetch('SIMP_BEAKER_HELPERS_VERSION', '~> 1.5')
 end

--- a/manifests/config.pp
+++ b/manifests/config.pp
@@ -107,4 +107,15 @@ class auditd::config (
     group => 'root',
     mode  => '0600'
   }
+
+  if ($facts['os']['release']['major'] < '7') {
+    # make sure audit.rules is regenerated every time the
+    # service is started
+    augeas { 'auditd/USE_AUGENRULES':
+      changes => [
+        "set /files/etc/sysconfig/auditd/USE_AUGENRULES yes",
+      ],
+    }
+  }
+
 }

--- a/metadata.json
+++ b/metadata.json
@@ -1,6 +1,6 @@
 {
   "name": "simp-auditd",
-  "version": "7.0.1",
+  "version": "7.0.2",
   "author": "SIMP Team",
   "summary": "A SIMP puppet module for managing auditd and audispd",
   "license": "Apache-2.0",

--- a/spec/acceptance/nodesets/default.yml
+++ b/spec/acceptance/nodesets/default.yml
@@ -11,9 +11,6 @@ HOSTS:
         mirrorlist: 'https://mirrors.fedoraproject.org/metalink?repo=epel-7&arch=$basearch'
         gpgkeys:
           - https://getfedora.org/static/352C64E5.txt
-      simp:
-        baseurl: https://dl.bintray.com/simp/5.1.X
-        gpgcheck: 0
 
   el6:
     roles:
@@ -26,9 +23,6 @@ HOSTS:
         mirrorlist: 'https://mirrors.fedoraproject.org/metalink?repo=epel-6&arch=$basearch'
         gpgkeys:
           - https://getfedora.org/static/0608B895.txt
-      simp:
-        baseurl: https://dl.bintray.com/simp/4.2.X
-        gpgcheck: 0
 
 CONFIG:
   log_level: verbose

--- a/spec/classes/config_spec.rb
+++ b/spec/classes/config_spec.rb
@@ -57,6 +57,14 @@ describe 'auditd::config' do
               :mode   => '0600'
             })
           }
+
+          if facts[:os][:release][:major] == '6'
+            it { is_expected.to contain_augeas('auditd/USE_AUGENRULES').with_changes(
+              ['set /files/etc/sysconfig/auditd/USE_AUGENRULES yes'])
+            }
+          else
+            it { is_expected.to_not contain_augeas('auditd/USE_AUGENRULES') }
+          end
         end
       end
     end


### PR DESCRIPTION
- Set service variable needed to ensure rules are generated
  upon service start
- Added more checks in acceptance test to verify rules are generated
  appropriately