### PR TITLE
(SIMP-4679) Update to Hiera 5 in tests

### DIFF
--- a/spec/acceptance/suites/compliance/00_default_spec.rb
+++ b/spec/acceptance/suites/compliance/00_default_spec.rb
@@ -24,16 +24,15 @@ compliance_markup::enforcement:
 
     let(:hiera_yaml) { <<-EOM
 ---
-:backends:
-  - yaml
-  - simp_compliance_enforcement
-:yaml:
-  :datadir: "#{hiera_datadir(host)}"
-:simp_compliance_enforcement:
-  :datadir: "#{hiera_datadir(host)}"
-:hierarchy:
-  - default
-:logger: console
+version: 5
+hierarchy:
+  - name: Common
+    path: default.yaml
+  - name: Compliance
+    lookup_key: compliance_markup::enforcement
+defaults:
+  data_hash: yaml_data
+  datadir: "#{hiera_datadir(host)}"
       EOM
     }
 
@@ -41,6 +40,8 @@ compliance_markup::enforcement:
       # Using puppet_apply as a helper
       it 'should work with no errors' do
         create_remote_file(host, host.puppet['hiera_config'], hiera_yaml)
+        write_hieradata_to(host, hieradata)
+
         apply_manifest_on(host, manifest, :catch_failures => true)
       end
 


### PR DESCRIPTION
Switch the compliance tests over to Hiera 5 since Puppet 4.10.4+ broke
the v3 backend in puppet apply.