### PR TITLE
(SIMP-7005) Monitor changes to /usr/share/selinux/

### DIFF
--- a/CHANGELOG
+++ b/CHANGELOG
@@ -1,3 +1,6 @@
+* Mon Aug 19 2019 Robert Vincent <pillarsdotnet@gmail.com> - 8.4.1-0
+- Add rules to monitor /usr/share/selinux
+
 * Fri Jul 05 2019 Steven Pritchard <steven.pritchard@onyxpoint.com> - 8.4.0-0
 - Add v2 compliance_markup data
 

--- a/metadata.json
+++ b/metadata.json
@@ -1,6 +1,6 @@
 {
   "name": "simp-auditd",
-  "version": "8.4.0",
+  "version": "8.4.1",
   "author": "SIMP Team",
   "summary": "A SIMP puppet module for managing auditd and audispd",
   "license": "Apache-2.0",

--- a/spec/classes/config/audit_profiles/expected/simp_el6_aggressive_rules.txt
+++ b/spec/classes/config/audit_profiles/expected/simp_el6_aggressive_rules.txt
@@ -190,6 +190,7 @@
 ## Audit selinux policy
 # CCE-26657-7
 -w /etc/selinux/ -p wa -k MAC-policy
+-w /usr/share/selinux/ -p wa -k MAC-policy
 
 ## Audit login files
 # CCE-26691-6

--- a/spec/classes/config/audit_profiles/expected/simp_el6_all_rules_custom_tags.txt
+++ b/spec/classes/config/audit_profiles/expected/simp_el6_all_rules_custom_tags.txt
@@ -226,6 +226,7 @@
 ## Audit selinux policy
 # CCE-26657-7
 -w /etc/selinux/ -p wa -k my_selinux_policy
+-w /usr/share/selinux/ -p wa -k my_selinux_policy
 
 ## Audit login files
 # CCE-26691-6

--- a/spec/classes/config/audit_profiles/expected/simp_el6_basic_rules.txt
+++ b/spec/classes/config/audit_profiles/expected/simp_el6_basic_rules.txt
@@ -190,6 +190,7 @@
 ## Audit selinux policy
 # CCE-26657-7
 -w /etc/selinux/ -p wa -k MAC-policy
+-w /usr/share/selinux/ -p wa -k MAC-policy
 
 ## Audit login files
 # CCE-26691-6

--- a/spec/classes/config/audit_profiles/expected/simp_el6_insane_rules.txt
+++ b/spec/classes/config/audit_profiles/expected/simp_el6_insane_rules.txt
@@ -190,6 +190,7 @@
 ## Audit selinux policy
 # CCE-26657-7
 -w /etc/selinux/ -p wa -k MAC-policy
+-w /usr/share/selinux/ -p wa -k MAC-policy
 
 ## Audit login files
 # CCE-26691-6

--- a/spec/classes/config/audit_profiles/expected/simp_el7_aggressive_rules.txt
+++ b/spec/classes/config/audit_profiles/expected/simp_el7_aggressive_rules.txt
@@ -213,6 +213,7 @@
 ## Audit selinux policy
 # CCE-26657-7
 -w /etc/selinux/ -p wa -k MAC-policy
+-w /usr/share/selinux/ -p wa -k MAC-policy
 
 ## Audit login files
 # CCE-26691-6

--- a/spec/classes/config/audit_profiles/expected/simp_el7_all_rules_custom_tags.txt
+++ b/spec/classes/config/audit_profiles/expected/simp_el7_all_rules_custom_tags.txt
@@ -252,6 +252,7 @@
 ## Audit selinux policy
 # CCE-26657-7
 -w /etc/selinux/ -p wa -k my_selinux_policy
+-w /usr/share/selinux/ -p wa -k my_selinux_policy
 
 ## Audit login files
 # CCE-26691-6

--- a/spec/classes/config/audit_profiles/expected/simp_el7_basic_rules.txt
+++ b/spec/classes/config/audit_profiles/expected/simp_el7_basic_rules.txt
@@ -213,6 +213,7 @@
 ## Audit selinux policy
 # CCE-26657-7
 -w /etc/selinux/ -p wa -k MAC-policy
+-w /usr/share/selinux/ -p wa -k MAC-policy
 
 ## Audit login files
 # CCE-26691-6

--- a/spec/classes/config/audit_profiles/expected/simp_el7_insane_rules.txt
+++ b/spec/classes/config/audit_profiles/expected/simp_el7_insane_rules.txt
@@ -213,6 +213,7 @@
 ## Audit selinux policy
 # CCE-26657-7
 -w /etc/selinux/ -p wa -k MAC-policy
+-w /usr/share/selinux/ -p wa -k MAC-policy
 
 ## Audit login files
 # CCE-26691-6

--- a/templates/rule_profiles/simp/base.epp
+++ b/templates/rule_profiles/simp/base.epp
@@ -391,6 +391,7 @@
 ## Audit selinux policy
 # CCE-26657-7
 -w /etc/selinux/ -p wa -k <%= $auditd::config::audit_profiles::simp::audit_selinux_policy_tag %>
+-w /usr/share/selinux/ -p wa -k <%= $auditd::config::audit_profiles::simp::audit_selinux_policy_tag %>
 <% } -%>
 <% if $auditd::config::audit_profiles::simp::audit_login_files  { -%>
 


### PR DESCRIPTION
Fixes: [SIMP-7005](https://simp-project.atlassian.net/browse/SIMP-7005)

A recent Nessus scan recommends monitoring `/usr/share/selinux/` as well as `/etc/selinux/`.

Reference Information:
- 800-171|3.3.1
- 800-171|3.3.2
- 800-53|AU-12
- CCE|CCE-27168-4
- CN-L3|7.1.3.3(a)
- CN-L3|7.1.3.3(b)
- CN-L3|7.1.3.3(c)
- CSF|DE.CM-1
- CSF|DE.CM-3
- CSF|DE.CM-7
- CSF|PR.PT-1
- HIPAA|164.312(b)
- ISO/IEC-27001|A.12.4.1
- ITSG-33|AU-12
- LEVEL|2S
- NESA|T3.6.2
- NESA|T3.6.5
- NESA|T3.6.6
- NIAv2|SM8
- PCI-DSS|10.1
- PCI-DSS|10.2
- SWIFT-CSCv1|6.4
- TBA-FIISB|45.1.1"

See Also: https://workbench.cisecurity.org/files/1858