### PR TITLE
(SIMP-4679) Update compliance tests

### DIFF
--- a/.fixtures.yml
+++ b/.fixtures.yml
@@ -15,6 +15,9 @@ fixtures:
     simplib: https://github.com/simp/pupmod-simp-simplib
     simp_options: https://github.com/simp/pupmod-simp-simp_options
     stdlib: https://github.com/simp/puppetlabs-stdlib
+    systemd:
+      repo: https://github.com/simp/puppet-systemd
+      branch: simp-master
     disa_stig-el7-baseline:
       repo: https://github.com/simp/inspec-profile-disa_stig-el7
       branch:  master

--- a/.fixtures.yml
+++ b/.fixtures.yml
@@ -15,9 +15,7 @@ fixtures:
     simplib: https://github.com/simp/pupmod-simp-simplib
     simp_options: https://github.com/simp/pupmod-simp-simp_options
     stdlib: https://github.com/simp/puppetlabs-stdlib
-    # For InSpec Testing
-    # Requires a currently unreleased version of puppetlabs_spec_helper
     disa_stig-el7-baseline:
       repo: https://github.com/simp/inspec-profile-disa_stig-el7
-      branch: master
+      branch:  master
       target: spec/fixtures/inspec_deps/inspec_profiles/profiles

--- a/Gemfile
+++ b/Gemfile
@@ -11,8 +11,7 @@ group :test do
   gem 'rspec'
   gem 'rspec-puppet'
   gem 'hiera-puppet-helper'
-  # For the target in .fixtures.yml
-  gem 'puppetlabs_spec_helper', :git => 'https://github.com/puppetlabs/puppetlabs_spec_helper', :ref => 'b049630ac2cfbab96702701e4997ec51c23cf9c0'
+  gem 'puppetlabs_spec_helper'
   gem 'metadata-json-lint'
   gem 'puppet-strings'
   gem 'puppet-lint-empty_string-check',   :require => false
@@ -22,20 +21,12 @@ group :test do
 end
 
 group :development do
-  gem 'travis'
-  gem 'travis-lint'
-  gem 'travish'
-  gem 'puppet-blacksmith'
-  gem 'guard-rake'
   gem 'pry'
   gem 'pry-doc'
-
-  # `listen` is a dependency of `guard`
-  # from `listen` 3.1+, `ruby_dep` requires Ruby version >= 2.2.3, ~> 2.2
-  gem 'listen', '~> 3.0.6'
 end
 
 group :system_tests do
+  gem 'beaker'
   gem 'beaker-rspec'
-  gem 'simp-beaker-helpers', ENV.fetch('SIMP_BEAKER_HELPERS_VERSION', '~> 1.7')
+  gem 'simp-beaker-helpers', ENV.fetch('SIMP_BEAKER_HELPERS_VERSION', ['>= 1.10.9', '< 2.0'])
 end

--- a/Gemfile
+++ b/Gemfile
@@ -28,5 +28,5 @@ end
 group :system_tests do
   gem 'beaker'
   gem 'beaker-rspec'
-  gem 'simp-beaker-helpers', ENV.fetch('SIMP_BEAKER_HELPERS_VERSION', ['>= 1.10.9', '< 2.0'])
+  gem 'simp-beaker-helpers', ENV.fetch('SIMP_BEAKER_HELPERS_VERSION', ['>= 1.10.8', '< 2.0'])
 end

--- a/spec/fixtures/inspec_profiles/RedHat-7-disa_stig/controls/00_Control_Selector.rb
+++ b/spec/fixtures/inspec_profiles/RedHat-7-disa_stig/controls/00_Control_Selector.rb
@@ -1,22 +1,37 @@
+skips = {}
 overrides = []
+subsystems = [ 'audit' ]
 
 require_controls 'disa_stig-el7-baseline' do
-  # SIMP uses Rsyslog for log offloading
-  # Need to create a profile and tests
-  control 'V-72087' do
-    overrides << self.to_s
-
-    only_if { file('/etc/audisp/audisp-remote.conf').exist? }
-  end
-
-  @conf['profile'].info[:controls].each do |ctrl|
-    next if overrides.include?(ctrl[:id])
-
-    tags = ctrl[:tags]
-    if tags && tags[:subsystems]
-      if tags[:subsystems].include?('audit')
-        control ctrl[:id]
+  skips.each_pair do |ctrl, reason|
+    control ctrl do
+      describe "Skip #{ctrl}" do
+        skip "Reason: #{skips[ctrl]}" do
+        end
       end
     end
   end
+
+  @conf['profile'].info[:controls].each do |ctrl|
+    next if (overrides + skips.keys).include?(ctrl[:id])
+
+    tags = ctrl[:tags]
+    if tags && tags[:subsystems]
+      subsystems.each do |subsystem|
+        if tags[:subsystems].include?(subsystem)
+          control ctrl[:id]
+        end
+      end
+    end
+  end
+
+  ## Overrides ##
+
+# # USEFUL DESCRIPTION
+# control 'V-IDENTIFIER' do
+#   # Enhancement, leave this out if you just want to add a different test
+#   overrides << self.to_s
+#
+#   only_if { file('whatever').exist? }
+# end
 end

--- a/spec/fixtures/inspec_profiles/RedHat-7-disa_stig/inspec.yml
+++ b/spec/fixtures/inspec_profiles/RedHat-7-disa_stig/inspec.yml
@@ -1,17 +1,14 @@
-name: EL7 auditd STIG
-title: Auditd STIG for EL 7
+name: EL7 ssh STIG
+title: SSH STIG for EL 7
 supports:
   - os-family: redhat
-maintainer: Trevor Vaughan
+maintainer: SIMP Team
 copyright: Onyx Point, Inc.
-copyright_email: tvaughan@onyxpoint.com
+copyright_email: simp@onyxpoint.com
 license: Apache-2.0
 summary: |
-  A collection of InSpec tests for the auditd subsystem.
+  A collection of InSpec tests for the ssh subsystem
 version: 0.0.1
 depends:
   - name: disa_stig-el7-baseline
     path: ../../inspec_deps/inspec_profiles/profiles/disa_stig-el7-baseline
-  # This can be activated after https://github.com/chef/inspec/pull/2121 gets fixed
-  #- name: simp_stig-rhel7
-  #  path: ../../inspec_deps/inspec_profiles/profiles/simp_stig-rhel7

--- a/spec/fixtures/inspec_profiles/RedHat-7-disa_stig/inspec.yml
+++ b/spec/fixtures/inspec_profiles/RedHat-7-disa_stig/inspec.yml
@@ -1,5 +1,5 @@
-name: EL7 ssh STIG
-title: SSH STIG for EL 7
+name: EL7 auditd STIG
+title: Auditd STIG for EL 7
 supports:
   - os-family: redhat
 maintainer: SIMP Team
@@ -7,7 +7,7 @@ copyright: Onyx Point, Inc.
 copyright_email: simp@onyxpoint.com
 license: Apache-2.0
 summary: |
-  A collection of InSpec tests for the ssh subsystem
+  A collection of InSpec tests for the auditd subsystem
 version: 0.0.1
 depends:
   - name: disa_stig-el7-baseline


### PR DESCRIPTION
Updated the tests to match the new patterns and work with the latest
version of inspec

Requires simp-beaker-helpers 1.10.9

SIMP-4679 #comment Update spec tests to working version