### PR TITLE
(SIMP-6213) Use latest concat in tests

### DIFF
--- a/.fixtures.yml
+++ b/.fixtures.yml
@@ -4,11 +4,7 @@ fixtures:
     compliance_markup: https://github.com/simp/pupmod-simp-compliance_markup
     augeasproviders_core: https://github.com/simp/augeasproviders_core
     augeasproviders_grub: https://github.com/simp/augeasproviders_grub
-    concat:
-      # master is beyond 4.1.1, but has breaking changes to
-      # how fragments are ordered (MODULES-6625)
-      repo: https://github.com/simp/puppetlabs-concat
-      ref: 4.1.1
+    concat: https://github.com/simp/puppetlabs-concat
     logrotate: https://github.com/simp/pupmod-simp-logrotate
     pki: https://github.com/simp/pupmod-simp-pki
     rsyslog: https://github.com/simp/pupmod-simp-rsyslog

--- a/CHANGELOG
+++ b/CHANGELOG
@@ -1,3 +1,7 @@
+* Mon Mar 04 2019 Liz Nemsick <lnemsick.simp@gmail.com> - 8.2.0-0
+- Expanded the upper limit of the stdlib Puppet module version
+- Updated a URL in the README.md
+
 * Tue Jan 15 2019 Trevor Vaughan <tvaughan@onyxpoint.com> - 8.2.0-0
 - Allow users to optimize their audit processing by only collecting on specific
   SELinux types

--- a/README.md
+++ b/README.md
@@ -29,9 +29,9 @@
 This module manages the Audit daemon, kernel parameters, and related subsystems.
 
 ## This is a SIMP module
-This module is a component of the [System Integrity Management
-Platform](https://github.com/NationalSecurityAgency/SIMP), a compliance
-management framework built on Puppet.
+
+This module is a component of the [System Integrity Management Platform](https://simp-project.com),
+a compliance-management framework built on Puppet.
 
 If you find any issues, they can be submitted to our [JIRA](https://simp-project.atlassian.net/).
 

--- a/README.md
+++ b/README.md
@@ -118,7 +118,7 @@ SIMP Puppet modules are generally intended to be used on a Redhat Enterprise Lin
 
 ## Development
 
-Please read our [Contribution Guide](https://simp.readthedocs.io/en/master/contributors_guide/Contribution_Procedure.html)
+Please read our [Contribution Guide](https://simp.readthedocs.io/en/stable/contributors_guide/Contribution_Procedure.html)
 
 ### Acceptance tests
 

--- a/metadata.json
+++ b/metadata.json
@@ -15,7 +15,7 @@
   "dependencies": [
     {
       "name": "puppetlabs/stdlib",
-      "version_requirement": ">= 4.13.1 < 5.0.0"
+      "version_requirement": ">= 4.13.1 < 6.0.0"
     },
     {
       "name": "simp/simplib",


### PR DESCRIPTION
- Test with latest concat Puppet module instead of 4.1.1
- Expanded the upper limit of the stdlib Puppet module version,
  since the tests are using a 5.X version
- Updated a URL in the README.md

SIMP-6213 #comment pupmod-simp-auditd