### PR TITLE
(SIMP-6565) auditd::rule no longer includes auditd

### DIFF
--- a/CHANGELOG
+++ b/CHANGELOG
@@ -1,14 +1,19 @@
+* Thu May 02 2019 Liz Nemsick <lnemsick.simp@gmail.com> - 8.3.1-0
+- Fix a breaking change inadvertantly introduced into auditd::rule
+  in which the auditd class was no longer included when an auditd::rule
+  was defined in a manifest.
+
 * Thu Apr 25 2019 Trevor Vaughan <tvaughan@onyxpoint.com> - 8.3.0-0
-  - Added a `custom` audit profile that accepts either an Array of rules or a
-    template path for ease of setting full rulesets via Hiera.
-  - Updated all module components for `puppet strings`
-  - Fixed the README
-  - Added a REFERENCE.md
-  - Refactored the filename logic in the base profiles to be simpler
-  - Converted the rule template to EPP
-  - Converted the rotated_audit_logs template to EPP
-  - Converted STIG audit profile template to EPP
-  - Converted SIMP audit profile template to EPP
+- Added a `custom` audit profile that accepts either an Array of rules or a
+  template path for ease of setting full rulesets via Hiera.
+- Updated all module components for `puppet strings`
+- Fixed the README
+- Added a REFERENCE.md
+- Refactored the filename logic in the base profiles to be simpler
+- Converted the rule template to EPP
+- Converted the rotated_audit_logs template to EPP
+- Converted STIG audit profile template to EPP
+- Converted SIMP audit profile template to EPP
 
 * Wed Apr 10 2019 Joseph Sharkey <shark.bruhaha@gmail.com> - 8.2.1-0
 - Ensure that space_left is always larger than admin_space_left

--- a/manifests/rule.pp
+++ b/manifests/rule.pp
@@ -35,7 +35,9 @@ define auditd::rule (
   Boolean                             $absolute = false,
   Boolean                             $prepend  = false
 ) {
-  if defined('$auditd::enable') and $auditd::enable {
+  include 'auditd'
+
+  if $auditd::enable {
 
     $_safe_name = regsubst($name, '(/|\s)', '__')
 

--- a/metadata.json
+++ b/metadata.json
@@ -1,6 +1,6 @@
 {
   "name": "simp-auditd",
-  "version": "8.3.0",
+  "version": "8.3.1",
   "author": "SIMP Team",
   "summary": "A SIMP puppet module for managing auditd and audispd",
   "license": "Apache-2.0",

--- a/spec/defines/rule_spec.rb
+++ b/spec/defines/rule_spec.rb
@@ -8,14 +8,11 @@ describe 'auditd::rule' do
         let(:params) {{ :content => 'rspec_audit_message' }}
         let(:facts) { os_facts }
 
-        let(:pre_condition) {
-          'include auditd'
-        }
-
         it { is_expected.to compile.with_all_deps }
 
         context "without any parameters" do
           it {
+            is_expected.to contain_class('auditd')
             is_expected.to contain_file("/etc/audit/rules.d/75.#{title}.rules").with_content(%r(#{params[:content]}))
           }
         end


### PR DESCRIPTION
Fix a breaking change inadvertantly introduced into auditd::rule
in which the auditd class was no longer included when an auditd::rule
was defined in a manifest.

SIMP-6565 #close