### PR TITLE
(SIMP-6104) Manage /etc/audit directory

### DIFF
--- a/CHANGELOG
+++ b/CHANGELOG
@@ -1,3 +1,8 @@
+* Sat Apr 06 2019 Jim Anderson <thesemicolons@protonmail.com> - 8.2.2-0
+- config.pp now managed /etc/audit in addition to /etc/audit/rules.d.
+  The permissions and ownership of the two directories should be the
+  same. Both directories use purge and recurse.
+
 * Mon Mar 25 2019 Joseph Sharkey <shark.bruhaha@gmail.com> - 8.2.1-0
 - Updated puppet template scope API from 3 to newer
 

--- a/manifests/config.pp
+++ b/manifests/config.pp
@@ -21,6 +21,15 @@ class auditd::config {
     default => '0640',
   }
 
+  file { '/etc/audit':
+    ensure  => 'directory',
+    owner   => 'root',
+    group   => $::auditd::log_group,
+    mode    => $log_file_mode,
+    recurse => true,
+    purge   => true
+  }
+
   file { '/etc/audit/rules.d':
     ensure  => 'directory',
     owner   => 'root',

--- a/metadata.json
+++ b/metadata.json
@@ -1,6 +1,6 @@
 {
   "name": "simp-auditd",
-  "version": "8.2.1",
+  "version": "8.2.2",
   "author": "SIMP Team",
   "summary": "A SIMP puppet module for managing auditd and audispd",
   "license": "Apache-2.0",

--- a/spec/classes/config_spec.rb
+++ b/spec/classes/config_spec.rb
@@ -16,6 +16,16 @@ describe 'auditd' do
 
           it { is_expected.to compile.with_all_deps }
           it {
+            is_expected.to contain_file('/etc/audit').with({
+              :ensure  => 'directory',
+              :owner   => 'root',
+              :group   => 'root',
+              :mode    => '0600',
+              :recurse => true,
+              :purge   => true
+            })
+          }
+          it {
             is_expected.to contain_file('/etc/audit/rules.d').with({
               :ensure  => 'directory',
               :owner   => 'root',
@@ -78,6 +88,16 @@ describe 'auditd' do
           let(:params) {{ log_group: 'rspec' }}
 
           it { is_expected.to compile.with_all_deps }
+          it {
+            is_expected.to contain_file('/etc/audit').with({
+              :ensure  => 'directory',
+              :owner   => 'root',
+              :group   => 'rspec',
+              :mode    => '0640',
+              :recurse => true,
+              :purge   => true
+            })
+          }
           it {
             is_expected.to contain_file('/etc/audit/rules.d').with({
               :ensure  => 'directory',


### PR DESCRIPTION
The /etc/audit directory is now managed in the same way as the
/etc/audit/rules.d directory. Both will have the same permissions,
ownership, and utilize purge and recourse.