### PR TITLE
Use default service provider

### DIFF
--- a/CHANGELOG
+++ b/CHANGELOG
@@ -1,3 +1,7 @@
+* Thu Nov 15 2018 Mark Leary  <leary.mark@gmail.com> - 8.1.1-0
+- Revert back to using the native service provider for the auditd service since
+  puppet fixed the service handling.
+
 * Wed Oct 31 2018 Trevor Vaughan <tvaughan@onyxpoint.com> - 8.1.0-0
 - Allow users to opt-out of hooking the audit dispatchers into the SIMP rsyslog
   module using `auditd::config::audisp::syslog::rsyslog = false` or,

--- a/Gemfile
+++ b/Gemfile
@@ -7,7 +7,7 @@ gem_sources.each { |gem_source| source gem_source }
 
 group :test do
   gem 'rake'
-  gem 'puppet', ENV.fetch('PUPPET_VERSION',  '~> 4.0')
+  gem 'puppet', ENV.fetch('PUPPET_VERSION',  '~> 5.0')
   gem 'rspec'
   gem 'rspec-puppet'
   gem 'hiera-puppet-helper'

--- a/manifests/service.pp
+++ b/manifests/service.pp
@@ -20,5 +20,8 @@ class auditd::service (
     enable     => $enable,
     hasrestart => true,
     hasstatus  => true,
+    start      => "/sbin/service ${::auditd::service_name} start",
+    stop       => "/sbin/service ${::auditd::service_name} stop",
+    restart    => "/sbin/service ${::auditd::service_name} restart",
   }
 }

--- a/manifests/service.pp
+++ b/manifests/service.pp
@@ -20,6 +20,5 @@ class auditd::service (
     enable     => $enable,
     hasrestart => true,
     hasstatus  => true,
-    provider   => 'redhat'
   }
 }

--- a/manifests/service.pp
+++ b/manifests/service.pp
@@ -18,10 +18,8 @@ class auditd::service (
   service { $::auditd::service_name:
     ensure     => $ensure,
     enable     => $enable,
-    hasrestart => true,
-    hasstatus  => true,
-    start      => "/sbin/service ${::auditd::service_name} start",
-    stop       => "/sbin/service ${::auditd::service_name} stop",
-    restart    => "/sbin/service ${::auditd::service_name} restart",
+    start      => "/sbin/service ${auditd::service_name} start",
+    stop       => "/sbin/service ${auditd::service_name} stop",
+    restart    => "/sbin/service ${auditd::service_name} restart"
   }
 }

--- a/metadata.json
+++ b/metadata.json
@@ -1,6 +1,6 @@
 {
   "name": "simp-auditd",
-  "version": "8.1.0",
+  "version": "8.1.1",
   "author": "SIMP Team",
   "summary": "A SIMP puppet module for managing auditd and audispd",
   "license": "Apache-2.0",

--- a/spec/classes/init_spec.rb
+++ b/spec/classes/init_spec.rb
@@ -22,10 +22,11 @@ describe 'auditd' do
           it_behaves_like 'a structured module'
           it {
             is_expected.to contain_service('auditd').with({
-              :ensure => 'running',
-              :enable => true,
-              :hasrestart => true,
-              :hasstatus => true
+              :ensure  => 'running',
+              :enable  => true,
+              :start   => "/sbin/service auditd start",
+              :stop    => "/sbin/service auditd stop",
+              :restart => "/sbin/service auditd restart"
             })
           }
           it { is_expected.to contain_class('auditd::install').that_comes_before('Class[auditd::config::grub]') }

--- a/spec/classes/init_spec.rb
+++ b/spec/classes/init_spec.rb
@@ -25,10 +25,7 @@ describe 'auditd' do
               :ensure => 'running',
               :enable => true,
               :hasrestart => true,
-              :hasstatus => true,
-              # This is because the default provider for RHEL7 uses systemd
-              # which does not work for auditd at this time.
-              :provider => 'redhat'
+              :hasstatus => true
             })
           }
           it { is_expected.to contain_class('auditd::install').that_comes_before('Class[auditd::config::grub]') }


### PR DESCRIPTION
Setting provider to 'redhat' causes an issue on RHEL7 systems as puppet tries to use sysvinit tools instead of systemd.  Specifically, the error I'm getting on RHEL 7.5 w/Puppet 5.5.2 is:

```
Error: Could not enable auditd: Execution of '/sbin/chkconfig --add auditd' returned 1: error reading information on service auditd: No such file or directory
Error: /Stage[main]/Auditd::Service/Service[auditd]/enable: change from 'false' to 'true' failed: Could not enable auditd: Execution of '/sbin/chkconfig --add auditd' returned 1: error reading information on service auditd: No such file or directory
```

Removing the provider attribute from the service resources fixes the error in RHEL7.  I also tested in RHEL6.