### PR TITLE
(SIMP-5934) Add restorecon audit

### DIFF
--- a/CHANGELOG
+++ b/CHANGELOG
@@ -1,3 +1,6 @@
+* Fri Jan 11 2019 Adam Yohrling <adam.yohrling@onyxpoint.com> - 8.1.2-0
+- Add restorecon audit for STIG profile
+
 * Fri Nov 16 2018 Trevor Vaughan <tvaughan@onyxpoint.com> - 8.1.2-0
 - Update to remove potentially redundant test code and use the updated
   simp-beaker-helpers

--- a/spec/classes/config/audit_profiles/expected/stig_el6_all_custom_tags.txt
+++ b/spec/classes/config/audit_profiles/expected/stig_el6_all_custom_tags.txt
@@ -101,6 +101,9 @@
 # RHEL-07-030590
 -a always,exit -F path=/sbin/setfiles -F perm=x -F auid>=500 -F auid!=4294967295 -k my_selinux_cmds
 
+# RHEL-07-030590
+-a always,exit -F path=/sbin/restorecon -F perm=x -F auid>=500 -F auid!=4294967295 -k my_selinux_cmds
+
 ## Permissions auditing separated by chown, chmod, and attr
 # RHEL-07-030370
 -a always,exit -F arch=b64 -S chown -F auid>=500 -F auid!=4294967295 -k my_chown

--- a/spec/classes/config/audit_profiles/expected/stig_el6_base_rules.txt
+++ b/spec/classes/config/audit_profiles/expected/stig_el6_base_rules.txt
@@ -101,6 +101,9 @@
 # RHEL-07-030590
 -a always,exit -F path=/sbin/setfiles -F perm=x -F auid>=500 -F auid!=4294967295 -k privileged-priv_change
 
+# RHEL-07-030590
+-a always,exit -F path=/sbin/restorecon -F perm=x -F auid>=500 -F auid!=4294967295 -k privileged-priv_change
+
 ## Permissions auditing separated by chown, chmod, and attr
 # RHEL-07-030370
 -a always,exit -F arch=b64 -S chown -F auid>=500 -F auid!=4294967295 -k perm_mod

--- a/spec/classes/config/audit_profiles/expected/stig_el7_all_custom_tags.txt
+++ b/spec/classes/config/audit_profiles/expected/stig_el7_all_custom_tags.txt
@@ -119,6 +119,10 @@
 -a always,exit -F path=/usr/sbin/setfiles -F perm=x -F auid>=1000 -F auid!=4294967295 -k my_selinux_cmds
 -a always,exit -F path=/sbin/setfiles -F perm=x -F auid>=1000 -F auid!=4294967295 -k my_selinux_cmds
 
+# RHEL-07-030590
+-a always,exit -F path=/sbin/restorecon -F perm=x -F auid>=1000 -F auid!=4294967295 -k my_selinux_cmds
+-a always,exit -F path=/usr/sbin/restorecon -F perm=x -F auid>=1000 -F auid!=4294967295 -k my_selinux_cmds
+
 ## Permissions auditing separated by chown, chmod, and attr
 # RHEL-07-030370
 -a always,exit -F arch=b64 -S chown -F auid>=1000 -F auid!=4294967295 -k my_chown

--- a/spec/classes/config/audit_profiles/expected/stig_el7_base_rules.txt
+++ b/spec/classes/config/audit_profiles/expected/stig_el7_base_rules.txt
@@ -119,6 +119,10 @@
 -a always,exit -F path=/usr/sbin/setfiles -F perm=x -F auid>=1000 -F auid!=4294967295 -k privileged-priv_change
 -a always,exit -F path=/sbin/setfiles -F perm=x -F auid>=1000 -F auid!=4294967295 -k privileged-priv_change
 
+# RHEL-07-030590
+-a always,exit -F path=/sbin/restorecon -F perm=x -F auid>=1000 -F auid!=4294967295 -k privileged-priv_change
+-a always,exit -F path=/usr/sbin/restorecon -F perm=x -F auid>=1000 -F auid!=4294967295 -k privileged-priv_change
+
 ## Permissions auditing separated by chown, chmod, and attr
 # RHEL-07-030370
 -a always,exit -F arch=b64 -S chown -F auid>=1000 -F auid!=4294967295 -k perm_mod

--- a/templates/rule_profiles/stig/base.erb
+++ b/templates/rule_profiles/stig/base.erb
@@ -181,6 +181,12 @@
 -a always,exit -F path=/usr/sbin/setfiles -F perm=x -F auid>=<%= @uid_min %> -F auid!=4294967295 -k <%= @audit_selinux_cmds_tag %>
 <%   end -%>
 -a always,exit -F path=/sbin/setfiles -F perm=x -F auid>=<%= @uid_min %> -F auid!=4294967295 -k <%= @audit_selinux_cmds_tag %>
+
+# RHEL-07-030590
+-a always,exit -F path=/sbin/restorecon -F perm=x -F auid>=<%= @uid_min %> -F auid!=4294967295 -k <%= @audit_selinux_cmds_tag %>
+<%   if @facts['os']['release']['major'] > '6' -%>
+-a always,exit -F path=/usr/sbin/restorecon -F perm=x -F auid>=<%= @uid_min %> -F auid!=4294967295 -k <%= @audit_selinux_cmds_tag %>
+<%   end -%>
 <% end -%>
 
 ## Permissions auditing separated by chown, chmod, and attr


### PR DESCRIPTION
This change adds auditing of restorecon under the SELinux commands
auditing section of the STIG profile.

SIMP-5934 #close #comment add restorecon audit