### PR TITLE
(SIMP-6706) Fix trailing newline in custom profile

### DIFF
--- a/CHANGELOG
+++ b/CHANGELOG
@@ -1,3 +1,7 @@
+* Tue Jun 25 2019 Trevor Vaughan <tvaughan@onyxpoint.com> - 8.3.2-0
+- Fix issue where traiing newlines may not be present on custom rule profiles,
+  particularly with rules defined in an Array.
+
 * Thu May 02 2019 Liz Nemsick <lnemsick.simp@gmail.com> - 8.3.1-0
 - Fix a breaking change inadvertantly introduced into auditd::rule
   in which the auditd class was no longer included when an auditd::rule

--- a/CHANGELOG
+++ b/CHANGELOG
@@ -1,6 +1,6 @@
 * Tue Jun 25 2019 Trevor Vaughan <tvaughan@onyxpoint.com> - 8.3.2-0
-- Fix issue where traiing newlines may not be present on custom rule profiles,
-  particularly with rules defined in an Array.
+- Fix an issue where trailing newlines may not be present on custom rule
+  profiles, particularly with rules defined in an Array.
 
 * Thu May 02 2019 Liz Nemsick <lnemsick.simp@gmail.com> - 8.3.1-0
 - Fix a breaking change inadvertantly introduced into auditd::rule

--- a/manifests/config/audit_profiles/custom.pp
+++ b/manifests/config/audit_profiles/custom.pp
@@ -70,6 +70,6 @@ class auditd::config::audit_profiles::custom (
   $_idx = auditd::get_array_index($_short_name, $auditd::config::profiles)
 
   file { "/etc/audit/rules.d/50_${_idx}_${_short_name}_base.rules":
-    content => $_custom_rules
+    content => "${_custom_rules}\n"
   }
 }

--- a/metadata.json
+++ b/metadata.json
@@ -1,6 +1,6 @@
 {
   "name": "simp-auditd",
-  "version": "8.3.1",
+  "version": "8.3.2",
   "author": "SIMP Team",
   "summary": "A SIMP puppet module for managing auditd and audispd",
   "license": "Apache-2.0",

--- a/spec/classes/config/audit_profiles/custom_spec.rb
+++ b/spec/classes/config/audit_profiles/custom_spec.rb
@@ -25,7 +25,7 @@ describe 'auditd::config::audit_profiles::custom' do
         }}
 
         it { is_expected.to compile.with_all_deps }
-        it { is_expected.to contain_file('/etc/audit/rules.d/50_00_custom_base.rules').with_content(params[:rules].join("\n")) }
+        it { is_expected.to contain_file('/etc/audit/rules.d/50_00_custom_base.rules').with_content(params[:rules].join("\n") + "\n") }
       end
 
       context 'when using templates' do
@@ -43,7 +43,7 @@ describe 'auditd::config::audit_profiles::custom' do
           }
 
           it { is_expected.to compile.with_all_deps }
-          it { is_expected.to contain_file('/etc/audit/rules.d/50_00_custom_base.rules').with_content('EPP!') }
+          it { is_expected.to contain_file('/etc/audit/rules.d/50_00_custom_base.rules').with_content("EPP!\n") }
         end
 
         context 'with ERB template specified' do
@@ -60,7 +60,7 @@ describe 'auditd::config::audit_profiles::custom' do
           }
 
           it { is_expected.to compile.with_all_deps }
-          it { is_expected.to contain_file('/etc/audit/rules.d/50_00_custom_base.rules').with_content('ERB!') }
+          it { is_expected.to contain_file('/etc/audit/rules.d/50_00_custom_base.rules').with_content("ERB!\n") }
         end
 
         context 'with an invalid template name specified' do
@@ -107,7 +107,7 @@ describe 'auditd::config::audit_profiles::custom' do
         }}
 
         it { is_expected.to compile.with_all_deps }
-        it { is_expected.to contain_file('/etc/audit/rules.d/50_01_custom_base.rules').with_content(params[:rules].join("\n")) }
+        it { is_expected.to contain_file('/etc/audit/rules.d/50_01_custom_base.rules').with_content(params[:rules].join("\n") + "\n") }
       end
     end
   end


### PR DESCRIPTION
Custom profiles had issues where a trailing newline would not be
present when joining on an Array. Now append a trailing newline in all
cases in case of a badly formatted template or Array join.

SIMP-6706 #close