### PR TITLE
(SIMP-5959) Allow users to filter on SELinux types

### DIFF
--- a/CHANGELOG
+++ b/CHANGELOG
@@ -1,7 +1,11 @@
-* Fri Jan 11 2019 Adam Yohrling <adam.yohrling@onyxpoint.com> - 8.1.2-0
+* Tue Jan 15 2019 Trevor Vaughan <tvaughan@onyxpoint.com> - 8.2.0-0
+- Allow users to optimize their audit processing by only collecting on specific
+  SELinux types
+
+* Fri Jan 11 2019 Adam Yohrling <adam.yohrling@onyxpoint.com> - 8.2.0-0
 - Add restorecon audit for STIG profile
 
-* Fri Nov 16 2018 Trevor Vaughan <tvaughan@onyxpoint.com> - 8.1.2-0
+* Fri Nov 16 2018 Trevor Vaughan <tvaughan@onyxpoint.com> - 8.2.0-0
 - Update to remove potentially redundant test code and use the updated
   simp-beaker-helpers
 

--- a/manifests/init.pp
+++ b/manifests/init.pp
@@ -134,6 +134,12 @@
 #   For built-in audit profiles, whether to drop events related to cron
 #   jobs. `cron` creates a lot of audit events that are not usually useful.
 #
+# @param target_selinux_types
+#   A list of SELinux types to target, all others will be dropped
+#
+#   For systems that require all users and processes to be an a confined
+#   namespace, you may find that only auditing unconfined types will be
+#   sufficient since all other invalid system actions are already audited.
 class auditd (
   String                                  $lname                   = $facts['fqdn'],
   Boolean                                 $immutable               = false,
@@ -175,6 +181,7 @@ class auditd (
   Boolean                                 $ignore_anonymous        = true,
   Boolean                                 $ignore_system_services  = true,
   Boolean                                 $ignore_crond            = true,
+  Optional[Array[Pattern['^.*_t$']]]      $target_selinux_types    = undef
 ) {
 
   if $enable {

--- a/manifests/init.pp
+++ b/manifests/init.pp
@@ -137,7 +137,7 @@
 # @param target_selinux_types
 #   A list of SELinux types to target, all others will be dropped
 #
-#   For systems that require all users and processes to be an a confined
+#   For systems that require all users and processes to be in a confined
 #   namespace, you may find that only auditing unconfined types will be
 #   sufficient since all other invalid system actions are already audited.
 class auditd (

--- a/metadata.json
+++ b/metadata.json
@@ -1,6 +1,6 @@
 {
   "name": "simp-auditd",
-  "version": "8.1.2",
+  "version": "8.2.0",
   "author": "SIMP Team",
   "summary": "A SIMP puppet module for managing auditd and audispd",
   "license": "Apache-2.0",

--- a/spec/classes/config/audit_profiles_spec.rb
+++ b/spec/classes/config/audit_profiles_spec.rb
@@ -63,6 +63,22 @@ describe 'auditd' do
 
       end
 
+      context 'targeting specific SELinux types' do
+        let(:params){{
+          :target_selinux_types => ['unconfined_t', 'bob_t']
+        }}
+
+        it 'adds a rule to drop types not in the match list' do
+          is_expected.to contain_file('/etc/audit/rules.d/05_default_drop.rules').with_content(
+            %r(^-a\s+never,user\s+-F\s+subj_type!=unconfined_t$)
+          )
+
+          is_expected.to contain_file('/etc/audit/rules.d/05_default_drop.rules').with_content(
+            %r(^-a\s+never,user\s+-F\s+subj_type!=bob_t$)
+          )
+        end
+      end
+
       context 'setting the root audit level to aggressive' do
         let(:params) {{ :root_audit_level => 'aggressive' }}
 

--- a/templates/rule_profiles/common/default_drop.epp
+++ b/templates/rule_profiles/common/default_drop.epp
@@ -10,8 +10,14 @@
 # that just makes for more processing time.
 -a exit,never -F auid!=0 -F auid<<%= $::auditd::uid_min %>
 <% } -%>
-<% if $::auditd::ignore_crond {-%>
+<% if $::auditd::ignore_crond { -%>
 # Drop events related to cron jobs.  It creates a lot of logs that are not
 # usually useful
 -a never,user -F subj_type=crond_t
+<% } -%>
+<% if $::auditd::target_selinux_types { -%>
+# Drop the following SELinux types to aid performance
+<%   $::auditd::target_selinux_types.each |$sel_type| { -%>
+-a never,user -F subj_type!=<%= $sel_type %>
+<%   } -%>
 <% } -%>


### PR DESCRIPTION
Audit processing can be highly optimized if you take the approach that
only specific SELinux types should generally be audited since all other,
non-allowed, actions are audited by SELinux itself.

This patch adds the capability to globally target specific SELinux types
for further audit processing and drop all other material in user space.

SIMP-5959 #close