### PR TITLE
(SIMP-5010) Allow lowercase values for several parameters

### DIFF
--- a/types/diskerroraction.pp
+++ b/types/diskerroraction.pp
@@ -1,1 +1,4 @@
-type Auditd::DiskErrorAction = Enum['IGNORE','SYSLOG','EXEC','SUSPEND','SINGLE','HALT']
+type Auditd::DiskErrorAction = Enum[
+  'IGNORE','SYSLOG','EXEC','SUSPEND','SINGLE','HALT',
+  'ignore','syslog','exec','suspend','single','halt'
+]

--- a/types/diskfullaction.pp
+++ b/types/diskfullaction.pp
@@ -1,1 +1,4 @@
-type Auditd::DiskFullAction = Enum['IGNORE','SYSLOG','ROTATE','EXEC','SUSPEND','SINGLE','HALT']
+type Auditd::DiskFullAction = Enum[
+  'IGNORE','SYSLOG','ROTATE','EXEC','SUSPEND','SINGLE','HALT',
+  'ignore','syslog','rotate','exec','suspend','single','halt'
+]

--- a/types/flush.pp
+++ b/types/flush.pp
@@ -1,1 +1,1 @@
-type Auditd::Flush = Enum['NONE','INCREMENTAL','DATA','SYNC']
+type Auditd::Flush = Enum['NONE','INCREMENTAL','DATA','SYNC','none','incremental','data','sync']

--- a/types/maxlogfileaction.pp
+++ b/types/maxlogfileaction.pp
@@ -1,1 +1,4 @@
-type Auditd::MaxLogFileAction = Enum['IGNORE','SYSLOG','SUSPEND','ROTATE','KEEP_LOGS']
+type Auditd::MaxLogFileAction = Enum[
+  'IGNORE','SYSLOG','SUSPEND','ROTATE','KEEP_LOGS',
+  'ignore','syslog','suspend','rotate','keep_logs'
+]

--- a/types/nameformat.pp
+++ b/types/nameformat.pp
@@ -1,1 +1,1 @@
-type Auditd::NameFormat = Enum['NONE','HOSTNAME','FQD','NUMERIC','USER']
+type Auditd::NameFormat = Enum['NONE','HOSTNAME','FQD','NUMERIC','USER','none','hostname','fqd','numeric','user']

--- a/types/overflowaction.pp
+++ b/types/overflowaction.pp
@@ -1,1 +1,1 @@
-type Auditd::OverflowAction = Enum['IGNORE','SYSLOG','SUSPEND','SINGLE','HALT']
+type Auditd::OverflowAction = Enum['IGNORE','SYSLOG','SUSPEND','SINGLE','HALT','ignore','syslog','suspend','single','halt']

--- a/types/spaceleftaction.pp
+++ b/types/spaceleftaction.pp
@@ -1,1 +1,4 @@
-type Auditd::SpaceLeftAction = Enum['IGNORE','SYSLOG','ROTATE','EMAIL','EXEC','SUSPEND','SINGLE','HALT']
+type Auditd::SpaceLeftAction = Enum[
+  'IGNORE','SYSLOG','ROTATE','EMAIL','EXEC','SUSPEND','SINGLE','HALT',
+  'ignore','syslog','rotate','email','exec','suspend','single','halt'
+]


### PR DESCRIPTION
The man page for auditd.conf documents all lowercase values.
Latest OpenSCAP for RHEL 7 also expects all lowercase.