### PR TITLE
(SIMP-6120) Convert to_integer() calls

### DIFF
--- a/CHANGELOG
+++ b/CHANGELOG
@@ -1,3 +1,6 @@
+* Tue Mar 19 2019 Liz Nemsick <lnemsick.simp@gmail.com> - 8.2.1-0
+- Use Puppet Integer in lieu of simplib's deprecated Puppet 3 to_integer
+
 * Mon Mar 04 2019 Liz Nemsick <lnemsick.simp@gmail.com> - 8.2.0-0
 - Expanded the upper limit of the stdlib Puppet module version
 - Updated a URL in the README.md
@@ -26,7 +29,6 @@
   breaking changes in these settings after `auditd` version `2.6.0`.
 - Add support for `log_format = ENHANCED` for `auditd` version >= `2.6.0`.
   Older versions will simply fall back to `RAW`.
-
 
 * Tue Oct 16 2018 Nick Markowski <nicholas.markowski@onyxpoint.com> - 8.1.0-0
 - Removed unnecessary dependencies from metadata.json.  Now, when users install

--- a/manifests/init.pp
+++ b/manifests/init.pp
@@ -144,7 +144,7 @@ class auditd (
   String                                  $lname                   = $facts['fqdn'],
   Boolean                                 $immutable               = false,
   Auditd::RootAuditLevel                  $root_audit_level        = 'basic',
-  Integer[0]                              $uid_min                 = to_integer($facts['uid_min']),
+  Integer[0]                              $uid_min                 = Integer($facts['uid_min']),
   Boolean                                 $at_boot                 = true, # CCE-26785-6
   Boolean                                 $syslog                  = simplib::lookup('simp_options::syslog', {'default_value' => false }),  # CCE-26933-2
   Optional[Variant[Enum['simp'],Boolean]] $default_audit_profile   = undef,

--- a/metadata.json
+++ b/metadata.json
@@ -1,6 +1,6 @@
 {
   "name": "simp-auditd",
-  "version": "8.2.0",
+  "version": "8.2.1",
   "author": "SIMP Team",
   "summary": "A SIMP puppet module for managing auditd and audispd",
   "license": "Apache-2.0",


### PR DESCRIPTION
Use Puppet Integer in lieu of simplib's deprecated Puppet 3 to_integer

SIMP-6120 #close