### PR TITLE
(SIMP-7116) Auditd Defaults

### DIFF
--- a/CHANGELOG
+++ b/CHANGELOG
@@ -1,3 +1,6 @@
+* Thu Oct 24 2019 Jeanne Greulich <jeanne.greulich@onyxpoint.com> - 8.5.0-0
+- Set defaults for syslog parameters if auditd version is unknown.
+
 * Fri Oct 11 2019 Jeanne Greulich <jeanne.greulich@onyxpoint.com> - 8.5.0-0
 - Added support for auditd v3.0 which is used by RedHat 8.
 - A fact that determines the major version of auditd that is running on the system

--- a/data/common.yaml
+++ b/data/common.yaml
@@ -12,6 +12,9 @@ auditd::config::audisp::priority_boost: "%{alias('auditd::priority_boost')}"
 auditd::config::audisp::max_restarts: "%{alias('auditd::max_restarts')}"
 auditd::config::audisp::name_format: "%{alias('auditd::name_format')}"
 
+auditd::config::audisp::syslog::type: 'builtin'
+auditd::config::audisp::syslog::syslog_path: 'builtin_syslog'
+
 auditd::config::audit_profiles::simp::basic_root_audit_syscalls:
   - 'capset'
   - 'mknod'

--- a/spec/classes/config/audisp/syslog_spec.rb
+++ b/spec/classes/config/audisp/syslog_spec.rb
@@ -8,6 +8,15 @@ describe 'auditd::config::audisp::syslog' do
           'include "auditd"'
         end
 
+        #Test if auditd version is not defined that it finds defaults.
+        #This will be the case first time it is run if auditd is not installed
+        #already. 
+        context 'if auditd version is unknown' do
+          let(:facts) { os_facts.reject { |k,v| k == :auditd_major_version }}
+          it { is_expected.to compile.with_all_deps }
+        end
+
+
         context 'for all versions of auditd' do
           [{ :auditd_version => "3.0", :auditd_major_version => "3"}, { :auditd_version => "2.8.4", :auditd_major_version => "2"}].each do |  more_facts |
             let(:facts) {os_facts.merge(more_facts)}


### PR DESCRIPTION
- set defaults for auditd syslog plugin  parameters in hiera to ensure if
  the auditd version is not defined, that they are set.