### PR TITLE
(SIMP-7139) Update best practice auditd rules

### DIFF
--- a/CHANGELOG
+++ b/CHANGELOG
@@ -1,7 +1,21 @@
+* Thu Oct 31 2019 Trevor Vaughan <tvaughan@onyxpoint.com> - 8.5.0-0
+- Allow users to knockout entries from arrays specified in Hiera
+- Multiple rules added based on best practices mostly pulled from
+  /usr/share/doc/auditd:
+  - Audit 32 bit operations on 64 bit systems
+  - Audit calls to the auditd CLI commands
+  - Audit IPv4 and IPv6 inbound connections
+  - Optionally audit IPv4 and IPv6 outbound connections
+  - Audit suspicious applications
+  - Audit systemd
+  - Audit the auditd configuration space
+  - Ignore time daemon logs (clutter)
+  - Ignore CRYPTO_KEY_USER logs (clutter)
+  - Add ability to set the backlog_wait_time
+  - Set loginuid_immutable
+
 * Thu Oct 24 2019 Jeanne Greulich <jeanne.greulich@onyxpoint.com> - 8.5.0-0
 - Set defaults for syslog parameters if auditd version is unknown.
-
-* Fri Oct 11 2019 Jeanne Greulich <jeanne.greulich@onyxpoint.com> - 8.5.0-0
 - Added support for auditd v3.0 which is used by RedHat 8.
 - A fact that determines the major version of auditd that is running on the system
   was added, auditd_major_version.  This is used in hiera.yaml hierarchy to add

--- a/Gemfile
+++ b/Gemfile
@@ -13,7 +13,7 @@ group :test do
   gem 'puppet-strings'
   gem 'puppet-lint-empty_string-check',   :require => false
   gem 'puppet-lint-trailing_comma-check', :require => false
-  gem 'simp-rspec-puppet-facts', ENV.fetch('SIMP_RSPEC_PUPPET_FACTS_VERSION', '~> 2.2')
+  gem 'simp-rspec-puppet-facts', ENV.fetch('SIMP_RSPEC_PUPPET_FACTS_VERSION', ['>= 2.3.1', '< 3.0.0'] )
   gem 'simp-rake-helpers', ENV.fetch('SIMP_RAKE_HELPERS_VERSION', ['>= 5.9', '< 6.0'])
 end
 

--- a/data/common.yaml
+++ b/data/common.yaml
@@ -1,4 +1,25 @@
 ---
+lookup_options:
+  auditd::config::audit_profiles::simp::audit_auditd_cmds_list:
+    merge:
+      strategy: deep
+      knockout_prefix: --
+  auditd::config::audit_profiles::simp::basic_root_audit_syscalls:
+    merge:
+      strategy: deep
+      knockout_prefix: --
+  auditd::config::audit_profiles::simp::aggressive_root_audit_syscalls:
+    merge:
+      strategy: deep
+      knockout_prefix: --
+  auditd::config::audit_profiles::simp::insane_root_audit_syscalls:
+    merge:
+      strategy: deep
+      knockout_prefix: --
+  auditd::config::audit_profiles::simp::audit_suspicious_apps_list:
+    merge:
+      strategy: deep
+      knockout_prefix: --
 
 auditd::q_depth: 160
 auditd::overflow_action: 'SYSLOG'
@@ -79,3 +100,21 @@ auditd::config::audit_profiles::simp::insane_root_audit_syscalls:
   - 'symlinkat'
   - 'mkdir'
   - 'mkdirat'
+
+auditd::config::audit_profiles::simp::audit_suspicious_apps_list:
+  - '/usr/bin/nc'
+  - '/usr/bin/ncat'
+  - '/usr/bin/nmap'
+  - '/usr/bin/rawshark'
+  - '/usr/bin/socat'
+  - '/usr/bin/wireshark'
+  - '/usr/sbin/tcpdump'
+  - '/usr/sbin/traceroute'
+  - '/usr/sbin/traceroute6'
+
+auditd::config::audit_profiles::simp::audit_auditd_cmds_list:
+  - '/usr/sbin/aulast'
+  - '/usr/sbin/aulastlogin'
+  - '/usr/sbin/aureport'
+  - '/usr/sbin/ausearch'
+  - '/usr/sbin/auvirt'

--- a/data/os/CentOS-6.yaml
+++ b/data/os/CentOS-6.yaml
@@ -55,3 +55,10 @@ auditd::config::audit_profiles::stig::default_suid_sgid_cmds:
   - "/usr/sbin/unix_chkpwd"
   - "/usr/sbin/userhelper"
   - "/usr/sbin/usernetctl"
+
+auditd::config::audit_profiles::simp::audit_auditd_cmds_list:
+  - '/usr/sbin/aulast'
+  - '/usr/sbin/aulastlogin'
+  - '/usr/sbin/aureport'
+  - '/usr/sbin/ausearch'
+  - '/usr/sbin/auvirt'

--- a/data/os/CentOS-8.yaml
+++ b/data/os/CentOS-8.yaml
@@ -1,17 +1,41 @@
 ---
+#  Default to auditd version 3 settings
+auditd::plugin_dir: '/etc/audit/plugins.d'
+auditd::config::audisp::syslog::type: 'always'
+auditd::config::audisp::syslog::syslog_path: '/sbin/audisp-syslog'
+auditd::config::audisp::syslog::pkg_name: 'audispd-plugins'
+
 auditd::config::audit_profiles::stig::default_suid_sgid_cmds:
   - "/usr/bin/at"
+  - "/usr/bin/chage"
+  - "/usr/bin/chcon"
   - "/usr/bin/chfn"
+  - "/usr/bin/chsh"
+  - "/usr/bin/crontab"
   - "/usr/bin/fusermount"
+  - "/usr/bin/gpasswd"
   - "/usr/bin/incrontab"
   - "/usr/bin/ksu"
   - "/usr/bin/locate"
+  - "/usr/bin/mount"
+  - "/usr/bin/newgidmap"
+  - "/usr/bin/newgrp"
+  - "/usr/bin/newuidmap"
+  - "/usr/bin/passwd"
   - "/usr/bin/pkexec"
+  - "/usr/bin/screen"
   - "/usr/bin/ssh-agent"
+  - "/usr/bin/su"
+  - "/usr/bin/sudo"
+  - "/usr/bin/sudoedit"
+  - "/usr/bin/umount"
   - "/usr/bin/wall"
   - "/usr/bin/write"
   - "/usr/bin/Xorg"
   - "/usr/lib64/dbus-1/dbus-daemon-launch-helper"
+  - "/usr/libexec/dbus-1/dbus-daemon-launch-helper"
+  - "/usr/libexec/openssh/ssh-keysign"
+  - "/usr/libexec/pt_chown"
   - "/usr/libexec/sssd/krb5_child"
   - "/usr/libexec/sssd/ldap_child"
   - "/usr/libexec/sssd/proxy_child"
@@ -20,10 +44,14 @@ auditd::config::audit_profiles::stig::default_suid_sgid_cmds:
   - "/usr/lib/polkit-1/polkit-agent-helper-1"
   - "/usr/sbin/mount.nfs"
   - "/usr/sbin/netreport"
+  - "/usr/sbin/pam_timestamp_check"
+  - "/usr/sbin/postdrop"
+  - "/usr/sbin/postqueue"
+  - "/usr/sbin/restorecon"
+  - "/usr/sbin/semanage"
+  - "/usr/sbin/setfiles"
+  - "/usr/sbin/setsebool"
+  - "/usr/sbin/seunshare"
+  - "/usr/sbin/unix_chkpwd"
+  - "/usr/sbin/userhelper"
   - "/usr/sbin/usernetctl"
-
-#  Default to auditd version 3 settings
-auditd::plugin_dir: '/etc/audit/plugins.d'
-auditd::config::audisp::syslog::type: 'always'
-auditd::config::audisp::syslog::syslog_path: '/sbin/audisp-syslog'
-auditd::config::audisp::syslog::pkg_name: 'audispd-plugins'

--- a/data/os/OracleLinux-6.yaml
+++ b/data/os/OracleLinux-6.yaml
@@ -1,6 +1,6 @@
 ---
 
-# Default to version 2 settings
+# Default to auditd version 2 settings
 auditd::dispatcher: '/sbin/audispd'
 auditd::disp_qos: 'lossy'
 auditd::plugin_dir: '/etc/audisp/plugins.d'
@@ -55,3 +55,10 @@ auditd::config::audit_profiles::stig::default_suid_sgid_cmds:
   - "/usr/sbin/unix_chkpwd"
   - "/usr/sbin/userhelper"
   - "/usr/sbin/usernetctl"
+
+auditd::config::audit_profiles::simp::audit_auditd_cmds_list:
+  - '/usr/sbin/aulast'
+  - '/usr/sbin/aulastlogin'
+  - '/usr/sbin/aureport'
+  - '/usr/sbin/ausearch'
+  - '/usr/sbin/auvirt'

--- a/data/os/RedHat-6.yaml
+++ b/data/os/RedHat-6.yaml
@@ -1,4 +1,5 @@
 ---
+
 # Default to auditd version 2 settings
 auditd::dispatcher: '/sbin/audispd'
 auditd::disp_qos: 'lossy'
@@ -54,3 +55,10 @@ auditd::config::audit_profiles::stig::default_suid_sgid_cmds:
   - "/usr/sbin/unix_chkpwd"
   - "/usr/sbin/userhelper"
   - "/usr/sbin/usernetctl"
+
+auditd::config::audit_profiles::simp::audit_auditd_cmds_list:
+  - '/usr/sbin/aulast'
+  - '/usr/sbin/aulastlogin'
+  - '/usr/sbin/aureport'
+  - '/usr/sbin/ausearch'
+  - '/usr/sbin/auvirt'

--- a/data/os/RedHat-8.yaml
+++ b/data/os/RedHat-8.yaml
@@ -1,17 +1,41 @@
 ---
+#  Default to auditd version 3 settings
+auditd::plugin_dir: '/etc/audit/plugins.d'
+auditd::config::audisp::syslog::type: 'always'
+auditd::config::audisp::syslog::syslog_path: '/sbin/audisp-syslog'
+auditd::config::audisp::syslog::pkg_name: 'audispd-plugins'
+
 auditd::config::audit_profiles::stig::default_suid_sgid_cmds:
   - "/usr/bin/at"
+  - "/usr/bin/chage"
+  - "/usr/bin/chcon"
   - "/usr/bin/chfn"
+  - "/usr/bin/chsh"
+  - "/usr/bin/crontab"
   - "/usr/bin/fusermount"
+  - "/usr/bin/gpasswd"
   - "/usr/bin/incrontab"
   - "/usr/bin/ksu"
   - "/usr/bin/locate"
+  - "/usr/bin/mount"
+  - "/usr/bin/newgidmap"
+  - "/usr/bin/newgrp"
+  - "/usr/bin/newuidmap"
+  - "/usr/bin/passwd"
   - "/usr/bin/pkexec"
+  - "/usr/bin/screen"
   - "/usr/bin/ssh-agent"
+  - "/usr/bin/su"
+  - "/usr/bin/sudo"
+  - "/usr/bin/sudoedit"
+  - "/usr/bin/umount"
   - "/usr/bin/wall"
   - "/usr/bin/write"
   - "/usr/bin/Xorg"
   - "/usr/lib64/dbus-1/dbus-daemon-launch-helper"
+  - "/usr/libexec/dbus-1/dbus-daemon-launch-helper"
+  - "/usr/libexec/openssh/ssh-keysign"
+  - "/usr/libexec/pt_chown"
   - "/usr/libexec/sssd/krb5_child"
   - "/usr/libexec/sssd/ldap_child"
   - "/usr/libexec/sssd/proxy_child"
@@ -20,10 +44,14 @@ auditd::config::audit_profiles::stig::default_suid_sgid_cmds:
   - "/usr/lib/polkit-1/polkit-agent-helper-1"
   - "/usr/sbin/mount.nfs"
   - "/usr/sbin/netreport"
+  - "/usr/sbin/pam_timestamp_check"
+  - "/usr/sbin/postdrop"
+  - "/usr/sbin/postqueue"
+  - "/usr/sbin/restorecon"
+  - "/usr/sbin/semanage"
+  - "/usr/sbin/setfiles"
+  - "/usr/sbin/setsebool"
+  - "/usr/sbin/seunshare"
+  - "/usr/sbin/unix_chkpwd"
+  - "/usr/sbin/userhelper"
   - "/usr/sbin/usernetctl"
-
-#  Default to auditd version 3 settings
-auditd::plugin_dir: '/etc/audit/plugins.d'
-auditd::config::audisp::syslog::type: 'always'
-auditd::config::audisp::syslog::syslog_path: '/sbin/audisp-syslog'
-auditd::config::audisp::syslog::pkg_name: 'audispd-plugins'

--- a/manifests/config/audit_profiles.pp
+++ b/manifests/config/audit_profiles.pp
@@ -39,11 +39,21 @@ class auditd::config::audit_profiles {
 
   $_common_template_path = "${module_name}/rule_profiles/common"
 
-  auditd::rule { 'init.d_auditd':
-    content => [
-      '-w /etc/rc.d/init.d/auditd -p wa -k auditd',
-      "-w ${$auditd::log_file} -p wa -k audit-logs"
-    ]
+  if $auditd::audit_auditd_config {
+    $_audit_log_dir = dirname($auditd::log_file)
+
+    auditd::rule { 'audit_auditd_config':
+      content => [
+        '-w /etc/rc.d/init.d/auditd -p wa -k auditd',
+        "-w ${$_audit_log_dir} -p wa -k audit-logs",
+        '-w /etc/audit/ -p wa -k auditconfig',
+        '-w /etc/libaudit.conf -p wa -k auditconfig',
+        '-w /sbin/auditctl -p x -k audittools',
+        '-w /usr/sbin/auditctl -p x -k audittools',
+        '-w /sbin/auditd -p x -k audittools',
+        '-w /usr/sbin/auditd -p x -k audittools'
+      ]
+    }
   }
 
   auditd::rule { 'rotated_audit_logs':

--- a/manifests/config/audit_profiles.pp
+++ b/manifests/config/audit_profiles.pp
@@ -56,10 +56,6 @@ class auditd::config::audit_profiles {
     }
   }
 
-  auditd::rule { 'rotated_audit_logs':
-    content => epp("${_common_template_path}/rotated_audit_logs.epp", { num_logs => $auditd::num_logs, log_file => $auditd::log_file } )
-  }
-
   if ( $auditd::root_audit_level == 'aggressive' ) and ( $auditd::buffer_size < 32788 ) {
     $_buffer_size = 32788
   } elsif ( $auditd::root_audit_level == 'insane' ) and ( $auditd::buffer_size < 65576 ) {

--- a/manifests/config/audit_profiles/simp.pp
+++ b/manifests/config/audit_profiles/simp.pp
@@ -38,6 +38,22 @@
 #    - Insane: Adds syscall rules for write, creat and variants of chown,
 #      fork, link and mkdir
 #
+# @param audit_32bit_operations
+#   In general, any 32bit system calls on a 64bit systems should be seen as
+#   suspicious.
+#
+# @param audit_32bit_operations_tag
+#   Tag to be added to entries triggered by `audit_32bit_operations`
+#
+# @param audit_auditd_cmds
+#   Audit calls to the auditd management CLI commands
+#
+# @param audit_auditd_cmds_tag
+#   Tag to be added to entries triggered by `audit_auditd_cmds`
+#
+# @param audit_auditd_cmds_list
+#   Commands to be audited if enabled by `audit_auditd_cmds`
+#
 # @param basic_root_audit_syscalls
 #   Basic syscalls to audit for su-root activity
 #
@@ -128,6 +144,30 @@
 #
 # @param audit_locale_tag
 #   The tag to identify system locale operations in an audit record
+#
+# @param audit_network_ipv4_accept
+#   Audit **incoming** IPv4 connections
+#
+# @param audit_network_ipv4_accept_tag
+#   Tag to be added to entries triggered by `audit_network_ipv4_accept`
+#
+# @param audit_network_ipv6_accept
+#   Audit **incoming** IPv6 connections
+#
+# @param audit_network_ipv6_accept_tag
+#   Tag to be added to entries triggered by `audit_network_ipv6_accept`
+#
+# @param audit_network_ipv4_connect
+#   Audit **outgoing** IPv4 connections
+#
+# @param audit_network_ipv4_connect_tag
+#   Tag to be added to entries triggered by `audit_network_ipv4_connect`
+#
+# @param audit_network_ipv6_connect
+#   Audit **outgoing** IPv6 connections
+#
+# @param audit_network_ipv6_connect_tag
+#   Tag to be added to entries triggered by `audit_network_ipv6_connect`
 #
 # @param audit_mount
 #   Whether to audit mount operations
@@ -224,10 +264,10 @@
 #   audit record
 #
 # @param audit_cfg_pam
-#   Whether to audit changes to pam configuration files
+#   Whether to audit changes to PAM configuration files
 #
 # @param audit_cfg_pam_tag
-#   The tag to identify pam configuration file changes in an audit record
+#   The tag to identify PAM configuration file changes in an audit record
 #
 # @param audit_cfg_security
 #   Whether to audit changes to `/etc/security`
@@ -310,6 +350,23 @@
 # @param audit_ssh_keysign_cmd_tag
 #   The tag to identify `ssh-keysign` command execution in an audit record
 #
+# @param audit_suspicious_apps
+#   Audit various applications that generally represent suspicious host activity
+#
+# @param audit_suspicious_apps_tag
+#   Tag to be added to entries triggered by `audit_suspicious_apps`
+#
+# @param audit_suspicious_apps_list
+#   List of applications to be audited when `audit_suspicious_apps` is enabled
+#
+# @param audit_systemd
+#   Audit systemd components
+#
+#   * Only takes effect on systems with systemd present
+#
+# @param audit_systemd_tag
+#   Tag to be added to entries triggered by `audit_systemd`
+#
 # @param audit_crontab_cmd
 #   Whether to audit the execution of the `crontab` command
 #
@@ -324,90 +381,108 @@
 #   record
 #
 class auditd::config::audit_profiles::simp (
-  Auditd::RootAuditLevel $root_audit_level                       = $::auditd::root_audit_level,
-  Boolean                $audit_unsuccessful_file_operations     = true,
-  String[1]              $audit_unsuccessful_file_operations_tag = 'access',
-  Boolean                $audit_chown                            = true,
-  String[1]              $audit_chown_tag                        = 'chown',
-  Boolean                $audit_chmod                            = false,
-  String[1]              $audit_chmod_tag                        = 'chmod',
-  Boolean                $audit_attr                             = true,
-  String[1]              $audit_attr_tag                         = 'attr',
-  Boolean                $audit_rename_remove                    = false,
-  String[1]              $audit_rename_remove_tag                = 'delete',
-  Boolean                $audit_su_root_activity                 = true,
-  String[1]              $audit_su_root_activity_tag             = 'su-root-activity',
-  Boolean                $audit_suid_sgid                        = true,
-  String[1]              $audit_suid_sgid_tag                    = 'suid-root-exec',
-  Boolean                $audit_kernel_modules                   = true,
-  String[1]              $audit_kernel_modules_tag               = 'modules',
-  Boolean                $audit_time                             = true,
-  String[1]              $audit_time_tag                         = 'audit_time_rules',
-  Boolean                $audit_locale                           = true,
-  String[1]              $audit_locale_tag                       = 'audit_network_modifications',
-  Boolean                $audit_mount                            = true,
-  String[1]              $audit_mount_tag                        = 'mount',
-  Boolean                $audit_umask                            = false,
-  String[1]              $audit_umask_tag                        = 'umask',
-  Boolean                $audit_local_account                    = true,
-  String[1]              $audit_local_account_tag                = 'audit_account_changes',
-  Boolean                $audit_selinux_policy                   = true,
-  String[1]              $audit_selinux_policy_tag               = 'MAC-policy',
-  Boolean                $audit_selinux_cmds                     = false,
-  String[1]              $audit_selinux_cmds_tag                 = 'privileged-priv_change',
-  Boolean                $audit_login_files                      = true,
-  String[1]              $audit_login_files_tag                  = 'logins',
-  Boolean                $audit_session_files                    = true,
-  String[1]              $audit_session_files_tag                = 'session',
-  Optional[Boolean]      $audit_sudoers                          = undef,
-  Optional[String[1]]    $audit_sudoers_tag                      = undef,
-  Boolean                $audit_cfg_sudoers                      = true,
-  String[1]              $audit_cfg_sudoers_tag                  = 'CFG_sys',
-  Optional[Boolean]      $audit_grub                             = undef,
-  Optional[String[1]]    $audit_grub_tag                         = undef,
-  Boolean                $audit_cfg_grub                         = true,
-  String[1]              $audit_cfg_grub_tag                     = 'CFG_grub',
-  Boolean                $audit_cfg_sys                          = true,
-  String[1]              $audit_cfg_sys_tag                      = 'CFG_sys',
-  Boolean                $audit_cfg_cron                         = true,
-  String[1]              $audit_cfg_cron_tag                     = 'CFG_cron',
-  Boolean                $audit_cfg_shell                        = true,
-  String[1]              $audit_cfg_shell_tag                    = 'CFG_shell',
-  Boolean                $audit_cfg_pam                          = true,
-  String[1]              $audit_cfg_pam_tag                      = 'CFG_pam',
-  Boolean                $audit_cfg_security                     = true,
-  String[1]              $audit_cfg_security_tag                 = 'CFG_security',
-  Boolean                $audit_cfg_services                     = true,
-  String[1]              $audit_cfg_services_tag                 = 'CFG_services',
-  Boolean                $audit_cfg_xinetd                       = true,
-  String[1]              $audit_cfg_xinetd_tag                   = 'CFG_xinetd',
-  Optional[Boolean]      $audit_yum                              = undef,
-  Optional[String[1]]    $audit_yum_tag                          = undef,
-  Boolean                $audit_cfg_yum                          = true,
-  String[1]              $audit_cfg_yum_tag                      = 'yum-config',
-  Boolean                $audit_yum_cmd                          = false,
-  String[1]              $audit_yum_cmd_tag                      = 'package_changes',
-  Boolean                $audit_rpm_cmd                          = false,
-  String[1]              $audit_rpm_cmd_tag                      = 'package_changes',
-  Boolean                $audit_ptrace                           = true,
-  String[1]              $audit_ptrace_tag                       = 'paranoid',
-  Boolean                $audit_personality                      = true,
-  String[1]              $audit_personality_tag                  = 'paranoid',
-  Boolean                $audit_passwd_cmds                      = true,
-  String[1]              $audit_passwd_cmds_tag                  = 'privileged-passwd',
-  Boolean                $audit_priv_cmds                        = true,
-  String[1]              $audit_priv_cmds_tag                    = 'privileged-priv_change',
-  Boolean                $audit_postfix_cmds                     = true,
-  String[1]              $audit_postfix_cmds_tag                 = 'privileged-postfix',
-  Boolean                $audit_ssh_keysign_cmd                  = true,
-  String[1]              $audit_ssh_keysign_cmd_tag              = 'privileged-ssh',
-  Boolean                $audit_crontab_cmd                      = true,
-  String[1]              $audit_crontab_cmd_tag                  = 'privileged-cron',
-  Boolean                $audit_pam_timestamp_check_cmd          = true,
-  String[1]              $audit_pam_timestamp_check_cmd_tag      = 'privileged-pam',
-  Array[String[1]]       $basic_root_audit_syscalls,             # data in modules
-  Array[String[1]]       $aggressive_root_audit_syscalls,        # data in modules
-  Array[String[1]]       $insane_root_audit_syscalls             # data in modules
+  Auditd::RootAuditLevel      $root_audit_level                                         = $::auditd::root_audit_level,
+  Boolean                     $audit_32bit_operations                                   = $facts['hardwaremodel'] ? { 'x86_64' => true, default => false },
+  String[1]                   $audit_32bit_operations_tag                               = '32bit-api',
+  Boolean                     $audit_auditd_cmds                                        = true,
+  String[1]                   $audit_auditd_cmds_tag                                    = 'access-audit-trail',
+  Array[String[1]]            $audit_auditd_cmds_list,                                  # data in modules
+  Boolean                     $audit_unsuccessful_file_operations                       = true,
+  String[1]                   $audit_unsuccessful_file_operations_tag                   = 'access',
+  Boolean                     $audit_chown                                              = true,
+  String[1]                   $audit_chown_tag                                          = 'chown',
+  Boolean                     $audit_chmod                                              = false,
+  String[1]                   $audit_chmod_tag                                          = 'chmod',
+  Boolean                     $audit_attr                                               = true,
+  String[1]                   $audit_attr_tag                                           = 'attr',
+  Boolean                     $audit_rename_remove                                      = false,
+  String[1]                   $audit_rename_remove_tag                                  = 'delete',
+  Boolean                     $audit_su_root_activity                                   = true,
+  String[1]                   $audit_su_root_activity_tag                               = 'su-root-activity',
+  Boolean                     $audit_suid_sgid                                          = true,
+  String[1]                   $audit_suid_sgid_tag                                      = 'suid-root-exec',
+  Boolean                     $audit_kernel_modules                                     = true,
+  String[1]                   $audit_kernel_modules_tag                                 = 'modules',
+  Boolean                     $audit_time                                               = true,
+  String[1]                   $audit_time_tag                                           = 'audit_time_rules',
+  Boolean                     $audit_locale                                             = true,
+  String[1]                   $audit_locale_tag                                         = 'audit_network_modifications',
+  Boolean                     $audit_network_ipv4_accept                                = true,
+  String[1]                   $audit_network_ipv4_accept_tag                            = 'ipv4_in',
+  Boolean                     $audit_network_ipv6_accept                                = true,
+  String[1]                   $audit_network_ipv6_accept_tag                            = 'ipv6_in',
+  Boolean                     $audit_network_ipv4_connect                               = false,
+  String[1]                   $audit_network_ipv4_connect_tag                           = 'ipv4_in',
+  Boolean                     $audit_network_ipv6_connect                               = false,
+  String[1]                   $audit_network_ipv6_connect_tag                           = 'ipv6_in',
+  Boolean                     $audit_mount                                              = true,
+  String[1]                   $audit_mount_tag                                          = 'mount',
+  Boolean                     $audit_umask                                              = false,
+  String[1]                   $audit_umask_tag                                          = 'umask',
+  Boolean                     $audit_local_account                                      = true,
+  String[1]                   $audit_local_account_tag                                  = 'audit_account_changes',
+  Boolean                     $audit_selinux_policy                                     = true,
+  String[1]                   $audit_selinux_policy_tag                                 = 'MAC-policy',
+  Boolean                     $audit_selinux_cmds                                       = false,
+  String[1]                   $audit_selinux_cmds_tag                                   = 'privileged-priv_change',
+  Boolean                     $audit_login_files                                        = true,
+  String[1]                   $audit_login_files_tag                                    = 'logins',
+  Boolean                     $audit_session_files                                      = true,
+  String[1]                   $audit_session_files_tag                                  = 'session',
+  Optional[Boolean]           $audit_sudoers                                            = undef,
+  Optional[String[1]]         $audit_sudoers_tag                                        = undef,
+  Boolean                     $audit_cfg_sudoers                                        = true,
+  String[1]                   $audit_cfg_sudoers_tag                                    = 'CFG_sys',
+  Optional[Boolean]           $audit_grub                                               = undef,
+  Optional[String[1]]         $audit_grub_tag                                           = undef,
+  Boolean                     $audit_cfg_grub                                           = true,
+  String[1]                   $audit_cfg_grub_tag                                       = 'CFG_grub',
+  Boolean                     $audit_cfg_sys                                            = true,
+  String[1]                   $audit_cfg_sys_tag                                        = 'CFG_sys',
+  Boolean                     $audit_cfg_cron                                           = true,
+  String[1]                   $audit_cfg_cron_tag                                       = 'CFG_cron',
+  Boolean                     $audit_cfg_shell                                          = true,
+  String[1]                   $audit_cfg_shell_tag                                      = 'CFG_shell',
+  Boolean                     $audit_cfg_pam                                            = true,
+  String[1]                   $audit_cfg_pam_tag                                        = 'CFG_pam',
+  Boolean                     $audit_cfg_security                                       = true,
+  String[1]                   $audit_cfg_security_tag                                   = 'CFG_security',
+  Boolean                     $audit_cfg_services                                       = true,
+  String[1]                   $audit_cfg_services_tag                                   = 'CFG_services',
+  Boolean                     $audit_cfg_xinetd                                         = true,
+  String[1]                   $audit_cfg_xinetd_tag                                     = 'CFG_xinetd',
+  Optional[Boolean]           $audit_yum                                                = undef,
+  Optional[String[1]]         $audit_yum_tag                                            = undef,
+  Boolean                     $audit_cfg_yum                                            = true,
+  String[1]                   $audit_cfg_yum_tag                                        = 'yum-config',
+  Boolean                     $audit_yum_cmd                                            = false,
+  String[1]                   $audit_yum_cmd_tag                                        = 'package_changes',
+  Boolean                     $audit_rpm_cmd                                            = false,
+  String[1]                   $audit_rpm_cmd_tag                                        = 'package_changes',
+  Boolean                     $audit_ptrace                                             = true,
+  String[1]                   $audit_ptrace_tag                                         = 'paranoid',
+  Boolean                     $audit_personality                                        = true,
+  String[1]                   $audit_personality_tag                                    = 'paranoid',
+  Boolean                     $audit_passwd_cmds                                        = true,
+  String[1]                   $audit_passwd_cmds_tag                                    = 'privileged-passwd',
+  Boolean                     $audit_priv_cmds                                          = true,
+  String[1]                   $audit_priv_cmds_tag                                      = 'privileged-priv_change',
+  Boolean                     $audit_postfix_cmds                                       = true,
+  String[1]                   $audit_postfix_cmds_tag                                   = 'privileged-postfix',
+  Boolean                     $audit_ssh_keysign_cmd                                    = true,
+  String[1]                   $audit_ssh_keysign_cmd_tag                                = 'privileged-ssh',
+  Boolean                     $audit_suspicious_apps                                    = true,
+  String[1]                   $audit_suspicious_apps_tag                                = 'suspicious_apps',
+  Array[Stdlib::Absolutepath] $audit_suspicious_apps_list,                              # data in modules
+  Boolean                     $audit_systemd                                            = true,
+  String[1]                   $audit_systemd_tag                                        = 'systemd',
+  Boolean                     $audit_crontab_cmd                                        = true,
+  String[1]                   $audit_crontab_cmd_tag                                    = 'privileged-cron',
+  Boolean                     $audit_pam_timestamp_check_cmd                            = true,
+  String[1]                   $audit_pam_timestamp_check_cmd_tag                        = 'privileged-pam',
+  Array[String[1]]            $basic_root_audit_syscalls,                               # data in modules
+  Array[String[1]]            $aggressive_root_audit_syscalls,                          # data in modules
+  Array[String[1]]            $insane_root_audit_syscalls                               # data in modules
 ) {
   assert_private()
 

--- a/manifests/init.pp
+++ b/manifests/init.pp
@@ -6,51 +6,8 @@
 # @see auditd.conf(5)
 # @see auditctl(8)
 #
-# @param lname
-#   An alias for the ``name`` variable in the configuration file. This is used
-#   since ``$name`` is a reserved keyword in Puppet.
-#
-# @param immutable
-#   Whether or not to make the configuration immutable when using built-in
-#   audit profiles.  Be aware that, should you choose to make the
-#   configuration immutable, you will not be able to change your audit
-#   rules without a reboot.
-#
-# @param root_audit_level
-#   What level of auditing should be used for su-root activity in built-in
-#   audit profiles that provide su-root rules. Be aware that setting this to
-#   anything besides 'basic' may overwhelm your system and/or log server.
-#   Options can be, 'basic', 'aggressive', 'insane'.  For the 'simp' audit
-#   profile, these options are as follows:
-#    - Basic: Safe syscall rules, should not follow program execution outside
-#      of the base app
-#    - Aggressive: Adds syscall rules for execve, rmdir and variants of rename
-#      and unlink
-#    - Insane: Adds syscall rules for write, creat and variants of chown,
-#      fork, link and mkdir
-#
-# @param uid_min
-#   The minimum UID for human users on the system. For built-in audit profiles
-#   when `$ignore_system_services` is true, any audit events generated
-#   by users below this number will be ignored, unless a corresponding rule
-#   is inserted *before* the UID-limiting rule in the rules list.  When using
-#   `auditd::rule`, you can create such a rule by setting the `absolute`
-#   parameter to be 'first'.
-#
-# @param at_boot
-#   If true, modify the Grub settings to enable auditing at boot time.
-#   Meets CCE-26785-6
-#
-# @param syslog
-#   If true, manage the settings for the syslog plugin
-#   It was left defaulted to  simp_options::syslog value for backwards
-#   compatability.
-#   This does not  activate/deactivate the plugin.  That setting is
-#   in the auditd::config::audisp::syslog::enable setting.  If syslog
-#   is set to true, by default it will enable the syslog plugin in order
-#   to be backwards compatable.  If you want to ensure the plugin is disabled,
-#   set auditd::config::audisp::syslog::enable to false.
-#   If this is set to false the plugin settings are not managed by puppet.
+# @param enable
+#   If true, enable auditing.
 #
 # @param default_audit_profile
 #   Deprecated by `$default_audit_profiles`
@@ -66,70 +23,34 @@
 #   - @see `auditd::config::audit_profiles` for more details about this
 #     configuration.
 #
-# @param service_name
-#   The name of the auditd service.
+# @param audit_auditd_config
+#   Set up an audit rule to audit the `auditd` configuration files.
 #
-# @param package_name
-#   The name of the auditd package.
+# @param lname
+#   An alias for the ``name`` variable in the configuration file. This is used
+#   since ``$name`` is a reserved keyword in Puppet.
 #
-# @param package_ensure
+# @param ignore_anonymous
+#   For built-in audit profiles, whether to drop anonymous and daemon
+#   events, i.e., events for which ``auid`` is '-1' (aka '4294967295').
+#   Audit records from these events are prolific but not useful.
 #
-# @param enable
-#   If true, enable auditing.
+# @param ignore_crond
+#   For built-in audit profiles, whether to drop events related to cron
+#   jobs. `cron` creates a lot of audit events that are not usually useful.
 #
-# @param log_file
-# @param log_format
-#   The output log format
+# @param ignore_time_daemons
+#   Ignore time modifications by time daemons that are running on the system
+#   since this is valid activity.
 #
-#   * 'NOLOG' is deprecated as of auditd 2.5.2
-#   * 'ENRICHED' is only available in auditd >= 2.6.0
-#
-# @param log_group
-# @param priority_boost
-# @param flush
-# @param freq
-# @param num_logs
-# @param disp_qos   auditd version 2 only
-# @param dispatcher   auditd version 2 only
-# @param local_events   auditd version 3 only
-# @param name_format
-# @param max_log_file
-# @param max_log_file_action
-# @param space_left
-# @param space_left_action
-# @param verify_email auditd version 3 only
-# @param action_mail_acct
-# @param admin_space_left
-# @param admin_space_left_action
-# @param disk_full_action
-# @param disk_error_action
-#
-# @param write_logs
-#   Whether or not to write logs to disk.
-#
-#   * The `NOLOG` option on `log_format` has been deprecated in newer versions
-#     of `auditd` so this attempts to do "the right thing" when `log_format` is
-#     set to `NOLOG` for legacy support.
+# @param ignore_crypto_key_user
+#   Ignore CRYPTO_KEY_USER logs since these are generally noise.
 #
 # @param ignore_errors
 #   Whether to set the `auditctl` '-i' option
 #
 # @param ignore_failures
 #   Whether to set the `auditctl` '-c' option
-#
-# @param buffer_size
-#   Value of the `auditctl` '-b' option
-#
-# @param failure_mode
-#   Value of the `auditctl` '-f' option
-#
-# @param rate
-#   Value of the `auditctl` '-r' option
-#
-# @param ignore_anonymous
-#   For built-in audit profiles, whether to drop anonymous and daemon
-#   events, i.e., events for which ``auid`` is '-1' (aka '4294967295').
-#   Audit records from these events are prolific but not useful.
 #
 # @param ignore_system_services
 #   For built-in audit profiles, whether to ignore system service events,
@@ -139,9 +60,114 @@
 #   the filter in an upfront drop rule, this feature provides optimization
 #   of that filtering.
 #
-# @param ignore_crond
-#   For built-in audit profiles, whether to drop events related to cron
-#   jobs. `cron` creates a lot of audit events that are not usually useful.
+# @param action_mail_acct
+# @param admin_space_left
+# @param admin_space_left_action
+#
+# @param at_boot
+#   If true, modify the Grub settings to enable auditing at boot time.
+#
+# @param buffer_size
+#   Value of the `auditctl` '-b' option
+#
+# @param backlog_wait_time
+#
+# @param disk_error_action
+# @param disk_full_action
+# @param disp_qos
+#   `auditd` version 2 only
+# @param dispatcher
+#   `auditd` version 2 only
+#
+# @param failure_mode
+#   Value of the `auditctl` '-f' option
+#
+# @param flush
+# @param freq
+#
+# @param immutable
+#   Whether or not to make the configuration immutable when using built-in
+#   audit profiles.  Be aware that, should you choose to make the
+#   configuration immutable, you will not be able to change your audit
+#   rules without a reboot.
+#
+# @param log_file
+#
+# @param local_events
+#   `auditd` version 3 only
+#
+# @param log_format
+#   The output log format
+#
+#   * 'NOLOG' is deprecated as of auditd 2.5.2
+#   * 'ENRICHED' is only available in auditd >= 2.6.0
+#
+# @param log_group
+#
+# @param loginuid_immutable
+#   Sets the --loginuid-immutable option
+#
+#   * This has been noted to potentially cause issues with some types of
+#     containers but a concrete explanation of what types has not yet been
+#     found.
+#
+# @param max_log_file
+# @param max_log_file_action
+#
+# @param max_restarts
+#  sets the number of times a plugin will be restart.
+#
+# @param name_format
+# @param num_logs
+#
+# @param  overflow_action
+#  sets the overflow action.
+#
+# @param package_name
+#   The name of the auditd package.
+#
+# @param package_ensure
+#
+# @param plugin_dir
+#  sets the directory for the plugin configuration files.
+#
+# @param priority_boost
+#
+# @param q_depth
+#  how big to make the internal queue of the audit event dispatcher
+#
+# @param rate
+#   Value of the `auditctl` '-r' option
+#
+# @param root_audit_level
+#   What level of auditing should be used for su-root activity in built-in
+#   audit profiles that provide su-root rules. Be aware that setting this to
+#   anything besides 'basic' may overwhelm your system and/or log server.
+#   Options can be, 'basic', 'aggressive', 'insane'.  For the 'simp' audit
+#   profile, these options are as follows:
+#    - Basic: Safe syscall rules, should not follow program execution outside
+#      of the base app
+#    - Aggressive: Adds syscall rules for execve, rmdir and variants of rename
+#      and unlink
+#    - Insane: Adds syscall rules for write, creat and variants of chown,
+#      fork, link and mkdir
+#
+# @param service_name
+#   The name of the auditd service.
+#
+# @param space_left
+# @param space_left_action
+#
+# @param syslog
+#   If true, manage the settings for the syslog plugin
+#   It was left defaulted to  simp_options::syslog value for backwards
+#   compatability.
+#   This does not  activate/deactivate the plugin.  That setting is
+#   in the auditd::config::audisp::syslog::enable setting.  If syslog
+#   is set to true, by default it will enable the syslog plugin in order
+#   to be backwards compatable.  If you want to ensure the plugin is disabled,
+#   set auditd::config::audisp::syslog::enable to false.
+#   If this is set to false the plugin settings are not managed by puppet.
 #
 # @param target_selinux_types
 #   A list of SELinux types to target, all others will be dropped
@@ -150,48 +176,62 @@
 #   namespace, you may find that only auditing unconfined types will be
 #   sufficient since all other invalid system actions are already audited.
 #
-# @param q_depth
-#  how big to make the internal queue of the audit event dispatcher
+# @param uid_min
+#   The minimum UID for human users on the system. For built-in audit profiles
+#   when `$ignore_system_services` is true, any audit events generated
+#   by users below this number will be ignored, unless a corresponding rule
+#   is inserted *before* the UID-limiting rule in the rules list.  When using
+#   `auditd::rule`, you can create such a rule by setting the `absolute`
+#   parameter to be 'first'.
 #
-# @param  overflow_action
-#  sets the overflow action.
+# @param verify_email auditd version 3 only
 #
-# @param max_restarts
-#  sets the number of times a plugin will be restart.
+# @param write_logs
+#   Whether or not to write logs to disk.
 #
-# @param plugin_dir
-#  sets the directory for the plugin configuration files.
-#
+#   * The `NOLOG` option on `log_format` has been deprecated in newer versions
+#     of `auditd` so this attempts to do "the right thing" when `log_format` is
+#     set to `NOLOG` for legacy support.
 #
 # @author https://github.com/simp/pupmod-simp-auditd/graphs/contributors
 #
 class auditd (
+  # Control Parameters
   Boolean                                 $enable                  = true,
+  Optional[Variant[Enum['simp'],Boolean]] $default_audit_profile   = undef,
+  Array[Auditd::AuditProfile]             $default_audit_profiles  = [ 'simp' ],
+  Boolean                                 $audit_auditd_config     = true,
+  String                                  $lname                   = $facts['fqdn'],
+
+  # Rule Tweaks
+  Boolean                                 $ignore_anonymous        = true,
+  Boolean                                 $ignore_crond            = true,
+  Boolean                                 $ignore_time_daemons     = true,
+  Boolean                                 $ignore_crypto_key_user  = true,
+  Boolean                                 $ignore_errors           = true,
+  Boolean                                 $ignore_failures         = true,
+  Boolean                                 $ignore_system_services  = true,
+
+  # Configuration Parameters
   String[1]                               $action_mail_acct        = 'root', # CCE-27241-9
   Integer[0]                              $admin_space_left        = 50,
   Auditd::SpaceLeftAction                 $admin_space_left_action = 'SUSPEND', # CCE-27239-3 : No guarantee of e-mail server so sending to syslog.
   Boolean                                 $at_boot                 = true, # CCE-26785-6
   Integer[0]                              $buffer_size             = 16384,
-  Optional[Variant[Enum['simp'],Boolean]] $default_audit_profile   = undef,
-  Array[Auditd::AuditProfile]             $default_audit_profiles  = [ 'simp' ],
-  Auditd::DiskFullAction                  $disk_full_action        = 'SUSPEND',
+  Integer[1,600000]                       $backlog_wait_time       = 60000,
   Auditd::DiskErrorAction                 $disk_error_action       = 'SUSPEND',
+  Auditd::DiskFullAction                  $disk_full_action        = 'SUSPEND',
   Enum['lossy','lossless']                $disp_qos                = 'lossy',
   Stdlib::Absolutepath                    $dispatcher              = '/sbin/audispd',
   Integer[0]                              $failure_mode            = 1,
   Auditd::Flush                           $flush                   = 'INCREMENTAL',
   Integer[0]                              $freq                    = 20,
-  Boolean                                 $ignore_anonymous        = true,
-  Boolean                                 $ignore_crond            = true,
-  Boolean                                 $ignore_errors           = true,
-  Boolean                                 $ignore_failures         = true,
-  Boolean                                 $ignore_system_services  = true,
   Boolean                                 $immutable               = false,
   Optional[Boolean]                       $local_events            = undef,
   Stdlib::Absolutepath                    $log_file                = '/var/log/audit/audit.log',
   Enum['RAW','ENRICHED','NOLOG']          $log_format              = 'RAW',
   String                                  $log_group               = 'root',
-  String                                  $lname                   = $facts['fqdn'],
+  Boolean                                 $loginuid_immutable      = true,
   Integer[0]                              $max_log_file            = 24, # CCE-27550-3
   Auditd::MaxLogFileAction                $max_log_file_action     = 'ROTATE', # CCE-27237-7
   Optional[Integer[1]]                    $max_restarts            = undef,           #data            = 10, #auditd version 3.0 and later
@@ -212,7 +252,7 @@ class auditd (
   Optional[Array[Pattern['^.*_t$']]]      $target_selinux_types    = undef,
   Integer[0]                              $uid_min                 = Integer(pick(fact('uid_min'), 1000)),
   Optional[Boolean]                       $verify_email            = undef,
-  Boolean                                 $write_logs              = $log_format ? { 'NOLOG' => false, default => true },
+  Boolean                                 $write_logs              = $log_format ? { 'NOLOG' => false, default => true }
 ) {
 
   if $enable {

--- a/metadata.json
+++ b/metadata.json
@@ -34,17 +34,17 @@
     {
       "operatingsystem": "CentOS",
       "operatingsystemrelease": [
-        "6",
+        "8",
         "7",
-        "8"
+        "6"
       ]
     },
     {
       "operatingsystem": "RedHat",
       "operatingsystemrelease": [
-        "6",
+        "8",
         "7",
-        "8"
+        "6"
       ]
     },
     {

--- a/spec/acceptance/suites/default/00_base_spec.rb
+++ b/spec/acceptance/suites/default/00_base_spec.rb
@@ -137,7 +137,7 @@ describe 'auditd class with simp audit profile' do
           # spot check that audit.rules has been generated with SIMP rules
           on(host, %q(grep -qe '^-c$' /etc/audit/audit.rules))
           on(host, %q(grep -qe '\-a exit,never \-F auid=-1' /etc/audit/audit.rules))
-          on(host, %q(grep -qe '\-a always,exit \-F perm=a \-F exit=-EACCES \-k access' /etc/audit/audit.rules))
+          on(host, %q(grep -qe '\-a exit,always \-F perm=a \-F exit=-EACCES \-k access' /etc/audit/audit.rules))
           on(host, %q(grep -qe '\-w /var/log/audit/audit.log -p wa \-k audit-logs' /etc/audit/audit.rules))
           on(host, %q(grep -qe '\-w /var/log/audit/audit.log.5 \-p rwa \-k audit-logs' /etc/audit/audit.rules))
           # spot check that loaded audit rules contain SIMP rules
@@ -147,7 +147,7 @@ describe 'auditd class with simp audit profile' do
           #   - '-k keyname' arguments are expanded to '-F key=keyname' for '-a' rules
           result = on(host, "auditctl -l")
           expect(result.output).to include('-a never,exit -S all -F auid=-1')
-          expect(result.output).to include('-a always,exit -S all -F perm=a -F exit=-EACCES -F key=access')
+          expect(result.output).to include('-a exit,always -S all -F perm=a -F exit=-EACCES -F key=access')
           expect(result.output).to include('-w /var/log/audit/audit.log -p wa -k audit-logs')
           expect(result.output).to include('-w /var/log/audit/audit.log.5 -p rwa -k audit-logs')
         end

--- a/spec/acceptance/suites/default/00_base_spec.rb
+++ b/spec/acceptance/suites/default/00_base_spec.rb
@@ -78,13 +78,14 @@ describe 'auditd class with simp audit profile' do
           result = on(host, 'augenrules --load', :accept_all_exit_codes => true)
           rule_errors = result.stderr.split("\n").delete_if { |line| !line.include?('error in line') }
           rule_errors.map! { |line| line=line.match(%r{error in line (.+) of /etc/audit/audit.rules})[1] }
+          file_not_found_errors = result.stderr.split("\n").delete_if { |line| !line.include?('(No such file or directory)')}
           rule_errors.uniq!
 
           # We expect one rule to be rejected: the watch for
           # /etc/snmp/snmpd.conf changes.  This rule should be rejected
           # because the watched file's parent directory does not exist.
           # (net-snmp package is not installed.)
-          expect(rule_errors.size).to eq 1
+          expect(rule_errors.size).to eq file_not_found_errors.size
           result = on(host, "sed -n #{rule_errors[0]}p /etc/audit/audit.rules")
           expect(result.stdout).to match(%r{/etc/snmp/snmpd.conf})
 
@@ -147,7 +148,8 @@ describe 'auditd class with simp audit profile' do
           result = on(host, "auditctl -l")
           expect(result.output).to include('-a never,exit -S all -F auid=-1')
           expect(result.output).to include('-a always,exit -S all -F perm=a -F exit=-EACCES -F key=access')
-          expect(result.output).to include('-w /var/log/audit -p wa -k audit-logs')
+          # On El6 it adds / to the end of directories but not on later versions.
+          expect(result.output).to match(/-w \/var\/log\/audit[\/]* \-p wa \-k audit\-logs/)
         end
 
         it 'should send audit logs to syslog' do

--- a/spec/acceptance/suites/default/00_base_spec.rb
+++ b/spec/acceptance/suites/default/00_base_spec.rb
@@ -136,10 +136,9 @@ describe 'auditd class with simp audit profile' do
         it 'should have audit.rules has been generated with SIMP rules' do
           # spot check that audit.rules has been generated with SIMP rules
           on(host, %q(grep -qe '^-c$' /etc/audit/audit.rules))
-          on(host, %q(grep -qe '\-a exit,never \-F auid=-1' /etc/audit/audit.rules))
+          on(host, %q(grep -qe '\-a never,exit \-F auid=-1' /etc/audit/audit.rules))
           on(host, %q(grep -qe '\-a exit,always \-F perm=a \-F exit=-EACCES \-k access' /etc/audit/audit.rules))
-          on(host, %q(grep -qe '\-w /var/log/audit/audit.log -p wa \-k audit-logs' /etc/audit/audit.rules))
-          on(host, %q(grep -qe '\-w /var/log/audit/audit.log.5 \-p rwa \-k audit-logs' /etc/audit/audit.rules))
+          on(host, %q(grep -qe '\-w /var/log/audit -p wa \-k audit-logs' /etc/audit/audit.rules))
           # spot check that loaded audit rules contain SIMP rules
           # NOTE:  Loaded rules are normalized as follows:
           #   - Implicit '-S all' is included in '-a' rules without a '-S' option
@@ -147,9 +146,8 @@ describe 'auditd class with simp audit profile' do
           #   - '-k keyname' arguments are expanded to '-F key=keyname' for '-a' rules
           result = on(host, "auditctl -l")
           expect(result.output).to include('-a never,exit -S all -F auid=-1')
-          expect(result.output).to include('-a exit,always -S all -F perm=a -F exit=-EACCES -F key=access')
-          expect(result.output).to include('-w /var/log/audit/audit.log -p wa -k audit-logs')
-          expect(result.output).to include('-w /var/log/audit/audit.log.5 -p rwa -k audit-logs')
+          expect(result.output).to include('-a always,exit -S all -F perm=a -F exit=-EACCES -F key=access')
+          expect(result.output).to include('-w /var/log/audit -p wa -k audit-logs')
         end
 
         it 'should send audit logs to syslog' do

--- a/spec/classes/config/audit_profiles/expected/simp_el6_aggressive_rules.txt
+++ b/spec/classes/config/audit_profiles/expected/simp_el6_aggressive_rules.txt
@@ -1,92 +1,92 @@
 #### auditd::config::audit_profiles::simp Audit Rules ####
 # 64-bit systems should generally never call the 32-bit API. 32-bit syscalls
 # may be a sign of someone exploiting a hole in the API.
--a always,exit -F arch=b32 -S all -F key=32bit-api
--a always,exit -F arch=b64 -S accept -F a0=2 -F key=ipv4_in
--a always,exit -F arch=b32 -S accept -F a0=2 -F key=ipv4_in
--a always,exit -F arch=b64 -S accept -F a0=10 -F key=ipv6_in
--a always,exit -F arch=b32 -S accept -F a0=10 -F key=ipv6_in
+-a exit,always -F arch=b32 -S all -F key=32bit-api
+-a exit,always -F arch=b64 -S accept -F a0=2 -F key=ipv4_in
+-a exit,always -F arch=b32 -S accept -F a0=2 -F key=ipv4_in
+-a exit,always -F arch=b64 -S accept -F a0=10 -F key=ipv6_in
+-a exit,always -F arch=b32 -S accept -F a0=10 -F key=ipv6_in
 
 ## Audit unsuccessful file operations
--a always,exit -F arch=b64 -S creat,mkdir,mknod,link,symlink,mkdirat,mknodat,linkat,symlinkat,openat,open_by_handle_at,open,close,rename,renameat,truncate,ftruncate,rmdir,unlink,unlinkat -F exit=-EACCES -k access
--a always,exit -F arch=b64 -S creat,mkdir,mknod,link,symlink,mkdirat,mknodat,linkat,symlinkat,openat,open_by_handle_at,open,close,rename,renameat,truncate,ftruncate,rmdir,unlink,unlinkat -F exit=-EPERM -k access
--a always,exit -F arch=b32 -S creat,mkdir,mknod,link,symlink,mkdirat,mknodat,linkat,symlinkat,openat,open_by_handle_at,open,close,rename,renameat,truncate,ftruncate,rmdir,unlink,unlinkat -F exit=-EACCES -k access
--a always,exit -F arch=b32 -S creat,mkdir,mknod,link,symlink,mkdirat,mknodat,linkat,symlinkat,openat,open_by_handle_at,open,close,rename,renameat,truncate,ftruncate,rmdir,unlink,unlinkat -F exit=-EPERM -k access
+-a exit,always -F arch=b64 -S creat,mkdir,mknod,link,symlink,mkdirat,mknodat,linkat,symlinkat,openat,open_by_handle_at,open,close,rename,renameat,truncate,ftruncate,rmdir,unlink,unlinkat -F exit=-EACCES -k access
+-a exit,always -F arch=b64 -S creat,mkdir,mknod,link,symlink,mkdirat,mknodat,linkat,symlinkat,openat,open_by_handle_at,open,close,rename,renameat,truncate,ftruncate,rmdir,unlink,unlinkat -F exit=-EPERM -k access
+-a exit,always -F arch=b32 -S creat,mkdir,mknod,link,symlink,mkdirat,mknodat,linkat,symlinkat,openat,open_by_handle_at,open,close,rename,renameat,truncate,ftruncate,rmdir,unlink,unlinkat -F exit=-EACCES -k access
+-a exit,always -F arch=b32 -S creat,mkdir,mknod,link,symlink,mkdirat,mknodat,linkat,symlinkat,openat,open_by_handle_at,open,close,rename,renameat,truncate,ftruncate,rmdir,unlink,unlinkat -F exit=-EPERM -k access
 
--a always,exit -F perm=a -F exit=-EACCES -k access
--a always,exit -F perm=a -F exit=-EPERM -k access
+-a exit,always -F perm=a -F exit=-EACCES -k access
+-a exit,always -F perm=a -F exit=-EPERM -k access
 
 ## Audit the execution of password commands
--a always,exit -F path=/usr/bin/passwd -F perm=x -k privileged-passwd
+-a exit,always -F path=/usr/bin/passwd -F perm=x -k privileged-passwd
 
--a always,exit -F path=/sbin/unix_chkpwd -F perm=x -k privileged-passwd
+-a exit,always -F path=/sbin/unix_chkpwd -F perm=x -k privileged-passwd
 
--a always,exit -F path=/usr/bin/gpasswd -F perm=x -k privileged-passwd
+-a exit,always -F path=/usr/bin/gpasswd -F perm=x -k privileged-passwd
 
--a always,exit -F path=/usr/bin/chage -F perm=x -k privileged-passwd
+-a exit,always -F path=/usr/bin/chage -F perm=x -k privileged-passwd
 
--a always,exit -F path=/usr/sbin/userhelper -F perm=x -k privileged-passwd
+-a exit,always -F path=/usr/sbin/userhelper -F perm=x -k privileged-passwd
 
 ## Audit the execution of privilege-related commands
--a always,exit -F path=/bin/su -F perm=x -k privileged-priv_change
+-a exit,always -F path=/bin/su -F perm=x -k privileged-priv_change
 
--a always,exit -F path=/usr/bin/sudo -F perm=x -k privileged-priv_change
+-a exit,always -F path=/usr/bin/sudo -F perm=x -k privileged-priv_change
 
--a always,exit -F path=/usr/bin/newgrp -F perm=x -k privileged-priv_change
+-a exit,always -F path=/usr/bin/newgrp -F perm=x -k privileged-priv_change
 
--a always,exit -F path=/usr/bin/chsh -F perm=x -k privileged-priv_change
+-a exit,always -F path=/usr/bin/chsh -F perm=x -k privileged-priv_change
 
--a always,exit -F path=/usr/bin/sudoedit -F perm=x -k privileged-priv_change
+-a exit,always -F path=/usr/bin/sudoedit -F perm=x -k privileged-priv_change
 
 ## Audit the execution of postfix-related commands
--a always,exit -F path=/usr/sbin/postdrop -F perm=x -k privileged-postfix
+-a exit,always -F path=/usr/sbin/postdrop -F perm=x -k privileged-postfix
 
--a always,exit -F path=/usr/sbin/postqueue -F perm=x -k privileged-postfix
+-a exit,always -F path=/usr/sbin/postqueue -F perm=x -k privileged-postfix
 
 ## Audit the execution of the ssh-keysign command
--a always,exit -F path=/usr/libexec/openssh/ssh-keysign -F perm=x -k privileged-ssh
+-a exit,always -F path=/usr/libexec/openssh/ssh-keysign -F perm=x -k privileged-ssh
 
 ## Audit the execution of the crontab command
--a always,exit -F path=/usr/bin/crontab -F perm=x -k privileged-cron
+-a exit,always -F path=/usr/bin/crontab -F perm=x -k privileged-cron
 
 ## Audit the execution of the pam_timestamp_check command
--a always,exit -F path=/sbin/pam_timestamp_check -F perm=x -k privileged-pam
+-a exit,always -F path=/sbin/pam_timestamp_check -F perm=x -k privileged-pam
 
 ## Permissions auditing separated by chown, chmod, and attr
 
--a always,exit -F arch=b64 -S chown,fchown,fchownat,lchown -k chown
--a always,exit -F arch=b32 -S chown,fchown,fchownat,lchown -k chown
+-a exit,always -F arch=b64 -S chown,fchown,fchownat,lchown -k chown
+-a exit,always -F arch=b32 -S chown,fchown,fchownat,lchown -k chown
 
--a always,exit -F arch=b64 -S setxattr,lsetxattr,fsetxattr,removexattr,lremovexattr,fremovexattr -k attr
--a always,exit -F arch=b32 -S setxattr,lsetxattr,fsetxattr,removexattr,lremovexattr,fremovexattr -k attr
+-a exit,always -F arch=b64 -S setxattr,lsetxattr,fsetxattr,removexattr,lremovexattr,fremovexattr -k attr
+-a exit,always -F arch=b32 -S setxattr,lsetxattr,fsetxattr,removexattr,lremovexattr,fremovexattr -k attr
 
 ## Audit useful items that someone does when su'ing to root.
--a always,exit -F arch=b64 -F auid!=0 -F uid=0 -S capset,mknod,mknodat,pivot_root,quotactl,setsid,adjtimex,settimeofday,setuid,swapoff,swapon,execve,rename,renameat,rmdir,unlink,unlinkat -k su-root-activity
--a always,exit -F arch=b32 -F auid!=0 -F uid=0 -S capset,mknod,mknodat,pivot_root,quotactl,setsid,adjtimex,settimeofday,setuid,swapoff,swapon,execve,rename,renameat,rmdir,unlink,unlinkat -k su-root-activity
+-a exit,always -F arch=b64 -F auid!=0 -F uid=0 -S capset,mknod,mknodat,pivot_root,quotactl,setsid,adjtimex,settimeofday,setuid,swapoff,swapon,execve,rename,renameat,rmdir,unlink,unlinkat -k su-root-activity
+-a exit,always -F arch=b32 -F auid!=0 -F uid=0 -S capset,mknod,mknodat,pivot_root,quotactl,setsid,adjtimex,settimeofday,setuid,swapoff,swapon,execve,rename,renameat,rmdir,unlink,unlinkat -k su-root-activity
 
 ## Audit the execution of suid and sgid binaries.
--a always,exit -F arch=b64 -F euid=0 -F uid!=0 -S execve -k suid-root-exec
--a always,exit -F arch=b32 -F euid=0 -F uid!=0 -S execve -k suid-root-exec
+-a exit,always -F arch=b64 -F euid=0 -F uid!=0 -S execve -k suid-root-exec
+-a exit,always -F arch=b32 -F euid=0 -F uid!=0 -S execve -k suid-root-exec
 
 ## Audit the loading and unloading of kernel modules.
 -w /sbin/insmod -p x -k modules
 -w /sbin/rmmod -p x -k modules
 -w /sbin/modprobe -p x -k modules
 
--a always,exit -F arch=b64 -S create_module,init_module,finit_module,delete_module -k modules
--a always,exit -F arch=b32 -S create_module,init_module,finit_module,delete_module -k modules
+-a exit,always -F arch=b64 -S create_module,init_module,finit_module,delete_module -k modules
+-a exit,always -F arch=b32 -S create_module,init_module,finit_module,delete_module -k modules
 
 ## Audit things that could affect time
--a always,exit -F arch=b64 -S adjtimex,settimeofday -k audit_time_rules
--a always,exit -F arch=b64 -S clock_settime -F a0=0x0 -k audit_time_rules
--a always,exit -F arch=b32 -S adjtimex,stime,settimeofday -k audit_time_rules
--a always,exit -F arch=b32 -S clock_settime -F a0=0x0 -k audit_time_rules
+-a exit,always -F arch=b64 -S adjtimex,settimeofday -k audit_time_rules
+-a exit,always -F arch=b64 -S clock_settime -F a0=0x0 -k audit_time_rules
+-a exit,always -F arch=b32 -S adjtimex,stime,settimeofday -k audit_time_rules
+-a exit,always -F arch=b32 -S clock_settime -F a0=0x0 -k audit_time_rules
 
 -w /etc/localtime -p wa -k audit_time_rules
 
 ## Audit things that could affect system locale
--a always,exit -F arch=b64 -S sethostname,setdomainname -k audit_network_modifications
--a always,exit -F arch=b32 -S sethostname,setdomainname -k audit_network_modifications
+-a exit,always -F arch=b64 -S sethostname,setdomainname -k audit_network_modifications
+-a exit,always -F arch=b32 -S sethostname,setdomainname -k audit_network_modifications
 
 -w /etc/issue -p wa -k audit_network_modifications
 -w /etc/issue.net -p wa -k audit_network_modifications
@@ -95,12 +95,12 @@
 -w /etc/sysconfig/network -p wa -k audit_network_modifications
 
 ## Audit mount operations
--a always,exit -F arch=b64 -S mount,umount2 -k mount
--a always,exit -F arch=b32 -S mount,umount,umount2 -k mount
+-a exit,always -F arch=b64 -S mount,umount2 -k mount
+-a exit,always -F arch=b32 -S mount,umount,umount2 -k mount
 
--a always,exit -F arch=b64 -F path=/bin/mount -k mount
--a always,exit -F arch=b32 -F path=/bin/mount -k mount
--a always,exit -F path=/bin/umount -F perm=x -k mount
+-a exit,always -F arch=b64 -F path=/bin/mount -k mount
+-a exit,always -F arch=b32 -F path=/bin/mount -k mount
+-a exit,always -F path=/bin/umount -F perm=x -k mount
 
 ## Audit local accounts
 -w /etc/passwd -p wa -k audit_account_changes
@@ -201,13 +201,13 @@
 -w /etc/yum -p wa -k yum-config
 -w /etc/yum.conf -p wa -k yum-config
 -w /etc/yum.repos.d -p wa -k yum-config
--a always,exit -F arch=b64 -S ptrace -F a0=0x4 -k paranoid_code_injection
--a always,exit -F arch=b64 -S ptrace -F a0=0x5 -k paranoid_data_injection
--a always,exit -F arch=b64 -S ptrace -F a0=0x6 -k paranoid_register_injection
--a always,exit -F arch=b64 -S ptrace -k paranoid
--a always,exit -F arch=b32 -S ptrace -F a0=0x4 -k paranoid_code_injection
--a always,exit -F arch=b32 -S ptrace -F a0=0x5 -k paranoid_data_injection
--a always,exit -F arch=b32 -S ptrace -F a0=0x6 -k paranoid_register_injection
--a always,exit -F arch=b32 -S ptrace -k paranoid
--a always,exit -F arch=b64 -S personality -k paranoid
--a always,exit -F arch=b32 -S personality -k paranoid
+-a exit,always -F arch=b64 -S ptrace -F a0=0x4 -k paranoid_code_injection
+-a exit,always -F arch=b64 -S ptrace -F a0=0x5 -k paranoid_data_injection
+-a exit,always -F arch=b64 -S ptrace -F a0=0x6 -k paranoid_register_injection
+-a exit,always -F arch=b64 -S ptrace -k paranoid
+-a exit,always -F arch=b32 -S ptrace -F a0=0x4 -k paranoid_code_injection
+-a exit,always -F arch=b32 -S ptrace -F a0=0x5 -k paranoid_data_injection
+-a exit,always -F arch=b32 -S ptrace -F a0=0x6 -k paranoid_register_injection
+-a exit,always -F arch=b32 -S ptrace -k paranoid
+-a exit,always -F arch=b64 -S personality -k paranoid
+-a exit,always -F arch=b32 -S personality -k paranoid

--- a/spec/classes/config/audit_profiles/expected/simp_el6_aggressive_rules.txt
+++ b/spec/classes/config/audit_profiles/expected/simp_el6_aggressive_rules.txt
@@ -3,9 +3,7 @@
 # may be a sign of someone exploiting a hole in the API.
 -a exit,always -F arch=b32 -S all -F key=32bit-api
 -a exit,always -F arch=b64 -S accept -F a0=2 -F key=ipv4_in
--a exit,always -F arch=b32 -S accept -F a0=2 -F key=ipv4_in
 -a exit,always -F arch=b64 -S accept -F a0=10 -F key=ipv6_in
--a exit,always -F arch=b32 -S accept -F a0=10 -F key=ipv6_in
 
 ## Audit unsuccessful file operations
 -a exit,always -F arch=b64 -S creat,mkdir,mknod,link,symlink,mkdirat,mknodat,linkat,symlinkat,openat,open_by_handle_at,open,close,rename,renameat,truncate,ftruncate,rmdir,unlink,unlinkat -F exit=-EACCES -k access

--- a/spec/classes/config/audit_profiles/expected/simp_el6_aggressive_rules.txt
+++ b/spec/classes/config/audit_profiles/expected/simp_el6_aggressive_rules.txt
@@ -1,14 +1,13 @@
 #### auditd::config::audit_profiles::simp Audit Rules ####
+# 64-bit systems should generally never call the 32-bit API. 32-bit syscalls
+# may be a sign of someone exploiting a hole in the API.
+-a always,exit -F arch=b32 -S all -F key=32bit-api
+-a always,exit -F arch=b64 -S accept -F a0=2 -F key=ipv4_in
+-a always,exit -F arch=b32 -S accept -F a0=2 -F key=ipv4_in
+-a always,exit -F arch=b64 -S accept -F a0=10 -F key=ipv6_in
+-a always,exit -F arch=b32 -S accept -F a0=10 -F key=ipv6_in
 
 ## Audit unsuccessful file operations
-# CCE-26712-0
-# CCE-26651-0
-# RHEL-07-030500
-# RHEL-07-030510
-# RHEL-07-030520
-# RHEL-07-030530
-# RHEL-07-030540
-# RHEL-07-030550
 -a always,exit -F arch=b64 -S creat,mkdir,mknod,link,symlink,mkdirat,mknodat,linkat,symlinkat,openat,open_by_handle_at,open,close,rename,renameat,truncate,ftruncate,rmdir,unlink,unlinkat -F exit=-EACCES -k access
 -a always,exit -F arch=b64 -S creat,mkdir,mknod,link,symlink,mkdirat,mknodat,linkat,symlinkat,openat,open_by_handle_at,open,close,rename,renameat,truncate,ftruncate,rmdir,unlink,unlinkat -F exit=-EPERM -k access
 -a always,exit -F arch=b32 -S creat,mkdir,mknod,link,symlink,mkdirat,mknodat,linkat,symlinkat,openat,open_by_handle_at,open,close,rename,renameat,truncate,ftruncate,rmdir,unlink,unlinkat -F exit=-EACCES -k access
@@ -18,136 +17,77 @@
 -a always,exit -F perm=a -F exit=-EPERM -k access
 
 ## Audit the execution of password commands
-# RHEL-07-030630
 -a always,exit -F path=/usr/bin/passwd -F perm=x -k privileged-passwd
 
-# RHEL-07-030640
 -a always,exit -F path=/sbin/unix_chkpwd -F perm=x -k privileged-passwd
 
-# RHEL-07-030650
 -a always,exit -F path=/usr/bin/gpasswd -F perm=x -k privileged-passwd
 
-# RHEL-07-030660
 -a always,exit -F path=/usr/bin/chage -F perm=x -k privileged-passwd
 
-# RHEL-07-030670
 -a always,exit -F path=/usr/sbin/userhelper -F perm=x -k privileged-passwd
 
 ## Audit the execution of privilege-related commands
-# RHEL-07-030680
 -a always,exit -F path=/bin/su -F perm=x -k privileged-priv_change
 
-# RHEL-07-030690
 -a always,exit -F path=/usr/bin/sudo -F perm=x -k privileged-priv_change
 
-# RHEL-07-030710
 -a always,exit -F path=/usr/bin/newgrp -F perm=x -k privileged-priv_change
 
-# RHEL-07-030720
 -a always,exit -F path=/usr/bin/chsh -F perm=x -k privileged-priv_change
 
-# RHEL-07-030730
 -a always,exit -F path=/usr/bin/sudoedit -F perm=x -k privileged-priv_change
 
 ## Audit the execution of postfix-related commands
-# RHEL-07-030760
 -a always,exit -F path=/usr/sbin/postdrop -F perm=x -k privileged-postfix
 
-# RHEL-07-030770
 -a always,exit -F path=/usr/sbin/postqueue -F perm=x -k privileged-postfix
 
 ## Audit the execution of the ssh-keysign command
-# RHEL-07-030780
 -a always,exit -F path=/usr/libexec/openssh/ssh-keysign -F perm=x -k privileged-ssh
 
 ## Audit the execution of the crontab command
-# RHEL-07-030800
 -a always,exit -F path=/usr/bin/crontab -F perm=x -k privileged-cron
 
 ## Audit the execution of the pam_timestamp_check command
-# RHEL-07-030810
 -a always,exit -F path=/sbin/pam_timestamp_check -F perm=x -k privileged-pam
 
 ## Permissions auditing separated by chown, chmod, and attr
-# CCE-26280-8
-# CCE-27173-4
-# CCE-27174-2
-# CCE-27175-9
-# CCE-27177-5
-# CCE-27178-3
-# CCE-27179-1
-# CCE-27180-9
-# CCE-27181-7
-# CCE-27182-5
-# CCE-27183-3
-# CCE-27184-1
-# CCE-27185-8
 
-# RHEL-07-030370
-# RHEL-07-030380
-# RHEL-07-030390
-# RHEL-07-030400
 -a always,exit -F arch=b64 -S chown,fchown,fchownat,lchown -k chown
 -a always,exit -F arch=b32 -S chown,fchown,fchownat,lchown -k chown
 
-# RHEL-07-030440
-# RHEL-07-030450
-# RHEL-07-030460
-# RHEL-07-030470
-# RHEL-07-030480
-# RHEL-07-030490
 -a always,exit -F arch=b64 -S setxattr,lsetxattr,fsetxattr,removexattr,lremovexattr,fremovexattr -k attr
 -a always,exit -F arch=b32 -S setxattr,lsetxattr,fsetxattr,removexattr,lremovexattr,fremovexattr -k attr
 
 ## Audit useful items that someone does when su'ing to root.
-# Had to add an entry in the default_drop rules file for getting rid of
-# anonymous records.  They are only moderately useful and contain *way*
-# too much noise since this covers things like cron as well.
 -a always,exit -F arch=b64 -F auid!=0 -F uid=0 -S capset,mknod,mknodat,pivot_root,quotactl,setsid,adjtimex,settimeofday,setuid,swapoff,swapon,execve,rename,renameat,rmdir,unlink,unlinkat -k su-root-activity
 -a always,exit -F arch=b32 -F auid!=0 -F uid=0 -S capset,mknod,mknodat,pivot_root,quotactl,setsid,adjtimex,settimeofday,setuid,swapoff,swapon,execve,rename,renameat,rmdir,unlink,unlinkat -k su-root-activity
 
 ## Audit the execution of suid and sgid binaries.
-# CCE-26457-2
-# RHEL-07-030360
 -a always,exit -F arch=b64 -F euid=0 -F uid!=0 -S execve -k suid-root-exec
 -a always,exit -F arch=b32 -F euid=0 -F uid!=0 -S execve -k suid-root-exec
 
 ## Audit the loading and unloading of kernel modules.
-# CCE-26611-4
-
-# RHEL-07-030840
 -w /sbin/insmod -p x -k modules
-
-# RHEL-07-030850
 -w /sbin/rmmod -p x -k modules
-
-# RHEL-07-030860
 -w /sbin/modprobe -p x -k modules
 
-# RHEL-07-030819
-# RHEL-07-030820
-# RHEL-07-030821
-# RHEL-07-030830
 -a always,exit -F arch=b64 -S create_module,init_module,finit_module,delete_module -k modules
 -a always,exit -F arch=b32 -S create_module,init_module,finit_module,delete_module -k modules
 
 ## Audit things that could affect time
-# CCE-27172-6
-# CCE-27203-9
-# CCE-27169-2
-# CCE-27170-0
--a always,exit -F arch=b32 -S adjtimex,stime,settimeofday -k audit_time_rules
 -a always,exit -F arch=b64 -S adjtimex,settimeofday -k audit_time_rules
--a always,exit -F arch=b32 -S clock_settime -F a0=0x0 -k audit_time_rules
 -a always,exit -F arch=b64 -S clock_settime -F a0=0x0 -k audit_time_rules
+-a always,exit -F arch=b32 -S adjtimex,stime,settimeofday -k audit_time_rules
+-a always,exit -F arch=b32 -S clock_settime -F a0=0x0 -k audit_time_rules
 
-# CCE-27172-6
 -w /etc/localtime -p wa -k audit_time_rules
 
 ## Audit things that could affect system locale
-# CCE-26648-6
--a always,exit -F arch=b32 -S sethostname,setdomainname -k audit_network_modifications
 -a always,exit -F arch=b64 -S sethostname,setdomainname -k audit_network_modifications
+-a always,exit -F arch=b32 -S sethostname,setdomainname -k audit_network_modifications
+
 -w /etc/issue -p wa -k audit_network_modifications
 -w /etc/issue.net -p wa -k audit_network_modifications
 -w /etc/hosts -p wa -k audit_network_modifications
@@ -155,68 +95,59 @@
 -w /etc/sysconfig/network -p wa -k audit_network_modifications
 
 ## Audit mount operations
-# CCE-26573-6
-#
-# RHEL-07-030740
-# RHEL-07-030750
--a always,exit -F arch=b32 -S mount,umount,umount2 -k mount
 -a always,exit -F arch=b64 -S mount,umount2 -k mount
+-a always,exit -F arch=b32 -S mount,umount,umount2 -k mount
+
 -a always,exit -F arch=b64 -F path=/bin/mount -k mount
 -a always,exit -F arch=b32 -F path=/bin/mount -k mount
 -a always,exit -F path=/bin/umount -F perm=x -k mount
 
 ## Audit local accounts
-# CCE-26664-3
-#
-# RHEL-07-030870
 -w /etc/passwd -p wa -k audit_account_changes
-
-# RHEL-07-030871
 -w /etc/group -p wa -k audit_account_changes
-
-# RHEL-07-030872
 -w /etc/gshadow -p wa -k audit_account_changes
-
-# RHEL-07-030873
 -w /etc/shadow -p wa -k audit_account_changes
-
-# RHEL-07-030874
 -w /etc/security/opasswd -p wa -k audit_account_changes
-
 -w /etc/passwd- -p wa -k audit_account_changes
 -w /etc/group- -p wa -k audit_account_changes
 -w /etc/shadow- -p wa -k audit_account_changes
 
 ## Audit selinux policy
-# CCE-26657-7
 -w /etc/selinux/ -p wa -k MAC-policy
 -w /usr/share/selinux/ -p wa -k MAC-policy
 
 ## Audit login files
-# CCE-26691-6
-#
-# RHEL-07-030600
 -w /var/log/tallylog -p wa -k logins
-
-# RHEL-07-030610
 -w /var/run/faillock -p wa -k logins
-
-# RHEL-07-030620
 -w /var/log/lastlog -p wa -k logins
-
 -w /var/log/faillog -p wa -k logins
 
 ## Audit session files
-# CCE-26610-6
 -w /var/run/utmp -p wa -k session
 -w /var/log/btmp -p wa -k session
 -w /var/log/wtmp -p wa -k session
 
 ## Audit sudoers configuration files
-# CCE-26662-7
-# RHEL-07-030700
 -w /etc/sudoers -p wa -k CFG_sys
 -w /etc/sudoers.d/ -p wa -k CFG_sys
+
+## Audit accesses to the audit trail
+-w /usr/sbin/aulast -p x -k access-audit-trail
+-w /usr/sbin/aulastlogin -p x -k access-audit-trail
+-w /usr/sbin/aureport -p x -k access-audit-trail
+-w /usr/sbin/ausearch -p x -k access-audit-trail
+-w /usr/sbin/auvirt -p x -k access-audit-trail
+
+## Audit suspicious applications
+-w /usr/bin/nc -p x -k suspicious_apps
+-w /usr/bin/ncat -p x -k suspicious_apps
+-w /usr/bin/nmap -p x -k suspicious_apps
+-w /usr/bin/rawshark -p x -k suspicious_apps
+-w /usr/bin/socat -p x -k suspicious_apps
+-w /usr/bin/wireshark -p x -k suspicious_apps
+-w /usr/sbin/tcpdump -p x -k suspicious_apps
+-w /usr/sbin/traceroute -p x -k suspicious_apps
+-w /usr/sbin/traceroute6 -p x -k suspicious_apps
 
 ## Generally good things to audit.
 -w /boot/grub/grub.conf -p wa -k CFG_grub
@@ -228,8 +159,6 @@
 -w /etc/hosts.deny -p wa -k CFG_sys
 -w /etc/initlog.conf -p wa -k CFG_sys
 -w /etc/inittab -p wa -k CFG_sys
--w /etc/issue -p wa -k CFG_sys
--w /etc/issue.net -p wa -k CFG_sys
 -w /etc/krb5.conf -p wa -k CFG_sys
 -w /etc/ld.so.conf -p wa -k CFG_sys
 -w /etc/ld.so.conf.d -p wa -k CFG_sys
@@ -272,7 +201,13 @@
 -w /etc/yum -p wa -k yum-config
 -w /etc/yum.conf -p wa -k yum-config
 -w /etc/yum.repos.d -p wa -k yum-config
--a always,exit -F arch=b32 -S ptrace -k paranoid
+-a always,exit -F arch=b64 -S ptrace -F a0=0x4 -k paranoid_code_injection
+-a always,exit -F arch=b64 -S ptrace -F a0=0x5 -k paranoid_data_injection
+-a always,exit -F arch=b64 -S ptrace -F a0=0x6 -k paranoid_register_injection
 -a always,exit -F arch=b64 -S ptrace -k paranoid
--a always,exit -F arch=b32 -S personality -k paranoid
+-a always,exit -F arch=b32 -S ptrace -F a0=0x4 -k paranoid_code_injection
+-a always,exit -F arch=b32 -S ptrace -F a0=0x5 -k paranoid_data_injection
+-a always,exit -F arch=b32 -S ptrace -F a0=0x6 -k paranoid_register_injection
+-a always,exit -F arch=b32 -S ptrace -k paranoid
 -a always,exit -F arch=b64 -S personality -k paranoid
+-a always,exit -F arch=b32 -S personality -k paranoid

--- a/spec/classes/config/audit_profiles/expected/simp_el6_all_rules_custom_tags.txt
+++ b/spec/classes/config/audit_profiles/expected/simp_el6_all_rules_custom_tags.txt
@@ -1,105 +1,105 @@
 #### auditd::config::audit_profiles::simp Audit Rules ####
 # 64-bit systems should generally never call the 32-bit API. 32-bit syscalls
 # may be a sign of someone exploiting a hole in the API.
--a always,exit -F arch=b32 -S all -F key=32bit-api
--a always,exit -F arch=b64 -S accept -F a0=2 -F key=ipv4_in
--a always,exit -F arch=b32 -S accept -F a0=2 -F key=ipv4_in
--a always,exit -F arch=b64 -S accept -F a0=10 -F key=ipv6_in
--a always,exit -F arch=b32 -S accept -F a0=10 -F key=ipv6_in
+-a exit,always -F arch=b32 -S all -F key=32bit-api
+-a exit,always -F arch=b64 -S accept -F a0=2 -F key=ipv4_in
+-a exit,always -F arch=b32 -S accept -F a0=2 -F key=ipv4_in
+-a exit,always -F arch=b64 -S accept -F a0=10 -F key=ipv6_in
+-a exit,always -F arch=b32 -S accept -F a0=10 -F key=ipv6_in
 
 ## Audit unsuccessful file operations
--a always,exit -F arch=b64 -S creat,mkdir,mknod,link,symlink,mkdirat,mknodat,linkat,symlinkat,openat,open_by_handle_at,open,close,rename,renameat,truncate,ftruncate,rmdir,unlink,unlinkat -F exit=-EACCES -k my_unsuccessful_file_operations
--a always,exit -F arch=b64 -S creat,mkdir,mknod,link,symlink,mkdirat,mknodat,linkat,symlinkat,openat,open_by_handle_at,open,close,rename,renameat,truncate,ftruncate,rmdir,unlink,unlinkat -F exit=-EPERM -k my_unsuccessful_file_operations
--a always,exit -F arch=b32 -S creat,mkdir,mknod,link,symlink,mkdirat,mknodat,linkat,symlinkat,openat,open_by_handle_at,open,close,rename,renameat,truncate,ftruncate,rmdir,unlink,unlinkat -F exit=-EACCES -k my_unsuccessful_file_operations
--a always,exit -F arch=b32 -S creat,mkdir,mknod,link,symlink,mkdirat,mknodat,linkat,symlinkat,openat,open_by_handle_at,open,close,rename,renameat,truncate,ftruncate,rmdir,unlink,unlinkat -F exit=-EPERM -k my_unsuccessful_file_operations
+-a exit,always -F arch=b64 -S creat,mkdir,mknod,link,symlink,mkdirat,mknodat,linkat,symlinkat,openat,open_by_handle_at,open,close,rename,renameat,truncate,ftruncate,rmdir,unlink,unlinkat -F exit=-EACCES -k my_unsuccessful_file_operations
+-a exit,always -F arch=b64 -S creat,mkdir,mknod,link,symlink,mkdirat,mknodat,linkat,symlinkat,openat,open_by_handle_at,open,close,rename,renameat,truncate,ftruncate,rmdir,unlink,unlinkat -F exit=-EPERM -k my_unsuccessful_file_operations
+-a exit,always -F arch=b32 -S creat,mkdir,mknod,link,symlink,mkdirat,mknodat,linkat,symlinkat,openat,open_by_handle_at,open,close,rename,renameat,truncate,ftruncate,rmdir,unlink,unlinkat -F exit=-EACCES -k my_unsuccessful_file_operations
+-a exit,always -F arch=b32 -S creat,mkdir,mknod,link,symlink,mkdirat,mknodat,linkat,symlinkat,openat,open_by_handle_at,open,close,rename,renameat,truncate,ftruncate,rmdir,unlink,unlinkat -F exit=-EPERM -k my_unsuccessful_file_operations
 
--a always,exit -F perm=a -F exit=-EACCES -k my_unsuccessful_file_operations
--a always,exit -F perm=a -F exit=-EPERM -k my_unsuccessful_file_operations
+-a exit,always -F perm=a -F exit=-EACCES -k my_unsuccessful_file_operations
+-a exit,always -F perm=a -F exit=-EPERM -k my_unsuccessful_file_operations
 
 ## Audit the execution of password commands
--a always,exit -F path=/usr/bin/passwd -F perm=x -k my_passwd_cmds
+-a exit,always -F path=/usr/bin/passwd -F perm=x -k my_passwd_cmds
 
--a always,exit -F path=/sbin/unix_chkpwd -F perm=x -k my_passwd_cmds
+-a exit,always -F path=/sbin/unix_chkpwd -F perm=x -k my_passwd_cmds
 
--a always,exit -F path=/usr/bin/gpasswd -F perm=x -k my_passwd_cmds
+-a exit,always -F path=/usr/bin/gpasswd -F perm=x -k my_passwd_cmds
 
--a always,exit -F path=/usr/bin/chage -F perm=x -k my_passwd_cmds
+-a exit,always -F path=/usr/bin/chage -F perm=x -k my_passwd_cmds
 
--a always,exit -F path=/usr/sbin/userhelper -F perm=x -k my_passwd_cmds
+-a exit,always -F path=/usr/sbin/userhelper -F perm=x -k my_passwd_cmds
 
 ## Audit the execution of privilege-related commands
--a always,exit -F path=/bin/su -F perm=x -k my_priv_cmds
+-a exit,always -F path=/bin/su -F perm=x -k my_priv_cmds
 
--a always,exit -F path=/usr/bin/sudo -F perm=x -k my_priv_cmds
+-a exit,always -F path=/usr/bin/sudo -F perm=x -k my_priv_cmds
 
--a always,exit -F path=/usr/bin/newgrp -F perm=x -k my_priv_cmds
+-a exit,always -F path=/usr/bin/newgrp -F perm=x -k my_priv_cmds
 
--a always,exit -F path=/usr/bin/chsh -F perm=x -k my_priv_cmds
+-a exit,always -F path=/usr/bin/chsh -F perm=x -k my_priv_cmds
 
--a always,exit -F path=/usr/bin/sudoedit -F perm=x -k my_priv_cmds
+-a exit,always -F path=/usr/bin/sudoedit -F perm=x -k my_priv_cmds
 
 ## Audit the execution of postfix-related commands
--a always,exit -F path=/usr/sbin/postdrop -F perm=x -k my_postfix_cmds
+-a exit,always -F path=/usr/sbin/postdrop -F perm=x -k my_postfix_cmds
 
--a always,exit -F path=/usr/sbin/postqueue -F perm=x -k my_postfix_cmds
+-a exit,always -F path=/usr/sbin/postqueue -F perm=x -k my_postfix_cmds
 
 ## Audit the execution of the ssh-keysign command
--a always,exit -F path=/usr/libexec/openssh/ssh-keysign -F perm=x -k my_ssh_keysign_cmd
+-a exit,always -F path=/usr/libexec/openssh/ssh-keysign -F perm=x -k my_ssh_keysign_cmd
 
 ## Audit the execution of the crontab command
--a always,exit -F path=/usr/bin/crontab -F perm=x -k my_crontab_cmd
+-a exit,always -F path=/usr/bin/crontab -F perm=x -k my_crontab_cmd
 
 ## Audit the execution of the pam_timestamp_check command
--a always,exit -F path=/sbin/pam_timestamp_check -F perm=x -k my_pam_timestamp_check_cmd
+-a exit,always -F path=/sbin/pam_timestamp_check -F perm=x -k my_pam_timestamp_check_cmd
 
 ## Audit selinux commands
--a always,exit -F path=/usr/sbin/semanage -F perm=x -k my_selinux_cmds
--a always,exit -F path=/usr/sbin/setsebool -F perm=x -k my_selinux_cmds
--a always,exit -F path=/usr/bin/chcon -F perm=x -k my_selinux_cmds
--a always,exit -F path=/sbin/setfiles -F perm=x -k my_selinux_cmds
+-a exit,always -F path=/usr/sbin/semanage -F perm=x -k my_selinux_cmds
+-a exit,always -F path=/usr/sbin/setsebool -F perm=x -k my_selinux_cmds
+-a exit,always -F path=/usr/bin/chcon -F perm=x -k my_selinux_cmds
+-a exit,always -F path=/sbin/setfiles -F perm=x -k my_selinux_cmds
 
 ## Permissions auditing separated by chown, chmod, and attr
 
--a always,exit -F arch=b64 -S chown,fchown,fchownat,lchown -k my_chown
--a always,exit -F arch=b32 -S chown,fchown,fchownat,lchown -k my_chown
+-a exit,always -F arch=b64 -S chown,fchown,fchownat,lchown -k my_chown
+-a exit,always -F arch=b32 -S chown,fchown,fchownat,lchown -k my_chown
 
--a always,exit -F arch=b64 -S chmod,fchmod,fchmodat -k my_chmod
--a always,exit -F arch=b32 -S chmod,fchmod,fchmodat -k my_chmod
+-a exit,always -F arch=b64 -S chmod,fchmod,fchmodat -k my_chmod
+-a exit,always -F arch=b32 -S chmod,fchmod,fchmodat -k my_chmod
 
--a always,exit -F arch=b64 -S setxattr,lsetxattr,fsetxattr,removexattr,lremovexattr,fremovexattr -k my_attr
--a always,exit -F arch=b32 -S setxattr,lsetxattr,fsetxattr,removexattr,lremovexattr,fremovexattr -k my_attr
+-a exit,always -F arch=b64 -S setxattr,lsetxattr,fsetxattr,removexattr,lremovexattr,fremovexattr -k my_attr
+-a exit,always -F arch=b32 -S setxattr,lsetxattr,fsetxattr,removexattr,lremovexattr,fremovexattr -k my_attr
 
 ## Audit rename/removal operations
--a always,exit -F arch=b64 -S rename,renameat,rmdir,unlink,unlinkat -F perm=x -k my_rename_remove
--a always,exit -F arch=b32 -S rename,renameat,rmdir,unlink,unlinkat -F perm=x -k my_rename_remove
+-a exit,always -F arch=b64 -S rename,renameat,rmdir,unlink,unlinkat -F perm=x -k my_rename_remove
+-a exit,always -F arch=b32 -S rename,renameat,rmdir,unlink,unlinkat -F perm=x -k my_rename_remove
 
 ## Audit useful items that someone does when su'ing to root.
--a always,exit -F arch=b64 -F auid!=0 -F uid=0 -S capset,mknod,mknodat,pivot_root,quotactl,setsid,adjtimex,settimeofday,setuid,swapoff,swapon,execve,rename,renameat,rmdir,unlink,unlinkat,write,chown,fchown,fchownat,lchown,creat,fork,vfork,link,linkat,symlink,symlinkat,mkdir,mkdirat -k my_su_root_activity
--a always,exit -F arch=b32 -F auid!=0 -F uid=0 -S capset,mknod,mknodat,pivot_root,quotactl,setsid,adjtimex,settimeofday,setuid,swapoff,swapon,execve,rename,renameat,rmdir,unlink,unlinkat,write,chown,fchown,fchownat,lchown,creat,fork,vfork,link,linkat,symlink,symlinkat,mkdir,mkdirat -k my_su_root_activity
+-a exit,always -F arch=b64 -F auid!=0 -F uid=0 -S capset,mknod,mknodat,pivot_root,quotactl,setsid,adjtimex,settimeofday,setuid,swapoff,swapon,execve,rename,renameat,rmdir,unlink,unlinkat,write,chown,fchown,fchownat,lchown,creat,fork,vfork,link,linkat,symlink,symlinkat,mkdir,mkdirat -k my_su_root_activity
+-a exit,always -F arch=b32 -F auid!=0 -F uid=0 -S capset,mknod,mknodat,pivot_root,quotactl,setsid,adjtimex,settimeofday,setuid,swapoff,swapon,execve,rename,renameat,rmdir,unlink,unlinkat,write,chown,fchown,fchownat,lchown,creat,fork,vfork,link,linkat,symlink,symlinkat,mkdir,mkdirat -k my_su_root_activity
 
 ## Audit the execution of suid and sgid binaries.
--a always,exit -F arch=b64 -F euid=0 -F uid!=0 -S execve -k my_suid_sgid
--a always,exit -F arch=b32 -F euid=0 -F uid!=0 -S execve -k my_suid_sgid
+-a exit,always -F arch=b64 -F euid=0 -F uid!=0 -S execve -k my_suid_sgid
+-a exit,always -F arch=b32 -F euid=0 -F uid!=0 -S execve -k my_suid_sgid
 
 ## Audit the loading and unloading of kernel modules.
 -w /sbin/insmod -p x -k my_kernel_modules
 -w /sbin/rmmod -p x -k my_kernel_modules
 -w /sbin/modprobe -p x -k my_kernel_modules
 
--a always,exit -F arch=b64 -S create_module,init_module,finit_module,delete_module -k my_kernel_modules
--a always,exit -F arch=b32 -S create_module,init_module,finit_module,delete_module -k my_kernel_modules
+-a exit,always -F arch=b64 -S create_module,init_module,finit_module,delete_module -k my_kernel_modules
+-a exit,always -F arch=b32 -S create_module,init_module,finit_module,delete_module -k my_kernel_modules
 
 ## Audit things that could affect time
--a always,exit -F arch=b64 -S adjtimex,settimeofday -k my_time
--a always,exit -F arch=b64 -S clock_settime -F a0=0x0 -k my_time
--a always,exit -F arch=b32 -S adjtimex,stime,settimeofday -k my_time
--a always,exit -F arch=b32 -S clock_settime -F a0=0x0 -k my_time
+-a exit,always -F arch=b64 -S adjtimex,settimeofday -k my_time
+-a exit,always -F arch=b64 -S clock_settime -F a0=0x0 -k my_time
+-a exit,always -F arch=b32 -S adjtimex,stime,settimeofday -k my_time
+-a exit,always -F arch=b32 -S clock_settime -F a0=0x0 -k my_time
 
 -w /etc/localtime -p wa -k my_time
 
 ## Audit things that could affect system locale
--a always,exit -F arch=b64 -S sethostname,setdomainname -k my_locale
--a always,exit -F arch=b32 -S sethostname,setdomainname -k my_locale
+-a exit,always -F arch=b64 -S sethostname,setdomainname -k my_locale
+-a exit,always -F arch=b32 -S sethostname,setdomainname -k my_locale
 
 -w /etc/issue -p wa -k my_locale
 -w /etc/issue.net -p wa -k my_locale
@@ -108,16 +108,16 @@
 -w /etc/sysconfig/network -p wa -k my_locale
 
 ## Audit mount operations
--a always,exit -F arch=b64 -S mount,umount2 -k my_mount
--a always,exit -F arch=b32 -S mount,umount,umount2 -k my_mount
+-a exit,always -F arch=b64 -S mount,umount2 -k my_mount
+-a exit,always -F arch=b32 -S mount,umount,umount2 -k my_mount
 
--a always,exit -F arch=b64 -F path=/bin/mount -k my_mount
--a always,exit -F arch=b32 -F path=/bin/mount -k my_mount
--a always,exit -F path=/bin/umount -F perm=x -k my_mount
+-a exit,always -F arch=b64 -F path=/bin/mount -k my_mount
+-a exit,always -F arch=b32 -F path=/bin/mount -k my_mount
+-a exit,always -F path=/bin/umount -F perm=x -k my_mount
 
 ## Audit umask changes.
--a always,exit -F arch=b64 -S umask -k my_umask
--a always,exit -F arch=b32 -S umask -k my_umask
+-a exit,always -F arch=b64 -S umask -k my_umask
+-a exit,always -F arch=b32 -S umask -k my_umask
 
 ## Audit local accounts
 -w /etc/passwd -p wa -k my_local_account
@@ -220,13 +220,13 @@
 -w /etc/yum.repos.d -p wa -k my_cfg_yum
 -w /usr/bin/yum -p x -k my_yum_cmd
 -w /bin/rpm -p x -k my_rpm_cmd
--a always,exit -F arch=b64 -S ptrace -F a0=0x4 -k paranoid_code_injection
--a always,exit -F arch=b64 -S ptrace -F a0=0x5 -k paranoid_data_injection
--a always,exit -F arch=b64 -S ptrace -F a0=0x6 -k paranoid_register_injection
--a always,exit -F arch=b64 -S ptrace -k my_ptrace
--a always,exit -F arch=b32 -S ptrace -F a0=0x4 -k paranoid_code_injection
--a always,exit -F arch=b32 -S ptrace -F a0=0x5 -k paranoid_data_injection
--a always,exit -F arch=b32 -S ptrace -F a0=0x6 -k paranoid_register_injection
--a always,exit -F arch=b32 -S ptrace -k my_ptrace
--a always,exit -F arch=b64 -S personality -k my_personality
--a always,exit -F arch=b32 -S personality -k my_personality
+-a exit,always -F arch=b64 -S ptrace -F a0=0x4 -k paranoid_code_injection
+-a exit,always -F arch=b64 -S ptrace -F a0=0x5 -k paranoid_data_injection
+-a exit,always -F arch=b64 -S ptrace -F a0=0x6 -k paranoid_register_injection
+-a exit,always -F arch=b64 -S ptrace -k my_ptrace
+-a exit,always -F arch=b32 -S ptrace -F a0=0x4 -k paranoid_code_injection
+-a exit,always -F arch=b32 -S ptrace -F a0=0x5 -k paranoid_data_injection
+-a exit,always -F arch=b32 -S ptrace -F a0=0x6 -k paranoid_register_injection
+-a exit,always -F arch=b32 -S ptrace -k my_ptrace
+-a exit,always -F arch=b64 -S personality -k my_personality
+-a exit,always -F arch=b32 -S personality -k my_personality

--- a/spec/classes/config/audit_profiles/expected/simp_el6_all_rules_custom_tags.txt
+++ b/spec/classes/config/audit_profiles/expected/simp_el6_all_rules_custom_tags.txt
@@ -3,9 +3,7 @@
 # may be a sign of someone exploiting a hole in the API.
 -a exit,always -F arch=b32 -S all -F key=32bit-api
 -a exit,always -F arch=b64 -S accept -F a0=2 -F key=ipv4_in
--a exit,always -F arch=b32 -S accept -F a0=2 -F key=ipv4_in
 -a exit,always -F arch=b64 -S accept -F a0=10 -F key=ipv6_in
--a exit,always -F arch=b32 -S accept -F a0=10 -F key=ipv6_in
 
 ## Audit unsuccessful file operations
 -a exit,always -F arch=b64 -S creat,mkdir,mknod,link,symlink,mkdirat,mknodat,linkat,symlinkat,openat,open_by_handle_at,open,close,rename,renameat,truncate,ftruncate,rmdir,unlink,unlinkat -F exit=-EACCES -k my_unsuccessful_file_operations

--- a/spec/classes/config/audit_profiles/expected/simp_el6_all_rules_custom_tags.txt
+++ b/spec/classes/config/audit_profiles/expected/simp_el6_all_rules_custom_tags.txt
@@ -1,14 +1,13 @@
 #### auditd::config::audit_profiles::simp Audit Rules ####
+# 64-bit systems should generally never call the 32-bit API. 32-bit syscalls
+# may be a sign of someone exploiting a hole in the API.
+-a always,exit -F arch=b32 -S all -F key=32bit-api
+-a always,exit -F arch=b64 -S accept -F a0=2 -F key=ipv4_in
+-a always,exit -F arch=b32 -S accept -F a0=2 -F key=ipv4_in
+-a always,exit -F arch=b64 -S accept -F a0=10 -F key=ipv6_in
+-a always,exit -F arch=b32 -S accept -F a0=10 -F key=ipv6_in
 
 ## Audit unsuccessful file operations
-# CCE-26712-0
-# CCE-26651-0
-# RHEL-07-030500
-# RHEL-07-030510
-# RHEL-07-030520
-# RHEL-07-030530
-# RHEL-07-030540
-# RHEL-07-030550
 -a always,exit -F arch=b64 -S creat,mkdir,mknod,link,symlink,mkdirat,mknodat,linkat,symlinkat,openat,open_by_handle_at,open,close,rename,renameat,truncate,ftruncate,rmdir,unlink,unlinkat -F exit=-EACCES -k my_unsuccessful_file_operations
 -a always,exit -F arch=b64 -S creat,mkdir,mknod,link,symlink,mkdirat,mknodat,linkat,symlinkat,openat,open_by_handle_at,open,close,rename,renameat,truncate,ftruncate,rmdir,unlink,unlinkat -F exit=-EPERM -k my_unsuccessful_file_operations
 -a always,exit -F arch=b32 -S creat,mkdir,mknod,link,symlink,mkdirat,mknodat,linkat,symlinkat,openat,open_by_handle_at,open,close,rename,renameat,truncate,ftruncate,rmdir,unlink,unlinkat -F exit=-EACCES -k my_unsuccessful_file_operations
@@ -18,167 +17,90 @@
 -a always,exit -F perm=a -F exit=-EPERM -k my_unsuccessful_file_operations
 
 ## Audit the execution of password commands
-# RHEL-07-030630
 -a always,exit -F path=/usr/bin/passwd -F perm=x -k my_passwd_cmds
 
-# RHEL-07-030640
 -a always,exit -F path=/sbin/unix_chkpwd -F perm=x -k my_passwd_cmds
 
-# RHEL-07-030650
 -a always,exit -F path=/usr/bin/gpasswd -F perm=x -k my_passwd_cmds
 
-# RHEL-07-030660
 -a always,exit -F path=/usr/bin/chage -F perm=x -k my_passwd_cmds
 
-# RHEL-07-030670
 -a always,exit -F path=/usr/sbin/userhelper -F perm=x -k my_passwd_cmds
 
 ## Audit the execution of privilege-related commands
-# RHEL-07-030680
 -a always,exit -F path=/bin/su -F perm=x -k my_priv_cmds
 
-# RHEL-07-030690
 -a always,exit -F path=/usr/bin/sudo -F perm=x -k my_priv_cmds
 
-# RHEL-07-030710
 -a always,exit -F path=/usr/bin/newgrp -F perm=x -k my_priv_cmds
 
-# RHEL-07-030720
 -a always,exit -F path=/usr/bin/chsh -F perm=x -k my_priv_cmds
 
-# RHEL-07-030730
 -a always,exit -F path=/usr/bin/sudoedit -F perm=x -k my_priv_cmds
 
 ## Audit the execution of postfix-related commands
-# RHEL-07-030760
 -a always,exit -F path=/usr/sbin/postdrop -F perm=x -k my_postfix_cmds
 
-# RHEL-07-030770
 -a always,exit -F path=/usr/sbin/postqueue -F perm=x -k my_postfix_cmds
 
 ## Audit the execution of the ssh-keysign command
-# RHEL-07-030780
 -a always,exit -F path=/usr/libexec/openssh/ssh-keysign -F perm=x -k my_ssh_keysign_cmd
 
 ## Audit the execution of the crontab command
-# RHEL-07-030800
 -a always,exit -F path=/usr/bin/crontab -F perm=x -k my_crontab_cmd
 
 ## Audit the execution of the pam_timestamp_check command
-# RHEL-07-030810
 -a always,exit -F path=/sbin/pam_timestamp_check -F perm=x -k my_pam_timestamp_check_cmd
 
 ## Audit selinux commands
-# NOTE:  These rules come before the *xattr* checks, to ensure the
-#        correct tag is recorded.
-#
-# RHEL-07-030560
 -a always,exit -F path=/usr/sbin/semanage -F perm=x -k my_selinux_cmds
-
-# RHEL-07-030570
 -a always,exit -F path=/usr/sbin/setsebool -F perm=x -k my_selinux_cmds
-
-# RHEL-07-030580
 -a always,exit -F path=/usr/bin/chcon -F perm=x -k my_selinux_cmds
-
-# RHEL-07-030590
 -a always,exit -F path=/sbin/setfiles -F perm=x -k my_selinux_cmds
 
 ## Permissions auditing separated by chown, chmod, and attr
-# CCE-26280-8
-# CCE-27173-4
-# CCE-27174-2
-# CCE-27175-9
-# CCE-27177-5
-# CCE-27178-3
-# CCE-27179-1
-# CCE-27180-9
-# CCE-27181-7
-# CCE-27182-5
-# CCE-27183-3
-# CCE-27184-1
-# CCE-27185-8
 
-# RHEL-07-030370
-# RHEL-07-030380
-# RHEL-07-030390
-# RHEL-07-030400
 -a always,exit -F arch=b64 -S chown,fchown,fchownat,lchown -k my_chown
 -a always,exit -F arch=b32 -S chown,fchown,fchownat,lchown -k my_chown
 
-# RHEL-07-030410
-# RHEL-07-030420
-# RHEL-07-030430
 -a always,exit -F arch=b64 -S chmod,fchmod,fchmodat -k my_chmod
 -a always,exit -F arch=b32 -S chmod,fchmod,fchmodat -k my_chmod
 
-# RHEL-07-030440
-# RHEL-07-030450
-# RHEL-07-030460
-# RHEL-07-030470
-# RHEL-07-030480
-# RHEL-07-030490
 -a always,exit -F arch=b64 -S setxattr,lsetxattr,fsetxattr,removexattr,lremovexattr,fremovexattr -k my_attr
 -a always,exit -F arch=b32 -S setxattr,lsetxattr,fsetxattr,removexattr,lremovexattr,fremovexattr -k my_attr
 
 ## Audit rename/removal operations
-# RHEL-07-030880
-# RHEL-07-030890
-# RHEL-07-030900
-# RHEL-07-030910
-# RHEL-07-030920
 -a always,exit -F arch=b64 -S rename,renameat,rmdir,unlink,unlinkat -F perm=x -k my_rename_remove
 -a always,exit -F arch=b32 -S rename,renameat,rmdir,unlink,unlinkat -F perm=x -k my_rename_remove
 
 ## Audit useful items that someone does when su'ing to root.
-# Had to add an entry in the default_drop rules file for getting rid of
-# anonymous records.  They are only moderately useful and contain *way*
-# too much noise since this covers things like cron as well.
 -a always,exit -F arch=b64 -F auid!=0 -F uid=0 -S capset,mknod,mknodat,pivot_root,quotactl,setsid,adjtimex,settimeofday,setuid,swapoff,swapon,execve,rename,renameat,rmdir,unlink,unlinkat,write,chown,fchown,fchownat,lchown,creat,fork,vfork,link,linkat,symlink,symlinkat,mkdir,mkdirat -k my_su_root_activity
 -a always,exit -F arch=b32 -F auid!=0 -F uid=0 -S capset,mknod,mknodat,pivot_root,quotactl,setsid,adjtimex,settimeofday,setuid,swapoff,swapon,execve,rename,renameat,rmdir,unlink,unlinkat,write,chown,fchown,fchownat,lchown,creat,fork,vfork,link,linkat,symlink,symlinkat,mkdir,mkdirat -k my_su_root_activity
 
 ## Audit the execution of suid and sgid binaries.
-# CCE-26457-2
-# RHEL-07-030360
 -a always,exit -F arch=b64 -F euid=0 -F uid!=0 -S execve -k my_suid_sgid
 -a always,exit -F arch=b32 -F euid=0 -F uid!=0 -S execve -k my_suid_sgid
 
 ## Audit the loading and unloading of kernel modules.
-# CCE-26611-4
-
-# RHEL-07-030840
 -w /sbin/insmod -p x -k my_kernel_modules
-
-# RHEL-07-030850
 -w /sbin/rmmod -p x -k my_kernel_modules
-
-# RHEL-07-030860
 -w /sbin/modprobe -p x -k my_kernel_modules
 
-# RHEL-07-030819
-# RHEL-07-030820
-# RHEL-07-030821
-# RHEL-07-030830
 -a always,exit -F arch=b64 -S create_module,init_module,finit_module,delete_module -k my_kernel_modules
 -a always,exit -F arch=b32 -S create_module,init_module,finit_module,delete_module -k my_kernel_modules
 
 ## Audit things that could affect time
-# CCE-27172-6
-# CCE-27203-9
-# CCE-27169-2
-# CCE-27170-0
--a always,exit -F arch=b32 -S adjtimex,stime,settimeofday -k my_time
 -a always,exit -F arch=b64 -S adjtimex,settimeofday -k my_time
--a always,exit -F arch=b32 -S clock_settime -F a0=0x0 -k my_time
 -a always,exit -F arch=b64 -S clock_settime -F a0=0x0 -k my_time
+-a always,exit -F arch=b32 -S adjtimex,stime,settimeofday -k my_time
+-a always,exit -F arch=b32 -S clock_settime -F a0=0x0 -k my_time
 
-# CCE-27172-6
 -w /etc/localtime -p wa -k my_time
 
 ## Audit things that could affect system locale
-# CCE-26648-6
--a always,exit -F arch=b32 -S sethostname,setdomainname -k my_locale
 -a always,exit -F arch=b64 -S sethostname,setdomainname -k my_locale
+-a always,exit -F arch=b32 -S sethostname,setdomainname -k my_locale
+
 -w /etc/issue -p wa -k my_locale
 -w /etc/issue.net -p wa -k my_locale
 -w /etc/hosts -p wa -k my_locale
@@ -186,73 +108,63 @@
 -w /etc/sysconfig/network -p wa -k my_locale
 
 ## Audit mount operations
-# CCE-26573-6
-#
-# RHEL-07-030740
-# RHEL-07-030750
--a always,exit -F arch=b32 -S mount,umount,umount2 -k my_mount
 -a always,exit -F arch=b64 -S mount,umount2 -k my_mount
+-a always,exit -F arch=b32 -S mount,umount,umount2 -k my_mount
+
 -a always,exit -F arch=b64 -F path=/bin/mount -k my_mount
 -a always,exit -F arch=b32 -F path=/bin/mount -k my_mount
 -a always,exit -F path=/bin/umount -F perm=x -k my_mount
 
 ## Audit umask changes.
-# This is uselessly noisy.
 -a always,exit -F arch=b64 -S umask -k my_umask
 -a always,exit -F arch=b32 -S umask -k my_umask
 
 ## Audit local accounts
-# CCE-26664-3
-#
-# RHEL-07-030870
 -w /etc/passwd -p wa -k my_local_account
-
-# RHEL-07-030871
 -w /etc/group -p wa -k my_local_account
-
-# RHEL-07-030872
 -w /etc/gshadow -p wa -k my_local_account
-
-# RHEL-07-030873
 -w /etc/shadow -p wa -k my_local_account
-
-# RHEL-07-030874
 -w /etc/security/opasswd -p wa -k my_local_account
-
 -w /etc/passwd- -p wa -k my_local_account
 -w /etc/group- -p wa -k my_local_account
 -w /etc/shadow- -p wa -k my_local_account
 
 ## Audit selinux policy
-# CCE-26657-7
 -w /etc/selinux/ -p wa -k my_selinux_policy
 -w /usr/share/selinux/ -p wa -k my_selinux_policy
 
 ## Audit login files
-# CCE-26691-6
-#
-# RHEL-07-030600
 -w /var/log/tallylog -p wa -k my_login_files
-
-# RHEL-07-030610
 -w /var/run/faillock -p wa -k my_login_files
-
-# RHEL-07-030620
 -w /var/log/lastlog -p wa -k my_login_files
-
 -w /var/log/faillog -p wa -k my_login_files
 
 ## Audit session files
-# CCE-26610-6
 -w /var/run/utmp -p wa -k my_session_files
 -w /var/log/btmp -p wa -k my_session_files
 -w /var/log/wtmp -p wa -k my_session_files
 
 ## Audit sudoers configuration files
-# CCE-26662-7
-# RHEL-07-030700
 -w /etc/sudoers -p wa -k my_cfg_sudoers
 -w /etc/sudoers.d/ -p wa -k my_cfg_sudoers
+
+## Audit accesses to the audit trail
+-w /usr/sbin/aulast -p x -k access-audit-trail
+-w /usr/sbin/aulastlogin -p x -k access-audit-trail
+-w /usr/sbin/aureport -p x -k access-audit-trail
+-w /usr/sbin/ausearch -p x -k access-audit-trail
+-w /usr/sbin/auvirt -p x -k access-audit-trail
+
+## Audit suspicious applications
+-w /usr/bin/nc -p x -k suspicious_apps
+-w /usr/bin/ncat -p x -k suspicious_apps
+-w /usr/bin/nmap -p x -k suspicious_apps
+-w /usr/bin/rawshark -p x -k suspicious_apps
+-w /usr/bin/socat -p x -k suspicious_apps
+-w /usr/bin/wireshark -p x -k suspicious_apps
+-w /usr/sbin/tcpdump -p x -k suspicious_apps
+-w /usr/sbin/traceroute -p x -k suspicious_apps
+-w /usr/sbin/traceroute6 -p x -k suspicious_apps
 
 ## Generally good things to audit.
 -w /boot/grub/grub.conf -p wa -k my_cfg_grub
@@ -264,8 +176,6 @@
 -w /etc/hosts.deny -p wa -k my_cfg_sys
 -w /etc/initlog.conf -p wa -k my_cfg_sys
 -w /etc/inittab -p wa -k my_cfg_sys
--w /etc/issue -p wa -k my_cfg_sys
--w /etc/issue.net -p wa -k my_cfg_sys
 -w /etc/krb5.conf -p wa -k my_cfg_sys
 -w /etc/ld.so.conf -p wa -k my_cfg_sys
 -w /etc/ld.so.conf.d -p wa -k my_cfg_sys
@@ -310,7 +220,13 @@
 -w /etc/yum.repos.d -p wa -k my_cfg_yum
 -w /usr/bin/yum -p x -k my_yum_cmd
 -w /bin/rpm -p x -k my_rpm_cmd
--a always,exit -F arch=b32 -S ptrace -k my_ptrace
+-a always,exit -F arch=b64 -S ptrace -F a0=0x4 -k paranoid_code_injection
+-a always,exit -F arch=b64 -S ptrace -F a0=0x5 -k paranoid_data_injection
+-a always,exit -F arch=b64 -S ptrace -F a0=0x6 -k paranoid_register_injection
 -a always,exit -F arch=b64 -S ptrace -k my_ptrace
--a always,exit -F arch=b32 -S personality -k my_personality
+-a always,exit -F arch=b32 -S ptrace -F a0=0x4 -k paranoid_code_injection
+-a always,exit -F arch=b32 -S ptrace -F a0=0x5 -k paranoid_data_injection
+-a always,exit -F arch=b32 -S ptrace -F a0=0x6 -k paranoid_register_injection
+-a always,exit -F arch=b32 -S ptrace -k my_ptrace
 -a always,exit -F arch=b64 -S personality -k my_personality
+-a always,exit -F arch=b32 -S personality -k my_personality

--- a/spec/classes/config/audit_profiles/expected/simp_el6_basic_rules.txt
+++ b/spec/classes/config/audit_profiles/expected/simp_el6_basic_rules.txt
@@ -1,14 +1,13 @@
 #### auditd::config::audit_profiles::simp Audit Rules ####
+# 64-bit systems should generally never call the 32-bit API. 32-bit syscalls
+# may be a sign of someone exploiting a hole in the API.
+-a always,exit -F arch=b32 -S all -F key=32bit-api
+-a always,exit -F arch=b64 -S accept -F a0=2 -F key=ipv4_in
+-a always,exit -F arch=b32 -S accept -F a0=2 -F key=ipv4_in
+-a always,exit -F arch=b64 -S accept -F a0=10 -F key=ipv6_in
+-a always,exit -F arch=b32 -S accept -F a0=10 -F key=ipv6_in
 
 ## Audit unsuccessful file operations
-# CCE-26712-0
-# CCE-26651-0
-# RHEL-07-030500
-# RHEL-07-030510
-# RHEL-07-030520
-# RHEL-07-030530
-# RHEL-07-030540
-# RHEL-07-030550
 -a always,exit -F arch=b64 -S creat,mkdir,mknod,link,symlink,mkdirat,mknodat,linkat,symlinkat,openat,open_by_handle_at,open,close,rename,renameat,truncate,ftruncate,rmdir,unlink,unlinkat -F exit=-EACCES -k access
 -a always,exit -F arch=b64 -S creat,mkdir,mknod,link,symlink,mkdirat,mknodat,linkat,symlinkat,openat,open_by_handle_at,open,close,rename,renameat,truncate,ftruncate,rmdir,unlink,unlinkat -F exit=-EPERM -k access
 -a always,exit -F arch=b32 -S creat,mkdir,mknod,link,symlink,mkdirat,mknodat,linkat,symlinkat,openat,open_by_handle_at,open,close,rename,renameat,truncate,ftruncate,rmdir,unlink,unlinkat -F exit=-EACCES -k access
@@ -18,136 +17,77 @@
 -a always,exit -F perm=a -F exit=-EPERM -k access
 
 ## Audit the execution of password commands
-# RHEL-07-030630
 -a always,exit -F path=/usr/bin/passwd -F perm=x -k privileged-passwd
 
-# RHEL-07-030640
 -a always,exit -F path=/sbin/unix_chkpwd -F perm=x -k privileged-passwd
 
-# RHEL-07-030650
 -a always,exit -F path=/usr/bin/gpasswd -F perm=x -k privileged-passwd
 
-# RHEL-07-030660
 -a always,exit -F path=/usr/bin/chage -F perm=x -k privileged-passwd
 
-# RHEL-07-030670
 -a always,exit -F path=/usr/sbin/userhelper -F perm=x -k privileged-passwd
 
 ## Audit the execution of privilege-related commands
-# RHEL-07-030680
 -a always,exit -F path=/bin/su -F perm=x -k privileged-priv_change
 
-# RHEL-07-030690
 -a always,exit -F path=/usr/bin/sudo -F perm=x -k privileged-priv_change
 
-# RHEL-07-030710
 -a always,exit -F path=/usr/bin/newgrp -F perm=x -k privileged-priv_change
 
-# RHEL-07-030720
 -a always,exit -F path=/usr/bin/chsh -F perm=x -k privileged-priv_change
 
-# RHEL-07-030730
 -a always,exit -F path=/usr/bin/sudoedit -F perm=x -k privileged-priv_change
 
 ## Audit the execution of postfix-related commands
-# RHEL-07-030760
 -a always,exit -F path=/usr/sbin/postdrop -F perm=x -k privileged-postfix
 
-# RHEL-07-030770
 -a always,exit -F path=/usr/sbin/postqueue -F perm=x -k privileged-postfix
 
 ## Audit the execution of the ssh-keysign command
-# RHEL-07-030780
 -a always,exit -F path=/usr/libexec/openssh/ssh-keysign -F perm=x -k privileged-ssh
 
 ## Audit the execution of the crontab command
-# RHEL-07-030800
 -a always,exit -F path=/usr/bin/crontab -F perm=x -k privileged-cron
 
 ## Audit the execution of the pam_timestamp_check command
-# RHEL-07-030810
 -a always,exit -F path=/sbin/pam_timestamp_check -F perm=x -k privileged-pam
 
 ## Permissions auditing separated by chown, chmod, and attr
-# CCE-26280-8
-# CCE-27173-4
-# CCE-27174-2
-# CCE-27175-9
-# CCE-27177-5
-# CCE-27178-3
-# CCE-27179-1
-# CCE-27180-9
-# CCE-27181-7
-# CCE-27182-5
-# CCE-27183-3
-# CCE-27184-1
-# CCE-27185-8
 
-# RHEL-07-030370
-# RHEL-07-030380
-# RHEL-07-030390
-# RHEL-07-030400
 -a always,exit -F arch=b64 -S chown,fchown,fchownat,lchown -k chown
 -a always,exit -F arch=b32 -S chown,fchown,fchownat,lchown -k chown
 
-# RHEL-07-030440
-# RHEL-07-030450
-# RHEL-07-030460
-# RHEL-07-030470
-# RHEL-07-030480
-# RHEL-07-030490
 -a always,exit -F arch=b64 -S setxattr,lsetxattr,fsetxattr,removexattr,lremovexattr,fremovexattr -k attr
 -a always,exit -F arch=b32 -S setxattr,lsetxattr,fsetxattr,removexattr,lremovexattr,fremovexattr -k attr
 
 ## Audit useful items that someone does when su'ing to root.
-# Had to add an entry in the default_drop rules file for getting rid of
-# anonymous records.  They are only moderately useful and contain *way*
-# too much noise since this covers things like cron as well.
 -a always,exit -F arch=b64 -F auid!=0 -F uid=0 -S capset,mknod,mknodat,pivot_root,quotactl,setsid,adjtimex,settimeofday,setuid,swapoff,swapon -k su-root-activity
 -a always,exit -F arch=b32 -F auid!=0 -F uid=0 -S capset,mknod,mknodat,pivot_root,quotactl,setsid,adjtimex,settimeofday,setuid,swapoff,swapon -k su-root-activity
 
 ## Audit the execution of suid and sgid binaries.
-# CCE-26457-2
-# RHEL-07-030360
 -a always,exit -F arch=b64 -F euid=0 -F uid!=0 -S execve -k suid-root-exec
 -a always,exit -F arch=b32 -F euid=0 -F uid!=0 -S execve -k suid-root-exec
 
 ## Audit the loading and unloading of kernel modules.
-# CCE-26611-4
-
-# RHEL-07-030840
 -w /sbin/insmod -p x -k modules
-
-# RHEL-07-030850
 -w /sbin/rmmod -p x -k modules
-
-# RHEL-07-030860
 -w /sbin/modprobe -p x -k modules
 
-# RHEL-07-030819
-# RHEL-07-030820
-# RHEL-07-030821
-# RHEL-07-030830
 -a always,exit -F arch=b64 -S create_module,init_module,finit_module,delete_module -k modules
 -a always,exit -F arch=b32 -S create_module,init_module,finit_module,delete_module -k modules
 
 ## Audit things that could affect time
-# CCE-27172-6
-# CCE-27203-9
-# CCE-27169-2
-# CCE-27170-0
--a always,exit -F arch=b32 -S adjtimex,stime,settimeofday -k audit_time_rules
 -a always,exit -F arch=b64 -S adjtimex,settimeofday -k audit_time_rules
--a always,exit -F arch=b32 -S clock_settime -F a0=0x0 -k audit_time_rules
 -a always,exit -F arch=b64 -S clock_settime -F a0=0x0 -k audit_time_rules
+-a always,exit -F arch=b32 -S adjtimex,stime,settimeofday -k audit_time_rules
+-a always,exit -F arch=b32 -S clock_settime -F a0=0x0 -k audit_time_rules
 
-# CCE-27172-6
 -w /etc/localtime -p wa -k audit_time_rules
 
 ## Audit things that could affect system locale
-# CCE-26648-6
--a always,exit -F arch=b32 -S sethostname,setdomainname -k audit_network_modifications
 -a always,exit -F arch=b64 -S sethostname,setdomainname -k audit_network_modifications
+-a always,exit -F arch=b32 -S sethostname,setdomainname -k audit_network_modifications
+
 -w /etc/issue -p wa -k audit_network_modifications
 -w /etc/issue.net -p wa -k audit_network_modifications
 -w /etc/hosts -p wa -k audit_network_modifications
@@ -155,68 +95,59 @@
 -w /etc/sysconfig/network -p wa -k audit_network_modifications
 
 ## Audit mount operations
-# CCE-26573-6
-#
-# RHEL-07-030740
-# RHEL-07-030750
--a always,exit -F arch=b32 -S mount,umount,umount2 -k mount
 -a always,exit -F arch=b64 -S mount,umount2 -k mount
+-a always,exit -F arch=b32 -S mount,umount,umount2 -k mount
+
 -a always,exit -F arch=b64 -F path=/bin/mount -k mount
 -a always,exit -F arch=b32 -F path=/bin/mount -k mount
 -a always,exit -F path=/bin/umount -F perm=x -k mount
 
 ## Audit local accounts
-# CCE-26664-3
-#
-# RHEL-07-030870
 -w /etc/passwd -p wa -k audit_account_changes
-
-# RHEL-07-030871
 -w /etc/group -p wa -k audit_account_changes
-
-# RHEL-07-030872
 -w /etc/gshadow -p wa -k audit_account_changes
-
-# RHEL-07-030873
 -w /etc/shadow -p wa -k audit_account_changes
-
-# RHEL-07-030874
 -w /etc/security/opasswd -p wa -k audit_account_changes
-
 -w /etc/passwd- -p wa -k audit_account_changes
 -w /etc/group- -p wa -k audit_account_changes
 -w /etc/shadow- -p wa -k audit_account_changes
 
 ## Audit selinux policy
-# CCE-26657-7
 -w /etc/selinux/ -p wa -k MAC-policy
 -w /usr/share/selinux/ -p wa -k MAC-policy
 
 ## Audit login files
-# CCE-26691-6
-#
-# RHEL-07-030600
 -w /var/log/tallylog -p wa -k logins
-
-# RHEL-07-030610
 -w /var/run/faillock -p wa -k logins
-
-# RHEL-07-030620
 -w /var/log/lastlog -p wa -k logins
-
 -w /var/log/faillog -p wa -k logins
 
 ## Audit session files
-# CCE-26610-6
 -w /var/run/utmp -p wa -k session
 -w /var/log/btmp -p wa -k session
 -w /var/log/wtmp -p wa -k session
 
 ## Audit sudoers configuration files
-# CCE-26662-7
-# RHEL-07-030700
 -w /etc/sudoers -p wa -k CFG_sys
 -w /etc/sudoers.d/ -p wa -k CFG_sys
+
+## Audit accesses to the audit trail
+-w /usr/sbin/aulast -p x -k access-audit-trail
+-w /usr/sbin/aulastlogin -p x -k access-audit-trail
+-w /usr/sbin/aureport -p x -k access-audit-trail
+-w /usr/sbin/ausearch -p x -k access-audit-trail
+-w /usr/sbin/auvirt -p x -k access-audit-trail
+
+## Audit suspicious applications
+-w /usr/bin/nc -p x -k suspicious_apps
+-w /usr/bin/ncat -p x -k suspicious_apps
+-w /usr/bin/nmap -p x -k suspicious_apps
+-w /usr/bin/rawshark -p x -k suspicious_apps
+-w /usr/bin/socat -p x -k suspicious_apps
+-w /usr/bin/wireshark -p x -k suspicious_apps
+-w /usr/sbin/tcpdump -p x -k suspicious_apps
+-w /usr/sbin/traceroute -p x -k suspicious_apps
+-w /usr/sbin/traceroute6 -p x -k suspicious_apps
 
 ## Generally good things to audit.
 -w /boot/grub/grub.conf -p wa -k CFG_grub
@@ -228,8 +159,6 @@
 -w /etc/hosts.deny -p wa -k CFG_sys
 -w /etc/initlog.conf -p wa -k CFG_sys
 -w /etc/inittab -p wa -k CFG_sys
--w /etc/issue -p wa -k CFG_sys
--w /etc/issue.net -p wa -k CFG_sys
 -w /etc/krb5.conf -p wa -k CFG_sys
 -w /etc/ld.so.conf -p wa -k CFG_sys
 -w /etc/ld.so.conf.d -p wa -k CFG_sys
@@ -272,7 +201,13 @@
 -w /etc/yum -p wa -k yum-config
 -w /etc/yum.conf -p wa -k yum-config
 -w /etc/yum.repos.d -p wa -k yum-config
--a always,exit -F arch=b32 -S ptrace -k paranoid
+-a always,exit -F arch=b64 -S ptrace -F a0=0x4 -k paranoid_code_injection
+-a always,exit -F arch=b64 -S ptrace -F a0=0x5 -k paranoid_data_injection
+-a always,exit -F arch=b64 -S ptrace -F a0=0x6 -k paranoid_register_injection
 -a always,exit -F arch=b64 -S ptrace -k paranoid
--a always,exit -F arch=b32 -S personality -k paranoid
+-a always,exit -F arch=b32 -S ptrace -F a0=0x4 -k paranoid_code_injection
+-a always,exit -F arch=b32 -S ptrace -F a0=0x5 -k paranoid_data_injection
+-a always,exit -F arch=b32 -S ptrace -F a0=0x6 -k paranoid_register_injection
+-a always,exit -F arch=b32 -S ptrace -k paranoid
 -a always,exit -F arch=b64 -S personality -k paranoid
+-a always,exit -F arch=b32 -S personality -k paranoid

--- a/spec/classes/config/audit_profiles/expected/simp_el6_basic_rules.txt
+++ b/spec/classes/config/audit_profiles/expected/simp_el6_basic_rules.txt
@@ -1,92 +1,92 @@
 #### auditd::config::audit_profiles::simp Audit Rules ####
 # 64-bit systems should generally never call the 32-bit API. 32-bit syscalls
 # may be a sign of someone exploiting a hole in the API.
--a always,exit -F arch=b32 -S all -F key=32bit-api
--a always,exit -F arch=b64 -S accept -F a0=2 -F key=ipv4_in
--a always,exit -F arch=b32 -S accept -F a0=2 -F key=ipv4_in
--a always,exit -F arch=b64 -S accept -F a0=10 -F key=ipv6_in
--a always,exit -F arch=b32 -S accept -F a0=10 -F key=ipv6_in
+-a exit,always -F arch=b32 -S all -F key=32bit-api
+-a exit,always -F arch=b64 -S accept -F a0=2 -F key=ipv4_in
+-a exit,always -F arch=b32 -S accept -F a0=2 -F key=ipv4_in
+-a exit,always -F arch=b64 -S accept -F a0=10 -F key=ipv6_in
+-a exit,always -F arch=b32 -S accept -F a0=10 -F key=ipv6_in
 
 ## Audit unsuccessful file operations
--a always,exit -F arch=b64 -S creat,mkdir,mknod,link,symlink,mkdirat,mknodat,linkat,symlinkat,openat,open_by_handle_at,open,close,rename,renameat,truncate,ftruncate,rmdir,unlink,unlinkat -F exit=-EACCES -k access
--a always,exit -F arch=b64 -S creat,mkdir,mknod,link,symlink,mkdirat,mknodat,linkat,symlinkat,openat,open_by_handle_at,open,close,rename,renameat,truncate,ftruncate,rmdir,unlink,unlinkat -F exit=-EPERM -k access
--a always,exit -F arch=b32 -S creat,mkdir,mknod,link,symlink,mkdirat,mknodat,linkat,symlinkat,openat,open_by_handle_at,open,close,rename,renameat,truncate,ftruncate,rmdir,unlink,unlinkat -F exit=-EACCES -k access
--a always,exit -F arch=b32 -S creat,mkdir,mknod,link,symlink,mkdirat,mknodat,linkat,symlinkat,openat,open_by_handle_at,open,close,rename,renameat,truncate,ftruncate,rmdir,unlink,unlinkat -F exit=-EPERM -k access
+-a exit,always -F arch=b64 -S creat,mkdir,mknod,link,symlink,mkdirat,mknodat,linkat,symlinkat,openat,open_by_handle_at,open,close,rename,renameat,truncate,ftruncate,rmdir,unlink,unlinkat -F exit=-EACCES -k access
+-a exit,always -F arch=b64 -S creat,mkdir,mknod,link,symlink,mkdirat,mknodat,linkat,symlinkat,openat,open_by_handle_at,open,close,rename,renameat,truncate,ftruncate,rmdir,unlink,unlinkat -F exit=-EPERM -k access
+-a exit,always -F arch=b32 -S creat,mkdir,mknod,link,symlink,mkdirat,mknodat,linkat,symlinkat,openat,open_by_handle_at,open,close,rename,renameat,truncate,ftruncate,rmdir,unlink,unlinkat -F exit=-EACCES -k access
+-a exit,always -F arch=b32 -S creat,mkdir,mknod,link,symlink,mkdirat,mknodat,linkat,symlinkat,openat,open_by_handle_at,open,close,rename,renameat,truncate,ftruncate,rmdir,unlink,unlinkat -F exit=-EPERM -k access
 
--a always,exit -F perm=a -F exit=-EACCES -k access
--a always,exit -F perm=a -F exit=-EPERM -k access
+-a exit,always -F perm=a -F exit=-EACCES -k access
+-a exit,always -F perm=a -F exit=-EPERM -k access
 
 ## Audit the execution of password commands
--a always,exit -F path=/usr/bin/passwd -F perm=x -k privileged-passwd
+-a exit,always -F path=/usr/bin/passwd -F perm=x -k privileged-passwd
 
--a always,exit -F path=/sbin/unix_chkpwd -F perm=x -k privileged-passwd
+-a exit,always -F path=/sbin/unix_chkpwd -F perm=x -k privileged-passwd
 
--a always,exit -F path=/usr/bin/gpasswd -F perm=x -k privileged-passwd
+-a exit,always -F path=/usr/bin/gpasswd -F perm=x -k privileged-passwd
 
--a always,exit -F path=/usr/bin/chage -F perm=x -k privileged-passwd
+-a exit,always -F path=/usr/bin/chage -F perm=x -k privileged-passwd
 
--a always,exit -F path=/usr/sbin/userhelper -F perm=x -k privileged-passwd
+-a exit,always -F path=/usr/sbin/userhelper -F perm=x -k privileged-passwd
 
 ## Audit the execution of privilege-related commands
--a always,exit -F path=/bin/su -F perm=x -k privileged-priv_change
+-a exit,always -F path=/bin/su -F perm=x -k privileged-priv_change
 
--a always,exit -F path=/usr/bin/sudo -F perm=x -k privileged-priv_change
+-a exit,always -F path=/usr/bin/sudo -F perm=x -k privileged-priv_change
 
--a always,exit -F path=/usr/bin/newgrp -F perm=x -k privileged-priv_change
+-a exit,always -F path=/usr/bin/newgrp -F perm=x -k privileged-priv_change
 
--a always,exit -F path=/usr/bin/chsh -F perm=x -k privileged-priv_change
+-a exit,always -F path=/usr/bin/chsh -F perm=x -k privileged-priv_change
 
--a always,exit -F path=/usr/bin/sudoedit -F perm=x -k privileged-priv_change
+-a exit,always -F path=/usr/bin/sudoedit -F perm=x -k privileged-priv_change
 
 ## Audit the execution of postfix-related commands
--a always,exit -F path=/usr/sbin/postdrop -F perm=x -k privileged-postfix
+-a exit,always -F path=/usr/sbin/postdrop -F perm=x -k privileged-postfix
 
--a always,exit -F path=/usr/sbin/postqueue -F perm=x -k privileged-postfix
+-a exit,always -F path=/usr/sbin/postqueue -F perm=x -k privileged-postfix
 
 ## Audit the execution of the ssh-keysign command
--a always,exit -F path=/usr/libexec/openssh/ssh-keysign -F perm=x -k privileged-ssh
+-a exit,always -F path=/usr/libexec/openssh/ssh-keysign -F perm=x -k privileged-ssh
 
 ## Audit the execution of the crontab command
--a always,exit -F path=/usr/bin/crontab -F perm=x -k privileged-cron
+-a exit,always -F path=/usr/bin/crontab -F perm=x -k privileged-cron
 
 ## Audit the execution of the pam_timestamp_check command
--a always,exit -F path=/sbin/pam_timestamp_check -F perm=x -k privileged-pam
+-a exit,always -F path=/sbin/pam_timestamp_check -F perm=x -k privileged-pam
 
 ## Permissions auditing separated by chown, chmod, and attr
 
--a always,exit -F arch=b64 -S chown,fchown,fchownat,lchown -k chown
--a always,exit -F arch=b32 -S chown,fchown,fchownat,lchown -k chown
+-a exit,always -F arch=b64 -S chown,fchown,fchownat,lchown -k chown
+-a exit,always -F arch=b32 -S chown,fchown,fchownat,lchown -k chown
 
--a always,exit -F arch=b64 -S setxattr,lsetxattr,fsetxattr,removexattr,lremovexattr,fremovexattr -k attr
--a always,exit -F arch=b32 -S setxattr,lsetxattr,fsetxattr,removexattr,lremovexattr,fremovexattr -k attr
+-a exit,always -F arch=b64 -S setxattr,lsetxattr,fsetxattr,removexattr,lremovexattr,fremovexattr -k attr
+-a exit,always -F arch=b32 -S setxattr,lsetxattr,fsetxattr,removexattr,lremovexattr,fremovexattr -k attr
 
 ## Audit useful items that someone does when su'ing to root.
--a always,exit -F arch=b64 -F auid!=0 -F uid=0 -S capset,mknod,mknodat,pivot_root,quotactl,setsid,adjtimex,settimeofday,setuid,swapoff,swapon -k su-root-activity
--a always,exit -F arch=b32 -F auid!=0 -F uid=0 -S capset,mknod,mknodat,pivot_root,quotactl,setsid,adjtimex,settimeofday,setuid,swapoff,swapon -k su-root-activity
+-a exit,always -F arch=b64 -F auid!=0 -F uid=0 -S capset,mknod,mknodat,pivot_root,quotactl,setsid,adjtimex,settimeofday,setuid,swapoff,swapon -k su-root-activity
+-a exit,always -F arch=b32 -F auid!=0 -F uid=0 -S capset,mknod,mknodat,pivot_root,quotactl,setsid,adjtimex,settimeofday,setuid,swapoff,swapon -k su-root-activity
 
 ## Audit the execution of suid and sgid binaries.
--a always,exit -F arch=b64 -F euid=0 -F uid!=0 -S execve -k suid-root-exec
--a always,exit -F arch=b32 -F euid=0 -F uid!=0 -S execve -k suid-root-exec
+-a exit,always -F arch=b64 -F euid=0 -F uid!=0 -S execve -k suid-root-exec
+-a exit,always -F arch=b32 -F euid=0 -F uid!=0 -S execve -k suid-root-exec
 
 ## Audit the loading and unloading of kernel modules.
 -w /sbin/insmod -p x -k modules
 -w /sbin/rmmod -p x -k modules
 -w /sbin/modprobe -p x -k modules
 
--a always,exit -F arch=b64 -S create_module,init_module,finit_module,delete_module -k modules
--a always,exit -F arch=b32 -S create_module,init_module,finit_module,delete_module -k modules
+-a exit,always -F arch=b64 -S create_module,init_module,finit_module,delete_module -k modules
+-a exit,always -F arch=b32 -S create_module,init_module,finit_module,delete_module -k modules
 
 ## Audit things that could affect time
--a always,exit -F arch=b64 -S adjtimex,settimeofday -k audit_time_rules
--a always,exit -F arch=b64 -S clock_settime -F a0=0x0 -k audit_time_rules
--a always,exit -F arch=b32 -S adjtimex,stime,settimeofday -k audit_time_rules
--a always,exit -F arch=b32 -S clock_settime -F a0=0x0 -k audit_time_rules
+-a exit,always -F arch=b64 -S adjtimex,settimeofday -k audit_time_rules
+-a exit,always -F arch=b64 -S clock_settime -F a0=0x0 -k audit_time_rules
+-a exit,always -F arch=b32 -S adjtimex,stime,settimeofday -k audit_time_rules
+-a exit,always -F arch=b32 -S clock_settime -F a0=0x0 -k audit_time_rules
 
 -w /etc/localtime -p wa -k audit_time_rules
 
 ## Audit things that could affect system locale
--a always,exit -F arch=b64 -S sethostname,setdomainname -k audit_network_modifications
--a always,exit -F arch=b32 -S sethostname,setdomainname -k audit_network_modifications
+-a exit,always -F arch=b64 -S sethostname,setdomainname -k audit_network_modifications
+-a exit,always -F arch=b32 -S sethostname,setdomainname -k audit_network_modifications
 
 -w /etc/issue -p wa -k audit_network_modifications
 -w /etc/issue.net -p wa -k audit_network_modifications
@@ -95,12 +95,12 @@
 -w /etc/sysconfig/network -p wa -k audit_network_modifications
 
 ## Audit mount operations
--a always,exit -F arch=b64 -S mount,umount2 -k mount
--a always,exit -F arch=b32 -S mount,umount,umount2 -k mount
+-a exit,always -F arch=b64 -S mount,umount2 -k mount
+-a exit,always -F arch=b32 -S mount,umount,umount2 -k mount
 
--a always,exit -F arch=b64 -F path=/bin/mount -k mount
--a always,exit -F arch=b32 -F path=/bin/mount -k mount
--a always,exit -F path=/bin/umount -F perm=x -k mount
+-a exit,always -F arch=b64 -F path=/bin/mount -k mount
+-a exit,always -F arch=b32 -F path=/bin/mount -k mount
+-a exit,always -F path=/bin/umount -F perm=x -k mount
 
 ## Audit local accounts
 -w /etc/passwd -p wa -k audit_account_changes
@@ -201,13 +201,13 @@
 -w /etc/yum -p wa -k yum-config
 -w /etc/yum.conf -p wa -k yum-config
 -w /etc/yum.repos.d -p wa -k yum-config
--a always,exit -F arch=b64 -S ptrace -F a0=0x4 -k paranoid_code_injection
--a always,exit -F arch=b64 -S ptrace -F a0=0x5 -k paranoid_data_injection
--a always,exit -F arch=b64 -S ptrace -F a0=0x6 -k paranoid_register_injection
--a always,exit -F arch=b64 -S ptrace -k paranoid
--a always,exit -F arch=b32 -S ptrace -F a0=0x4 -k paranoid_code_injection
--a always,exit -F arch=b32 -S ptrace -F a0=0x5 -k paranoid_data_injection
--a always,exit -F arch=b32 -S ptrace -F a0=0x6 -k paranoid_register_injection
--a always,exit -F arch=b32 -S ptrace -k paranoid
--a always,exit -F arch=b64 -S personality -k paranoid
--a always,exit -F arch=b32 -S personality -k paranoid
+-a exit,always -F arch=b64 -S ptrace -F a0=0x4 -k paranoid_code_injection
+-a exit,always -F arch=b64 -S ptrace -F a0=0x5 -k paranoid_data_injection
+-a exit,always -F arch=b64 -S ptrace -F a0=0x6 -k paranoid_register_injection
+-a exit,always -F arch=b64 -S ptrace -k paranoid
+-a exit,always -F arch=b32 -S ptrace -F a0=0x4 -k paranoid_code_injection
+-a exit,always -F arch=b32 -S ptrace -F a0=0x5 -k paranoid_data_injection
+-a exit,always -F arch=b32 -S ptrace -F a0=0x6 -k paranoid_register_injection
+-a exit,always -F arch=b32 -S ptrace -k paranoid
+-a exit,always -F arch=b64 -S personality -k paranoid
+-a exit,always -F arch=b32 -S personality -k paranoid

--- a/spec/classes/config/audit_profiles/expected/simp_el6_basic_rules.txt
+++ b/spec/classes/config/audit_profiles/expected/simp_el6_basic_rules.txt
@@ -3,9 +3,7 @@
 # may be a sign of someone exploiting a hole in the API.
 -a exit,always -F arch=b32 -S all -F key=32bit-api
 -a exit,always -F arch=b64 -S accept -F a0=2 -F key=ipv4_in
--a exit,always -F arch=b32 -S accept -F a0=2 -F key=ipv4_in
 -a exit,always -F arch=b64 -S accept -F a0=10 -F key=ipv6_in
--a exit,always -F arch=b32 -S accept -F a0=10 -F key=ipv6_in
 
 ## Audit unsuccessful file operations
 -a exit,always -F arch=b64 -S creat,mkdir,mknod,link,symlink,mkdirat,mknodat,linkat,symlinkat,openat,open_by_handle_at,open,close,rename,renameat,truncate,ftruncate,rmdir,unlink,unlinkat -F exit=-EACCES -k access

--- a/spec/classes/config/audit_profiles/expected/simp_el6_insane_rules.txt
+++ b/spec/classes/config/audit_profiles/expected/simp_el6_insane_rules.txt
@@ -1,14 +1,13 @@
 #### auditd::config::audit_profiles::simp Audit Rules ####
+# 64-bit systems should generally never call the 32-bit API. 32-bit syscalls
+# may be a sign of someone exploiting a hole in the API.
+-a always,exit -F arch=b32 -S all -F key=32bit-api
+-a always,exit -F arch=b64 -S accept -F a0=2 -F key=ipv4_in
+-a always,exit -F arch=b32 -S accept -F a0=2 -F key=ipv4_in
+-a always,exit -F arch=b64 -S accept -F a0=10 -F key=ipv6_in
+-a always,exit -F arch=b32 -S accept -F a0=10 -F key=ipv6_in
 
 ## Audit unsuccessful file operations
-# CCE-26712-0
-# CCE-26651-0
-# RHEL-07-030500
-# RHEL-07-030510
-# RHEL-07-030520
-# RHEL-07-030530
-# RHEL-07-030540
-# RHEL-07-030550
 -a always,exit -F arch=b64 -S creat,mkdir,mknod,link,symlink,mkdirat,mknodat,linkat,symlinkat,openat,open_by_handle_at,open,close,rename,renameat,truncate,ftruncate,rmdir,unlink,unlinkat -F exit=-EACCES -k access
 -a always,exit -F arch=b64 -S creat,mkdir,mknod,link,symlink,mkdirat,mknodat,linkat,symlinkat,openat,open_by_handle_at,open,close,rename,renameat,truncate,ftruncate,rmdir,unlink,unlinkat -F exit=-EPERM -k access
 -a always,exit -F arch=b32 -S creat,mkdir,mknod,link,symlink,mkdirat,mknodat,linkat,symlinkat,openat,open_by_handle_at,open,close,rename,renameat,truncate,ftruncate,rmdir,unlink,unlinkat -F exit=-EACCES -k access
@@ -18,136 +17,77 @@
 -a always,exit -F perm=a -F exit=-EPERM -k access
 
 ## Audit the execution of password commands
-# RHEL-07-030630
 -a always,exit -F path=/usr/bin/passwd -F perm=x -k privileged-passwd
 
-# RHEL-07-030640
 -a always,exit -F path=/sbin/unix_chkpwd -F perm=x -k privileged-passwd
 
-# RHEL-07-030650
 -a always,exit -F path=/usr/bin/gpasswd -F perm=x -k privileged-passwd
 
-# RHEL-07-030660
 -a always,exit -F path=/usr/bin/chage -F perm=x -k privileged-passwd
 
-# RHEL-07-030670
 -a always,exit -F path=/usr/sbin/userhelper -F perm=x -k privileged-passwd
 
 ## Audit the execution of privilege-related commands
-# RHEL-07-030680
 -a always,exit -F path=/bin/su -F perm=x -k privileged-priv_change
 
-# RHEL-07-030690
 -a always,exit -F path=/usr/bin/sudo -F perm=x -k privileged-priv_change
 
-# RHEL-07-030710
 -a always,exit -F path=/usr/bin/newgrp -F perm=x -k privileged-priv_change
 
-# RHEL-07-030720
 -a always,exit -F path=/usr/bin/chsh -F perm=x -k privileged-priv_change
 
-# RHEL-07-030730
 -a always,exit -F path=/usr/bin/sudoedit -F perm=x -k privileged-priv_change
 
 ## Audit the execution of postfix-related commands
-# RHEL-07-030760
 -a always,exit -F path=/usr/sbin/postdrop -F perm=x -k privileged-postfix
 
-# RHEL-07-030770
 -a always,exit -F path=/usr/sbin/postqueue -F perm=x -k privileged-postfix
 
 ## Audit the execution of the ssh-keysign command
-# RHEL-07-030780
 -a always,exit -F path=/usr/libexec/openssh/ssh-keysign -F perm=x -k privileged-ssh
 
 ## Audit the execution of the crontab command
-# RHEL-07-030800
 -a always,exit -F path=/usr/bin/crontab -F perm=x -k privileged-cron
 
 ## Audit the execution of the pam_timestamp_check command
-# RHEL-07-030810
 -a always,exit -F path=/sbin/pam_timestamp_check -F perm=x -k privileged-pam
 
 ## Permissions auditing separated by chown, chmod, and attr
-# CCE-26280-8
-# CCE-27173-4
-# CCE-27174-2
-# CCE-27175-9
-# CCE-27177-5
-# CCE-27178-3
-# CCE-27179-1
-# CCE-27180-9
-# CCE-27181-7
-# CCE-27182-5
-# CCE-27183-3
-# CCE-27184-1
-# CCE-27185-8
 
-# RHEL-07-030370
-# RHEL-07-030380
-# RHEL-07-030390
-# RHEL-07-030400
 -a always,exit -F arch=b64 -S chown,fchown,fchownat,lchown -k chown
 -a always,exit -F arch=b32 -S chown,fchown,fchownat,lchown -k chown
 
-# RHEL-07-030440
-# RHEL-07-030450
-# RHEL-07-030460
-# RHEL-07-030470
-# RHEL-07-030480
-# RHEL-07-030490
 -a always,exit -F arch=b64 -S setxattr,lsetxattr,fsetxattr,removexattr,lremovexattr,fremovexattr -k attr
 -a always,exit -F arch=b32 -S setxattr,lsetxattr,fsetxattr,removexattr,lremovexattr,fremovexattr -k attr
 
 ## Audit useful items that someone does when su'ing to root.
-# Had to add an entry in the default_drop rules file for getting rid of
-# anonymous records.  They are only moderately useful and contain *way*
-# too much noise since this covers things like cron as well.
 -a always,exit -F arch=b64 -F auid!=0 -F uid=0 -S capset,mknod,mknodat,pivot_root,quotactl,setsid,adjtimex,settimeofday,setuid,swapoff,swapon,execve,rename,renameat,rmdir,unlink,unlinkat,write,chown,fchown,fchownat,lchown,creat,fork,vfork,link,linkat,symlink,symlinkat,mkdir,mkdirat -k su-root-activity
 -a always,exit -F arch=b32 -F auid!=0 -F uid=0 -S capset,mknod,mknodat,pivot_root,quotactl,setsid,adjtimex,settimeofday,setuid,swapoff,swapon,execve,rename,renameat,rmdir,unlink,unlinkat,write,chown,fchown,fchownat,lchown,creat,fork,vfork,link,linkat,symlink,symlinkat,mkdir,mkdirat -k su-root-activity
 
 ## Audit the execution of suid and sgid binaries.
-# CCE-26457-2
-# RHEL-07-030360
 -a always,exit -F arch=b64 -F euid=0 -F uid!=0 -S execve -k suid-root-exec
 -a always,exit -F arch=b32 -F euid=0 -F uid!=0 -S execve -k suid-root-exec
 
 ## Audit the loading and unloading of kernel modules.
-# CCE-26611-4
-
-# RHEL-07-030840
 -w /sbin/insmod -p x -k modules
-
-# RHEL-07-030850
 -w /sbin/rmmod -p x -k modules
-
-# RHEL-07-030860
 -w /sbin/modprobe -p x -k modules
 
-# RHEL-07-030819
-# RHEL-07-030820
-# RHEL-07-030821
-# RHEL-07-030830
 -a always,exit -F arch=b64 -S create_module,init_module,finit_module,delete_module -k modules
 -a always,exit -F arch=b32 -S create_module,init_module,finit_module,delete_module -k modules
 
 ## Audit things that could affect time
-# CCE-27172-6
-# CCE-27203-9
-# CCE-27169-2
-# CCE-27170-0
--a always,exit -F arch=b32 -S adjtimex,stime,settimeofday -k audit_time_rules
 -a always,exit -F arch=b64 -S adjtimex,settimeofday -k audit_time_rules
--a always,exit -F arch=b32 -S clock_settime -F a0=0x0 -k audit_time_rules
 -a always,exit -F arch=b64 -S clock_settime -F a0=0x0 -k audit_time_rules
+-a always,exit -F arch=b32 -S adjtimex,stime,settimeofday -k audit_time_rules
+-a always,exit -F arch=b32 -S clock_settime -F a0=0x0 -k audit_time_rules
 
-# CCE-27172-6
 -w /etc/localtime -p wa -k audit_time_rules
 
 ## Audit things that could affect system locale
-# CCE-26648-6
--a always,exit -F arch=b32 -S sethostname,setdomainname -k audit_network_modifications
 -a always,exit -F arch=b64 -S sethostname,setdomainname -k audit_network_modifications
+-a always,exit -F arch=b32 -S sethostname,setdomainname -k audit_network_modifications
+
 -w /etc/issue -p wa -k audit_network_modifications
 -w /etc/issue.net -p wa -k audit_network_modifications
 -w /etc/hosts -p wa -k audit_network_modifications
@@ -155,68 +95,59 @@
 -w /etc/sysconfig/network -p wa -k audit_network_modifications
 
 ## Audit mount operations
-# CCE-26573-6
-#
-# RHEL-07-030740
-# RHEL-07-030750
--a always,exit -F arch=b32 -S mount,umount,umount2 -k mount
 -a always,exit -F arch=b64 -S mount,umount2 -k mount
+-a always,exit -F arch=b32 -S mount,umount,umount2 -k mount
+
 -a always,exit -F arch=b64 -F path=/bin/mount -k mount
 -a always,exit -F arch=b32 -F path=/bin/mount -k mount
 -a always,exit -F path=/bin/umount -F perm=x -k mount
 
 ## Audit local accounts
-# CCE-26664-3
-#
-# RHEL-07-030870
 -w /etc/passwd -p wa -k audit_account_changes
-
-# RHEL-07-030871
 -w /etc/group -p wa -k audit_account_changes
-
-# RHEL-07-030872
 -w /etc/gshadow -p wa -k audit_account_changes
-
-# RHEL-07-030873
 -w /etc/shadow -p wa -k audit_account_changes
-
-# RHEL-07-030874
 -w /etc/security/opasswd -p wa -k audit_account_changes
-
 -w /etc/passwd- -p wa -k audit_account_changes
 -w /etc/group- -p wa -k audit_account_changes
 -w /etc/shadow- -p wa -k audit_account_changes
 
 ## Audit selinux policy
-# CCE-26657-7
 -w /etc/selinux/ -p wa -k MAC-policy
 -w /usr/share/selinux/ -p wa -k MAC-policy
 
 ## Audit login files
-# CCE-26691-6
-#
-# RHEL-07-030600
 -w /var/log/tallylog -p wa -k logins
-
-# RHEL-07-030610
 -w /var/run/faillock -p wa -k logins
-
-# RHEL-07-030620
 -w /var/log/lastlog -p wa -k logins
-
 -w /var/log/faillog -p wa -k logins
 
 ## Audit session files
-# CCE-26610-6
 -w /var/run/utmp -p wa -k session
 -w /var/log/btmp -p wa -k session
 -w /var/log/wtmp -p wa -k session
 
 ## Audit sudoers configuration files
-# CCE-26662-7
-# RHEL-07-030700
 -w /etc/sudoers -p wa -k CFG_sys
 -w /etc/sudoers.d/ -p wa -k CFG_sys
+
+## Audit accesses to the audit trail
+-w /usr/sbin/aulast -p x -k access-audit-trail
+-w /usr/sbin/aulastlogin -p x -k access-audit-trail
+-w /usr/sbin/aureport -p x -k access-audit-trail
+-w /usr/sbin/ausearch -p x -k access-audit-trail
+-w /usr/sbin/auvirt -p x -k access-audit-trail
+
+## Audit suspicious applications
+-w /usr/bin/nc -p x -k suspicious_apps
+-w /usr/bin/ncat -p x -k suspicious_apps
+-w /usr/bin/nmap -p x -k suspicious_apps
+-w /usr/bin/rawshark -p x -k suspicious_apps
+-w /usr/bin/socat -p x -k suspicious_apps
+-w /usr/bin/wireshark -p x -k suspicious_apps
+-w /usr/sbin/tcpdump -p x -k suspicious_apps
+-w /usr/sbin/traceroute -p x -k suspicious_apps
+-w /usr/sbin/traceroute6 -p x -k suspicious_apps
 
 ## Generally good things to audit.
 -w /boot/grub/grub.conf -p wa -k CFG_grub
@@ -228,8 +159,6 @@
 -w /etc/hosts.deny -p wa -k CFG_sys
 -w /etc/initlog.conf -p wa -k CFG_sys
 -w /etc/inittab -p wa -k CFG_sys
--w /etc/issue -p wa -k CFG_sys
--w /etc/issue.net -p wa -k CFG_sys
 -w /etc/krb5.conf -p wa -k CFG_sys
 -w /etc/ld.so.conf -p wa -k CFG_sys
 -w /etc/ld.so.conf.d -p wa -k CFG_sys
@@ -272,7 +201,13 @@
 -w /etc/yum -p wa -k yum-config
 -w /etc/yum.conf -p wa -k yum-config
 -w /etc/yum.repos.d -p wa -k yum-config
--a always,exit -F arch=b32 -S ptrace -k paranoid
+-a always,exit -F arch=b64 -S ptrace -F a0=0x4 -k paranoid_code_injection
+-a always,exit -F arch=b64 -S ptrace -F a0=0x5 -k paranoid_data_injection
+-a always,exit -F arch=b64 -S ptrace -F a0=0x6 -k paranoid_register_injection
 -a always,exit -F arch=b64 -S ptrace -k paranoid
--a always,exit -F arch=b32 -S personality -k paranoid
+-a always,exit -F arch=b32 -S ptrace -F a0=0x4 -k paranoid_code_injection
+-a always,exit -F arch=b32 -S ptrace -F a0=0x5 -k paranoid_data_injection
+-a always,exit -F arch=b32 -S ptrace -F a0=0x6 -k paranoid_register_injection
+-a always,exit -F arch=b32 -S ptrace -k paranoid
 -a always,exit -F arch=b64 -S personality -k paranoid
+-a always,exit -F arch=b32 -S personality -k paranoid

--- a/spec/classes/config/audit_profiles/expected/simp_el6_insane_rules.txt
+++ b/spec/classes/config/audit_profiles/expected/simp_el6_insane_rules.txt
@@ -3,9 +3,7 @@
 # may be a sign of someone exploiting a hole in the API.
 -a exit,always -F arch=b32 -S all -F key=32bit-api
 -a exit,always -F arch=b64 -S accept -F a0=2 -F key=ipv4_in
--a exit,always -F arch=b32 -S accept -F a0=2 -F key=ipv4_in
 -a exit,always -F arch=b64 -S accept -F a0=10 -F key=ipv6_in
--a exit,always -F arch=b32 -S accept -F a0=10 -F key=ipv6_in
 
 ## Audit unsuccessful file operations
 -a exit,always -F arch=b64 -S creat,mkdir,mknod,link,symlink,mkdirat,mknodat,linkat,symlinkat,openat,open_by_handle_at,open,close,rename,renameat,truncate,ftruncate,rmdir,unlink,unlinkat -F exit=-EACCES -k access

--- a/spec/classes/config/audit_profiles/expected/simp_el6_insane_rules.txt
+++ b/spec/classes/config/audit_profiles/expected/simp_el6_insane_rules.txt
@@ -1,92 +1,92 @@
 #### auditd::config::audit_profiles::simp Audit Rules ####
 # 64-bit systems should generally never call the 32-bit API. 32-bit syscalls
 # may be a sign of someone exploiting a hole in the API.
--a always,exit -F arch=b32 -S all -F key=32bit-api
--a always,exit -F arch=b64 -S accept -F a0=2 -F key=ipv4_in
--a always,exit -F arch=b32 -S accept -F a0=2 -F key=ipv4_in
--a always,exit -F arch=b64 -S accept -F a0=10 -F key=ipv6_in
--a always,exit -F arch=b32 -S accept -F a0=10 -F key=ipv6_in
+-a exit,always -F arch=b32 -S all -F key=32bit-api
+-a exit,always -F arch=b64 -S accept -F a0=2 -F key=ipv4_in
+-a exit,always -F arch=b32 -S accept -F a0=2 -F key=ipv4_in
+-a exit,always -F arch=b64 -S accept -F a0=10 -F key=ipv6_in
+-a exit,always -F arch=b32 -S accept -F a0=10 -F key=ipv6_in
 
 ## Audit unsuccessful file operations
--a always,exit -F arch=b64 -S creat,mkdir,mknod,link,symlink,mkdirat,mknodat,linkat,symlinkat,openat,open_by_handle_at,open,close,rename,renameat,truncate,ftruncate,rmdir,unlink,unlinkat -F exit=-EACCES -k access
--a always,exit -F arch=b64 -S creat,mkdir,mknod,link,symlink,mkdirat,mknodat,linkat,symlinkat,openat,open_by_handle_at,open,close,rename,renameat,truncate,ftruncate,rmdir,unlink,unlinkat -F exit=-EPERM -k access
--a always,exit -F arch=b32 -S creat,mkdir,mknod,link,symlink,mkdirat,mknodat,linkat,symlinkat,openat,open_by_handle_at,open,close,rename,renameat,truncate,ftruncate,rmdir,unlink,unlinkat -F exit=-EACCES -k access
--a always,exit -F arch=b32 -S creat,mkdir,mknod,link,symlink,mkdirat,mknodat,linkat,symlinkat,openat,open_by_handle_at,open,close,rename,renameat,truncate,ftruncate,rmdir,unlink,unlinkat -F exit=-EPERM -k access
+-a exit,always -F arch=b64 -S creat,mkdir,mknod,link,symlink,mkdirat,mknodat,linkat,symlinkat,openat,open_by_handle_at,open,close,rename,renameat,truncate,ftruncate,rmdir,unlink,unlinkat -F exit=-EACCES -k access
+-a exit,always -F arch=b64 -S creat,mkdir,mknod,link,symlink,mkdirat,mknodat,linkat,symlinkat,openat,open_by_handle_at,open,close,rename,renameat,truncate,ftruncate,rmdir,unlink,unlinkat -F exit=-EPERM -k access
+-a exit,always -F arch=b32 -S creat,mkdir,mknod,link,symlink,mkdirat,mknodat,linkat,symlinkat,openat,open_by_handle_at,open,close,rename,renameat,truncate,ftruncate,rmdir,unlink,unlinkat -F exit=-EACCES -k access
+-a exit,always -F arch=b32 -S creat,mkdir,mknod,link,symlink,mkdirat,mknodat,linkat,symlinkat,openat,open_by_handle_at,open,close,rename,renameat,truncate,ftruncate,rmdir,unlink,unlinkat -F exit=-EPERM -k access
 
--a always,exit -F perm=a -F exit=-EACCES -k access
--a always,exit -F perm=a -F exit=-EPERM -k access
+-a exit,always -F perm=a -F exit=-EACCES -k access
+-a exit,always -F perm=a -F exit=-EPERM -k access
 
 ## Audit the execution of password commands
--a always,exit -F path=/usr/bin/passwd -F perm=x -k privileged-passwd
+-a exit,always -F path=/usr/bin/passwd -F perm=x -k privileged-passwd
 
--a always,exit -F path=/sbin/unix_chkpwd -F perm=x -k privileged-passwd
+-a exit,always -F path=/sbin/unix_chkpwd -F perm=x -k privileged-passwd
 
--a always,exit -F path=/usr/bin/gpasswd -F perm=x -k privileged-passwd
+-a exit,always -F path=/usr/bin/gpasswd -F perm=x -k privileged-passwd
 
--a always,exit -F path=/usr/bin/chage -F perm=x -k privileged-passwd
+-a exit,always -F path=/usr/bin/chage -F perm=x -k privileged-passwd
 
--a always,exit -F path=/usr/sbin/userhelper -F perm=x -k privileged-passwd
+-a exit,always -F path=/usr/sbin/userhelper -F perm=x -k privileged-passwd
 
 ## Audit the execution of privilege-related commands
--a always,exit -F path=/bin/su -F perm=x -k privileged-priv_change
+-a exit,always -F path=/bin/su -F perm=x -k privileged-priv_change
 
--a always,exit -F path=/usr/bin/sudo -F perm=x -k privileged-priv_change
+-a exit,always -F path=/usr/bin/sudo -F perm=x -k privileged-priv_change
 
--a always,exit -F path=/usr/bin/newgrp -F perm=x -k privileged-priv_change
+-a exit,always -F path=/usr/bin/newgrp -F perm=x -k privileged-priv_change
 
--a always,exit -F path=/usr/bin/chsh -F perm=x -k privileged-priv_change
+-a exit,always -F path=/usr/bin/chsh -F perm=x -k privileged-priv_change
 
--a always,exit -F path=/usr/bin/sudoedit -F perm=x -k privileged-priv_change
+-a exit,always -F path=/usr/bin/sudoedit -F perm=x -k privileged-priv_change
 
 ## Audit the execution of postfix-related commands
--a always,exit -F path=/usr/sbin/postdrop -F perm=x -k privileged-postfix
+-a exit,always -F path=/usr/sbin/postdrop -F perm=x -k privileged-postfix
 
--a always,exit -F path=/usr/sbin/postqueue -F perm=x -k privileged-postfix
+-a exit,always -F path=/usr/sbin/postqueue -F perm=x -k privileged-postfix
 
 ## Audit the execution of the ssh-keysign command
--a always,exit -F path=/usr/libexec/openssh/ssh-keysign -F perm=x -k privileged-ssh
+-a exit,always -F path=/usr/libexec/openssh/ssh-keysign -F perm=x -k privileged-ssh
 
 ## Audit the execution of the crontab command
--a always,exit -F path=/usr/bin/crontab -F perm=x -k privileged-cron
+-a exit,always -F path=/usr/bin/crontab -F perm=x -k privileged-cron
 
 ## Audit the execution of the pam_timestamp_check command
--a always,exit -F path=/sbin/pam_timestamp_check -F perm=x -k privileged-pam
+-a exit,always -F path=/sbin/pam_timestamp_check -F perm=x -k privileged-pam
 
 ## Permissions auditing separated by chown, chmod, and attr
 
--a always,exit -F arch=b64 -S chown,fchown,fchownat,lchown -k chown
--a always,exit -F arch=b32 -S chown,fchown,fchownat,lchown -k chown
+-a exit,always -F arch=b64 -S chown,fchown,fchownat,lchown -k chown
+-a exit,always -F arch=b32 -S chown,fchown,fchownat,lchown -k chown
 
--a always,exit -F arch=b64 -S setxattr,lsetxattr,fsetxattr,removexattr,lremovexattr,fremovexattr -k attr
--a always,exit -F arch=b32 -S setxattr,lsetxattr,fsetxattr,removexattr,lremovexattr,fremovexattr -k attr
+-a exit,always -F arch=b64 -S setxattr,lsetxattr,fsetxattr,removexattr,lremovexattr,fremovexattr -k attr
+-a exit,always -F arch=b32 -S setxattr,lsetxattr,fsetxattr,removexattr,lremovexattr,fremovexattr -k attr
 
 ## Audit useful items that someone does when su'ing to root.
--a always,exit -F arch=b64 -F auid!=0 -F uid=0 -S capset,mknod,mknodat,pivot_root,quotactl,setsid,adjtimex,settimeofday,setuid,swapoff,swapon,execve,rename,renameat,rmdir,unlink,unlinkat,write,chown,fchown,fchownat,lchown,creat,fork,vfork,link,linkat,symlink,symlinkat,mkdir,mkdirat -k su-root-activity
--a always,exit -F arch=b32 -F auid!=0 -F uid=0 -S capset,mknod,mknodat,pivot_root,quotactl,setsid,adjtimex,settimeofday,setuid,swapoff,swapon,execve,rename,renameat,rmdir,unlink,unlinkat,write,chown,fchown,fchownat,lchown,creat,fork,vfork,link,linkat,symlink,symlinkat,mkdir,mkdirat -k su-root-activity
+-a exit,always -F arch=b64 -F auid!=0 -F uid=0 -S capset,mknod,mknodat,pivot_root,quotactl,setsid,adjtimex,settimeofday,setuid,swapoff,swapon,execve,rename,renameat,rmdir,unlink,unlinkat,write,chown,fchown,fchownat,lchown,creat,fork,vfork,link,linkat,symlink,symlinkat,mkdir,mkdirat -k su-root-activity
+-a exit,always -F arch=b32 -F auid!=0 -F uid=0 -S capset,mknod,mknodat,pivot_root,quotactl,setsid,adjtimex,settimeofday,setuid,swapoff,swapon,execve,rename,renameat,rmdir,unlink,unlinkat,write,chown,fchown,fchownat,lchown,creat,fork,vfork,link,linkat,symlink,symlinkat,mkdir,mkdirat -k su-root-activity
 
 ## Audit the execution of suid and sgid binaries.
--a always,exit -F arch=b64 -F euid=0 -F uid!=0 -S execve -k suid-root-exec
--a always,exit -F arch=b32 -F euid=0 -F uid!=0 -S execve -k suid-root-exec
+-a exit,always -F arch=b64 -F euid=0 -F uid!=0 -S execve -k suid-root-exec
+-a exit,always -F arch=b32 -F euid=0 -F uid!=0 -S execve -k suid-root-exec
 
 ## Audit the loading and unloading of kernel modules.
 -w /sbin/insmod -p x -k modules
 -w /sbin/rmmod -p x -k modules
 -w /sbin/modprobe -p x -k modules
 
--a always,exit -F arch=b64 -S create_module,init_module,finit_module,delete_module -k modules
--a always,exit -F arch=b32 -S create_module,init_module,finit_module,delete_module -k modules
+-a exit,always -F arch=b64 -S create_module,init_module,finit_module,delete_module -k modules
+-a exit,always -F arch=b32 -S create_module,init_module,finit_module,delete_module -k modules
 
 ## Audit things that could affect time
--a always,exit -F arch=b64 -S adjtimex,settimeofday -k audit_time_rules
--a always,exit -F arch=b64 -S clock_settime -F a0=0x0 -k audit_time_rules
--a always,exit -F arch=b32 -S adjtimex,stime,settimeofday -k audit_time_rules
--a always,exit -F arch=b32 -S clock_settime -F a0=0x0 -k audit_time_rules
+-a exit,always -F arch=b64 -S adjtimex,settimeofday -k audit_time_rules
+-a exit,always -F arch=b64 -S clock_settime -F a0=0x0 -k audit_time_rules
+-a exit,always -F arch=b32 -S adjtimex,stime,settimeofday -k audit_time_rules
+-a exit,always -F arch=b32 -S clock_settime -F a0=0x0 -k audit_time_rules
 
 -w /etc/localtime -p wa -k audit_time_rules
 
 ## Audit things that could affect system locale
--a always,exit -F arch=b64 -S sethostname,setdomainname -k audit_network_modifications
--a always,exit -F arch=b32 -S sethostname,setdomainname -k audit_network_modifications
+-a exit,always -F arch=b64 -S sethostname,setdomainname -k audit_network_modifications
+-a exit,always -F arch=b32 -S sethostname,setdomainname -k audit_network_modifications
 
 -w /etc/issue -p wa -k audit_network_modifications
 -w /etc/issue.net -p wa -k audit_network_modifications
@@ -95,12 +95,12 @@
 -w /etc/sysconfig/network -p wa -k audit_network_modifications
 
 ## Audit mount operations
--a always,exit -F arch=b64 -S mount,umount2 -k mount
--a always,exit -F arch=b32 -S mount,umount,umount2 -k mount
+-a exit,always -F arch=b64 -S mount,umount2 -k mount
+-a exit,always -F arch=b32 -S mount,umount,umount2 -k mount
 
--a always,exit -F arch=b64 -F path=/bin/mount -k mount
--a always,exit -F arch=b32 -F path=/bin/mount -k mount
--a always,exit -F path=/bin/umount -F perm=x -k mount
+-a exit,always -F arch=b64 -F path=/bin/mount -k mount
+-a exit,always -F arch=b32 -F path=/bin/mount -k mount
+-a exit,always -F path=/bin/umount -F perm=x -k mount
 
 ## Audit local accounts
 -w /etc/passwd -p wa -k audit_account_changes
@@ -201,13 +201,13 @@
 -w /etc/yum -p wa -k yum-config
 -w /etc/yum.conf -p wa -k yum-config
 -w /etc/yum.repos.d -p wa -k yum-config
--a always,exit -F arch=b64 -S ptrace -F a0=0x4 -k paranoid_code_injection
--a always,exit -F arch=b64 -S ptrace -F a0=0x5 -k paranoid_data_injection
--a always,exit -F arch=b64 -S ptrace -F a0=0x6 -k paranoid_register_injection
--a always,exit -F arch=b64 -S ptrace -k paranoid
--a always,exit -F arch=b32 -S ptrace -F a0=0x4 -k paranoid_code_injection
--a always,exit -F arch=b32 -S ptrace -F a0=0x5 -k paranoid_data_injection
--a always,exit -F arch=b32 -S ptrace -F a0=0x6 -k paranoid_register_injection
--a always,exit -F arch=b32 -S ptrace -k paranoid
--a always,exit -F arch=b64 -S personality -k paranoid
--a always,exit -F arch=b32 -S personality -k paranoid
+-a exit,always -F arch=b64 -S ptrace -F a0=0x4 -k paranoid_code_injection
+-a exit,always -F arch=b64 -S ptrace -F a0=0x5 -k paranoid_data_injection
+-a exit,always -F arch=b64 -S ptrace -F a0=0x6 -k paranoid_register_injection
+-a exit,always -F arch=b64 -S ptrace -k paranoid
+-a exit,always -F arch=b32 -S ptrace -F a0=0x4 -k paranoid_code_injection
+-a exit,always -F arch=b32 -S ptrace -F a0=0x5 -k paranoid_data_injection
+-a exit,always -F arch=b32 -S ptrace -F a0=0x6 -k paranoid_register_injection
+-a exit,always -F arch=b32 -S ptrace -k paranoid
+-a exit,always -F arch=b64 -S personality -k paranoid
+-a exit,always -F arch=b32 -S personality -k paranoid

--- a/spec/classes/config/audit_profiles/expected/simp_el7_aggressive_rules.txt
+++ b/spec/classes/config/audit_profiles/expected/simp_el7_aggressive_rules.txt
@@ -1,86 +1,86 @@
 #### auditd::config::audit_profiles::simp Audit Rules ####
 # 64-bit systems should generally never call the 32-bit API. 32-bit syscalls
 # may be a sign of someone exploiting a hole in the API.
--a always,exit -F arch=b32 -S all -F key=32bit-api
--a always,exit -F arch=b64 -S accept -F a0=2 -F key=ipv4_in
--a always,exit -F arch=b32 -S accept -F a0=2 -F key=ipv4_in
--a always,exit -F arch=b64 -S accept -F a0=10 -F key=ipv6_in
--a always,exit -F arch=b32 -S accept -F a0=10 -F key=ipv6_in
+-a exit,always -F arch=b32 -S all -F key=32bit-api
+-a exit,always -F arch=b64 -S accept -F a0=2 -F key=ipv4_in
+-a exit,always -F arch=b32 -S accept -F a0=2 -F key=ipv4_in
+-a exit,always -F arch=b64 -S accept -F a0=10 -F key=ipv6_in
+-a exit,always -F arch=b32 -S accept -F a0=10 -F key=ipv6_in
 
 ## Audit unsuccessful file operations
--a always,exit -F arch=b64 -S creat,mkdir,mknod,link,symlink,mkdirat,mknodat,linkat,symlinkat,openat,open_by_handle_at,open,close,rename,renameat,truncate,ftruncate,rmdir,unlink,unlinkat -F exit=-EACCES -k access
--a always,exit -F arch=b64 -S creat,mkdir,mknod,link,symlink,mkdirat,mknodat,linkat,symlinkat,openat,open_by_handle_at,open,close,rename,renameat,truncate,ftruncate,rmdir,unlink,unlinkat -F exit=-EPERM -k access
--a always,exit -F arch=b32 -S creat,mkdir,mknod,link,symlink,mkdirat,mknodat,linkat,symlinkat,openat,open_by_handle_at,open,close,rename,renameat,truncate,ftruncate,rmdir,unlink,unlinkat -F exit=-EACCES -k access
--a always,exit -F arch=b32 -S creat,mkdir,mknod,link,symlink,mkdirat,mknodat,linkat,symlinkat,openat,open_by_handle_at,open,close,rename,renameat,truncate,ftruncate,rmdir,unlink,unlinkat -F exit=-EPERM -k access
+-a exit,always -F arch=b64 -S creat,mkdir,mknod,link,symlink,mkdirat,mknodat,linkat,symlinkat,openat,open_by_handle_at,open,close,rename,renameat,truncate,ftruncate,rmdir,unlink,unlinkat -F exit=-EACCES -k access
+-a exit,always -F arch=b64 -S creat,mkdir,mknod,link,symlink,mkdirat,mknodat,linkat,symlinkat,openat,open_by_handle_at,open,close,rename,renameat,truncate,ftruncate,rmdir,unlink,unlinkat -F exit=-EPERM -k access
+-a exit,always -F arch=b32 -S creat,mkdir,mknod,link,symlink,mkdirat,mknodat,linkat,symlinkat,openat,open_by_handle_at,open,close,rename,renameat,truncate,ftruncate,rmdir,unlink,unlinkat -F exit=-EACCES -k access
+-a exit,always -F arch=b32 -S creat,mkdir,mknod,link,symlink,mkdirat,mknodat,linkat,symlinkat,openat,open_by_handle_at,open,close,rename,renameat,truncate,ftruncate,rmdir,unlink,unlinkat -F exit=-EPERM -k access
 
--a always,exit -F perm=a -F exit=-EACCES -k access
--a always,exit -F perm=a -F exit=-EPERM -k access
+-a exit,always -F perm=a -F exit=-EACCES -k access
+-a exit,always -F perm=a -F exit=-EPERM -k access
 
 ## Audit the execution of password commands
--a always,exit -F path=/usr/bin/passwd -F perm=x -k privileged-passwd
--a always,exit -F path=/bin/passwd -F perm=x -k privileged-passwd
+-a exit,always -F path=/usr/bin/passwd -F perm=x -k privileged-passwd
+-a exit,always -F path=/bin/passwd -F perm=x -k privileged-passwd
 
--a always,exit -F path=/usr/sbin/unix_chkpwd -F perm=x -k privileged-passwd
--a always,exit -F path=/sbin/unix_chkpwd -F perm=x -k privileged-passwd
+-a exit,always -F path=/usr/sbin/unix_chkpwd -F perm=x -k privileged-passwd
+-a exit,always -F path=/sbin/unix_chkpwd -F perm=x -k privileged-passwd
 
--a always,exit -F path=/usr/bin/gpasswd -F perm=x -k privileged-passwd
--a always,exit -F path=/bin/gpasswd -F perm=x -k privileged-passwd
+-a exit,always -F path=/usr/bin/gpasswd -F perm=x -k privileged-passwd
+-a exit,always -F path=/bin/gpasswd -F perm=x -k privileged-passwd
 
--a always,exit -F path=/usr/bin/chage -F perm=x -k privileged-passwd
--a always,exit -F path=/bin/chage -F perm=x -k privileged-passwd
+-a exit,always -F path=/usr/bin/chage -F perm=x -k privileged-passwd
+-a exit,always -F path=/bin/chage -F perm=x -k privileged-passwd
 
--a always,exit -F path=/usr/sbin/userhelper -F perm=x -k privileged-passwd
--a always,exit -F path=/sbin/userhelper -F perm=x -k privileged-passwd
+-a exit,always -F path=/usr/sbin/userhelper -F perm=x -k privileged-passwd
+-a exit,always -F path=/sbin/userhelper -F perm=x -k privileged-passwd
 
 ## Audit the execution of privilege-related commands
--a always,exit -F path=/usr/bin/su -F perm=x -k privileged-priv_change
--a always,exit -F path=/bin/su -F perm=x -k privileged-priv_change
+-a exit,always -F path=/usr/bin/su -F perm=x -k privileged-priv_change
+-a exit,always -F path=/bin/su -F perm=x -k privileged-priv_change
 
--a always,exit -F path=/usr/bin/sudo -F perm=x -k privileged-priv_change
--a always,exit -F path=/bin/sudo -F perm=x -k privileged-priv_change
+-a exit,always -F path=/usr/bin/sudo -F perm=x -k privileged-priv_change
+-a exit,always -F path=/bin/sudo -F perm=x -k privileged-priv_change
 
--a always,exit -F path=/usr/bin/newgrp -F perm=x -k privileged-priv_change
--a always,exit -F path=/bin/newgrp -F perm=x -k privileged-priv_change
+-a exit,always -F path=/usr/bin/newgrp -F perm=x -k privileged-priv_change
+-a exit,always -F path=/bin/newgrp -F perm=x -k privileged-priv_change
 
--a always,exit -F path=/usr/bin/chsh -F perm=x -k privileged-priv_change
--a always,exit -F path=/bin/chsh -F perm=x -k privileged-priv_change
+-a exit,always -F path=/usr/bin/chsh -F perm=x -k privileged-priv_change
+-a exit,always -F path=/bin/chsh -F perm=x -k privileged-priv_change
 
--a always,exit -F path=/usr/bin/sudoedit -F perm=x -k privileged-priv_change
--a always,exit -F path=/bin/sudoedit -F perm=x -k privileged-priv_change
+-a exit,always -F path=/usr/bin/sudoedit -F perm=x -k privileged-priv_change
+-a exit,always -F path=/bin/sudoedit -F perm=x -k privileged-priv_change
 
 ## Audit the execution of postfix-related commands
--a always,exit -F path=/usr/sbin/postdrop -F perm=x -k privileged-postfix
--a always,exit -F path=/sbin/postdrop -F perm=x -k privileged-postfix
+-a exit,always -F path=/usr/sbin/postdrop -F perm=x -k privileged-postfix
+-a exit,always -F path=/sbin/postdrop -F perm=x -k privileged-postfix
 
--a always,exit -F path=/usr/sbin/postqueue -F perm=x -k privileged-postfix
--a always,exit -F path=/sbin/postqueue -F perm=x -k privileged-postfix
+-a exit,always -F path=/usr/sbin/postqueue -F perm=x -k privileged-postfix
+-a exit,always -F path=/sbin/postqueue -F perm=x -k privileged-postfix
 
 ## Audit the execution of the ssh-keysign command
--a always,exit -F path=/usr/libexec/openssh/ssh-keysign -F perm=x -k privileged-ssh
+-a exit,always -F path=/usr/libexec/openssh/ssh-keysign -F perm=x -k privileged-ssh
 
 ## Audit the execution of the crontab command
--a always,exit -F path=/usr/bin/crontab -F perm=x -k privileged-cron
--a always,exit -F path=/bin/crontab -F perm=x -k privileged-cron
+-a exit,always -F path=/usr/bin/crontab -F perm=x -k privileged-cron
+-a exit,always -F path=/bin/crontab -F perm=x -k privileged-cron
 
 ## Audit the execution of the pam_timestamp_check command
--a always,exit -F path=/usr/sbin/pam_timestamp_check -F perm=x -k privileged-pam
--a always,exit -F path=/sbin/pam_timestamp_check -F perm=x -k privileged-pam
+-a exit,always -F path=/usr/sbin/pam_timestamp_check -F perm=x -k privileged-pam
+-a exit,always -F path=/sbin/pam_timestamp_check -F perm=x -k privileged-pam
 
 ## Permissions auditing separated by chown, chmod, and attr
 
--a always,exit -F arch=b64 -S chown,fchown,fchownat,lchown -k chown
--a always,exit -F arch=b32 -S chown,fchown,fchownat,lchown -k chown
+-a exit,always -F arch=b64 -S chown,fchown,fchownat,lchown -k chown
+-a exit,always -F arch=b32 -S chown,fchown,fchownat,lchown -k chown
 
--a always,exit -F arch=b64 -S setxattr,lsetxattr,fsetxattr,removexattr,lremovexattr,fremovexattr -k attr
--a always,exit -F arch=b32 -S setxattr,lsetxattr,fsetxattr,removexattr,lremovexattr,fremovexattr -k attr
+-a exit,always -F arch=b64 -S setxattr,lsetxattr,fsetxattr,removexattr,lremovexattr,fremovexattr -k attr
+-a exit,always -F arch=b32 -S setxattr,lsetxattr,fsetxattr,removexattr,lremovexattr,fremovexattr -k attr
 
 ## Audit useful items that someone does when su'ing to root.
--a always,exit -F arch=b64 -F auid!=0 -F uid=0 -S capset,mknod,mknodat,pivot_root,quotactl,setsid,adjtimex,settimeofday,setuid,swapoff,swapon,execve,rename,renameat,rmdir,unlink,unlinkat -k su-root-activity
--a always,exit -F arch=b32 -F auid!=0 -F uid=0 -S capset,mknod,mknodat,pivot_root,quotactl,setsid,adjtimex,settimeofday,setuid,swapoff,swapon,execve,rename,renameat,rmdir,unlink,unlinkat -k su-root-activity
+-a exit,always -F arch=b64 -F auid!=0 -F uid=0 -S capset,mknod,mknodat,pivot_root,quotactl,setsid,adjtimex,settimeofday,setuid,swapoff,swapon,execve,rename,renameat,rmdir,unlink,unlinkat -k su-root-activity
+-a exit,always -F arch=b32 -F auid!=0 -F uid=0 -S capset,mknod,mknodat,pivot_root,quotactl,setsid,adjtimex,settimeofday,setuid,swapoff,swapon,execve,rename,renameat,rmdir,unlink,unlinkat -k su-root-activity
 
 ## Audit the execution of suid and sgid binaries.
--a always,exit -F arch=b64 -F euid=0 -F uid!=0 -S execve -k suid-root-exec
--a always,exit -F arch=b32 -F euid=0 -F uid!=0 -S execve -k suid-root-exec
+-a exit,always -F arch=b64 -F euid=0 -F uid!=0 -S execve -k suid-root-exec
+-a exit,always -F arch=b32 -F euid=0 -F uid!=0 -S execve -k suid-root-exec
 
 ## Audit the loading and unloading of kernel modules.
 -w /usr/bin/kmod -p x -k modules
@@ -92,38 +92,38 @@
 -w /usr/sbin/modprobe -p x -k modules
 -w /sbin/modprobe -p x -k modules
 
--a always,exit -F arch=b64 -S create_module,init_module,finit_module,delete_module -k modules
--a always,exit -F arch=b32 -S create_module,init_module,finit_module,delete_module -k modules
+-a exit,always -F arch=b64 -S create_module,init_module,finit_module,delete_module -k modules
+-a exit,always -F arch=b32 -S create_module,init_module,finit_module,delete_module -k modules
 
 ## Audit things that could affect time
--a always,exit -F arch=b64 -S adjtimex,settimeofday -k audit_time_rules
--a always,exit -F arch=b64 -S clock_settime -F a0=0x0 -k audit_time_rules
--a always,exit -F arch=b32 -S adjtimex,stime,settimeofday -k audit_time_rules
--a always,exit -F arch=b32 -S clock_settime -F a0=0x0 -k audit_time_rules
+-a exit,always -F arch=b64 -S adjtimex,settimeofday -k audit_time_rules
+-a exit,always -F arch=b64 -S clock_settime -F a0=0x0 -k audit_time_rules
+-a exit,always -F arch=b32 -S adjtimex,stime,settimeofday -k audit_time_rules
+-a exit,always -F arch=b32 -S clock_settime -F a0=0x0 -k audit_time_rules
 
 -w /etc/localtime -p wa -k audit_time_rules
 
 ## Audit things that could affect system locale
--a always,exit -F arch=b64 -S sethostname,setdomainname -k audit_network_modifications
--a always,exit -F arch=b32 -S sethostname,setdomainname -k audit_network_modifications
+-a exit,always -F arch=b64 -S sethostname,setdomainname -k audit_network_modifications
+-a exit,always -F arch=b32 -S sethostname,setdomainname -k audit_network_modifications
 
 -w /etc/issue -p wa -k audit_network_modifications
 -w /etc/issue.net -p wa -k audit_network_modifications
 -w /etc/hosts -p wa -k audit_network_modifications
 -w /etc/hostname -p wa -k audit_network_modifications
 -w /etc/sysconfig/network -p wa -k audit_network_modifications
--a always,exit -F dir=/etc/NetworkManager/ -F perm=wa -k audit_network_modifications
+-a exit,always -F dir=/etc/NetworkManager/ -F perm=wa -k audit_network_modifications
 
 ## Audit mount operations
--a always,exit -F arch=b64 -S mount,umount2 -k mount
--a always,exit -F arch=b32 -S mount,umount,umount2 -k mount
+-a exit,always -F arch=b64 -S mount,umount2 -k mount
+-a exit,always -F arch=b32 -S mount,umount,umount2 -k mount
 
--a always,exit -F arch=b64 -F path=/usr/bin/mount -k mount
--a always,exit -F arch=b64 -F path=/bin/mount -k mount
--a always,exit -F arch=b32 -F path=/usr/bin/mount -k mount
--a always,exit -F arch=b32 -F path=/bin/mount -k mount
--a always,exit -F path=/usr/bin/umount -F perm=x -k mount
--a always,exit -F path=/bin/umount -F perm=x -k mount
+-a exit,always -F arch=b64 -F path=/usr/bin/mount -k mount
+-a exit,always -F arch=b64 -F path=/bin/mount -k mount
+-a exit,always -F arch=b32 -F path=/usr/bin/mount -k mount
+-a exit,always -F arch=b32 -F path=/bin/mount -k mount
+-a exit,always -F path=/usr/bin/umount -F perm=x -k mount
+-a exit,always -F path=/bin/umount -F perm=x -k mount
 
 ## Audit local accounts
 -w /etc/passwd -p wa -k audit_account_changes
@@ -229,13 +229,13 @@
 -w /etc/yum -p wa -k yum-config
 -w /etc/yum.conf -p wa -k yum-config
 -w /etc/yum.repos.d -p wa -k yum-config
--a always,exit -F arch=b64 -S ptrace -F a0=0x4 -k paranoid_code_injection
--a always,exit -F arch=b64 -S ptrace -F a0=0x5 -k paranoid_data_injection
--a always,exit -F arch=b64 -S ptrace -F a0=0x6 -k paranoid_register_injection
--a always,exit -F arch=b64 -S ptrace -k paranoid
--a always,exit -F arch=b32 -S ptrace -F a0=0x4 -k paranoid_code_injection
--a always,exit -F arch=b32 -S ptrace -F a0=0x5 -k paranoid_data_injection
--a always,exit -F arch=b32 -S ptrace -F a0=0x6 -k paranoid_register_injection
--a always,exit -F arch=b32 -S ptrace -k paranoid
--a always,exit -F arch=b64 -S personality -k paranoid
--a always,exit -F arch=b32 -S personality -k paranoid
+-a exit,always -F arch=b64 -S ptrace -F a0=0x4 -k paranoid_code_injection
+-a exit,always -F arch=b64 -S ptrace -F a0=0x5 -k paranoid_data_injection
+-a exit,always -F arch=b64 -S ptrace -F a0=0x6 -k paranoid_register_injection
+-a exit,always -F arch=b64 -S ptrace -k paranoid
+-a exit,always -F arch=b32 -S ptrace -F a0=0x4 -k paranoid_code_injection
+-a exit,always -F arch=b32 -S ptrace -F a0=0x5 -k paranoid_data_injection
+-a exit,always -F arch=b32 -S ptrace -F a0=0x6 -k paranoid_register_injection
+-a exit,always -F arch=b32 -S ptrace -k paranoid
+-a exit,always -F arch=b64 -S personality -k paranoid
+-a exit,always -F arch=b32 -S personality -k paranoid

--- a/spec/classes/config/audit_profiles/expected/simp_el7_aggressive_rules.txt
+++ b/spec/classes/config/audit_profiles/expected/simp_el7_aggressive_rules.txt
@@ -3,9 +3,7 @@
 # may be a sign of someone exploiting a hole in the API.
 -a exit,always -F arch=b32 -S all -F key=32bit-api
 -a exit,always -F arch=b64 -S accept -F a0=2 -F key=ipv4_in
--a exit,always -F arch=b32 -S accept -F a0=2 -F key=ipv4_in
 -a exit,always -F arch=b64 -S accept -F a0=10 -F key=ipv6_in
--a exit,always -F arch=b32 -S accept -F a0=10 -F key=ipv6_in
 
 ## Audit unsuccessful file operations
 -a exit,always -F arch=b64 -S creat,mkdir,mknod,link,symlink,mkdirat,mknodat,linkat,symlinkat,openat,open_by_handle_at,open,close,rename,renameat,truncate,ftruncate,rmdir,unlink,unlinkat -F exit=-EACCES -k access

--- a/spec/classes/config/audit_profiles/expected/simp_el7_aggressive_rules.txt
+++ b/spec/classes/config/audit_profiles/expected/simp_el7_aggressive_rules.txt
@@ -1,14 +1,13 @@
 #### auditd::config::audit_profiles::simp Audit Rules ####
+# 64-bit systems should generally never call the 32-bit API. 32-bit syscalls
+# may be a sign of someone exploiting a hole in the API.
+-a always,exit -F arch=b32 -S all -F key=32bit-api
+-a always,exit -F arch=b64 -S accept -F a0=2 -F key=ipv4_in
+-a always,exit -F arch=b32 -S accept -F a0=2 -F key=ipv4_in
+-a always,exit -F arch=b64 -S accept -F a0=10 -F key=ipv6_in
+-a always,exit -F arch=b32 -S accept -F a0=10 -F key=ipv6_in
 
 ## Audit unsuccessful file operations
-# CCE-26712-0
-# CCE-26651-0
-# RHEL-07-030500
-# RHEL-07-030510
-# RHEL-07-030520
-# RHEL-07-030530
-# RHEL-07-030540
-# RHEL-07-030550
 -a always,exit -F arch=b64 -S creat,mkdir,mknod,link,symlink,mkdirat,mknodat,linkat,symlinkat,openat,open_by_handle_at,open,close,rename,renameat,truncate,ftruncate,rmdir,unlink,unlinkat -F exit=-EACCES -k access
 -a always,exit -F arch=b64 -S creat,mkdir,mknod,link,symlink,mkdirat,mknodat,linkat,symlinkat,openat,open_by_handle_at,open,close,rename,renameat,truncate,ftruncate,rmdir,unlink,unlinkat -F exit=-EPERM -k access
 -a always,exit -F arch=b32 -S creat,mkdir,mknod,link,symlink,mkdirat,mknodat,linkat,symlinkat,openat,open_by_handle_at,open,close,rename,renameat,truncate,ftruncate,rmdir,unlink,unlinkat -F exit=-EACCES -k access
@@ -18,155 +17,96 @@
 -a always,exit -F perm=a -F exit=-EPERM -k access
 
 ## Audit the execution of password commands
-# RHEL-07-030630
 -a always,exit -F path=/usr/bin/passwd -F perm=x -k privileged-passwd
 -a always,exit -F path=/bin/passwd -F perm=x -k privileged-passwd
 
-# RHEL-07-030640
 -a always,exit -F path=/usr/sbin/unix_chkpwd -F perm=x -k privileged-passwd
 -a always,exit -F path=/sbin/unix_chkpwd -F perm=x -k privileged-passwd
 
-# RHEL-07-030650
 -a always,exit -F path=/usr/bin/gpasswd -F perm=x -k privileged-passwd
 -a always,exit -F path=/bin/gpasswd -F perm=x -k privileged-passwd
 
-# RHEL-07-030660
 -a always,exit -F path=/usr/bin/chage -F perm=x -k privileged-passwd
 -a always,exit -F path=/bin/chage -F perm=x -k privileged-passwd
 
-# RHEL-07-030670
 -a always,exit -F path=/usr/sbin/userhelper -F perm=x -k privileged-passwd
 -a always,exit -F path=/sbin/userhelper -F perm=x -k privileged-passwd
 
 ## Audit the execution of privilege-related commands
-# RHEL-07-030680
 -a always,exit -F path=/usr/bin/su -F perm=x -k privileged-priv_change
 -a always,exit -F path=/bin/su -F perm=x -k privileged-priv_change
 
-# RHEL-07-030690
 -a always,exit -F path=/usr/bin/sudo -F perm=x -k privileged-priv_change
 -a always,exit -F path=/bin/sudo -F perm=x -k privileged-priv_change
 
-# RHEL-07-030710
 -a always,exit -F path=/usr/bin/newgrp -F perm=x -k privileged-priv_change
 -a always,exit -F path=/bin/newgrp -F perm=x -k privileged-priv_change
 
-# RHEL-07-030720
 -a always,exit -F path=/usr/bin/chsh -F perm=x -k privileged-priv_change
 -a always,exit -F path=/bin/chsh -F perm=x -k privileged-priv_change
 
-# RHEL-07-030730
 -a always,exit -F path=/usr/bin/sudoedit -F perm=x -k privileged-priv_change
 -a always,exit -F path=/bin/sudoedit -F perm=x -k privileged-priv_change
 
 ## Audit the execution of postfix-related commands
-# RHEL-07-030760
 -a always,exit -F path=/usr/sbin/postdrop -F perm=x -k privileged-postfix
 -a always,exit -F path=/sbin/postdrop -F perm=x -k privileged-postfix
 
-# RHEL-07-030770
 -a always,exit -F path=/usr/sbin/postqueue -F perm=x -k privileged-postfix
 -a always,exit -F path=/sbin/postqueue -F perm=x -k privileged-postfix
 
 ## Audit the execution of the ssh-keysign command
-# RHEL-07-030780
 -a always,exit -F path=/usr/libexec/openssh/ssh-keysign -F perm=x -k privileged-ssh
 
 ## Audit the execution of the crontab command
-# RHEL-07-030800
 -a always,exit -F path=/usr/bin/crontab -F perm=x -k privileged-cron
 -a always,exit -F path=/bin/crontab -F perm=x -k privileged-cron
 
 ## Audit the execution of the pam_timestamp_check command
-# RHEL-07-030810
 -a always,exit -F path=/usr/sbin/pam_timestamp_check -F perm=x -k privileged-pam
 -a always,exit -F path=/sbin/pam_timestamp_check -F perm=x -k privileged-pam
 
 ## Permissions auditing separated by chown, chmod, and attr
-# CCE-26280-8
-# CCE-27173-4
-# CCE-27174-2
-# CCE-27175-9
-# CCE-27177-5
-# CCE-27178-3
-# CCE-27179-1
-# CCE-27180-9
-# CCE-27181-7
-# CCE-27182-5
-# CCE-27183-3
-# CCE-27184-1
-# CCE-27185-8
 
-# RHEL-07-030370
-# RHEL-07-030380
-# RHEL-07-030390
-# RHEL-07-030400
 -a always,exit -F arch=b64 -S chown,fchown,fchownat,lchown -k chown
 -a always,exit -F arch=b32 -S chown,fchown,fchownat,lchown -k chown
 
-# RHEL-07-030440
-# RHEL-07-030450
-# RHEL-07-030460
-# RHEL-07-030470
-# RHEL-07-030480
-# RHEL-07-030490
 -a always,exit -F arch=b64 -S setxattr,lsetxattr,fsetxattr,removexattr,lremovexattr,fremovexattr -k attr
 -a always,exit -F arch=b32 -S setxattr,lsetxattr,fsetxattr,removexattr,lremovexattr,fremovexattr -k attr
 
 ## Audit useful items that someone does when su'ing to root.
-# Had to add an entry in the default_drop rules file for getting rid of
-# anonymous records.  They are only moderately useful and contain *way*
-# too much noise since this covers things like cron as well.
 -a always,exit -F arch=b64 -F auid!=0 -F uid=0 -S capset,mknod,mknodat,pivot_root,quotactl,setsid,adjtimex,settimeofday,setuid,swapoff,swapon,execve,rename,renameat,rmdir,unlink,unlinkat -k su-root-activity
 -a always,exit -F arch=b32 -F auid!=0 -F uid=0 -S capset,mknod,mknodat,pivot_root,quotactl,setsid,adjtimex,settimeofday,setuid,swapoff,swapon,execve,rename,renameat,rmdir,unlink,unlinkat -k su-root-activity
 
 ## Audit the execution of suid and sgid binaries.
-# CCE-26457-2
-# RHEL-07-030360
 -a always,exit -F arch=b64 -F euid=0 -F uid!=0 -S execve -k suid-root-exec
 -a always,exit -F arch=b32 -F euid=0 -F uid!=0 -S execve -k suid-root-exec
 
 ## Audit the loading and unloading of kernel modules.
-# CCE-26611-4
 -w /usr/bin/kmod -p x -k modules
 -w /bin/kmod -p x -k modules
-
-# RHEL-07-030840
 -w /usr/sbin/insmod -p x -k modules
 -w /sbin/insmod -p x -k modules
-
-# RHEL-07-030850
 -w /usr/sbin/rmmod -p x -k modules
 -w /sbin/rmmod -p x -k modules
-
-# RHEL-07-030860
 -w /usr/sbin/modprobe -p x -k modules
 -w /sbin/modprobe -p x -k modules
 
-# RHEL-07-030819
-# RHEL-07-030820
-# RHEL-07-030821
-# RHEL-07-030830
 -a always,exit -F arch=b64 -S create_module,init_module,finit_module,delete_module -k modules
 -a always,exit -F arch=b32 -S create_module,init_module,finit_module,delete_module -k modules
 
 ## Audit things that could affect time
-# CCE-27172-6
-# CCE-27203-9
-# CCE-27169-2
-# CCE-27170-0
--a always,exit -F arch=b32 -S adjtimex,stime,settimeofday -k audit_time_rules
 -a always,exit -F arch=b64 -S adjtimex,settimeofday -k audit_time_rules
--a always,exit -F arch=b32 -S clock_settime -F a0=0x0 -k audit_time_rules
 -a always,exit -F arch=b64 -S clock_settime -F a0=0x0 -k audit_time_rules
+-a always,exit -F arch=b32 -S adjtimex,stime,settimeofday -k audit_time_rules
+-a always,exit -F arch=b32 -S clock_settime -F a0=0x0 -k audit_time_rules
 
-# CCE-27172-6
 -w /etc/localtime -p wa -k audit_time_rules
 
 ## Audit things that could affect system locale
-# CCE-26648-6
--a always,exit -F arch=b32 -S sethostname,setdomainname -k audit_network_modifications
 -a always,exit -F arch=b64 -S sethostname,setdomainname -k audit_network_modifications
+-a always,exit -F arch=b32 -S sethostname,setdomainname -k audit_network_modifications
+
 -w /etc/issue -p wa -k audit_network_modifications
 -w /etc/issue.net -p wa -k audit_network_modifications
 -w /etc/hosts -p wa -k audit_network_modifications
@@ -175,12 +115,9 @@
 -a always,exit -F dir=/etc/NetworkManager/ -F perm=wa -k audit_network_modifications
 
 ## Audit mount operations
-# CCE-26573-6
-#
-# RHEL-07-030740
-# RHEL-07-030750
--a always,exit -F arch=b32 -S mount,umount,umount2 -k mount
 -a always,exit -F arch=b64 -S mount,umount2 -k mount
+-a always,exit -F arch=b32 -S mount,umount,umount2 -k mount
+
 -a always,exit -F arch=b64 -F path=/usr/bin/mount -k mount
 -a always,exit -F arch=b64 -F path=/bin/mount -k mount
 -a always,exit -F arch=b32 -F path=/usr/bin/mount -k mount
@@ -189,57 +126,56 @@
 -a always,exit -F path=/bin/umount -F perm=x -k mount
 
 ## Audit local accounts
-# CCE-26664-3
-#
-# RHEL-07-030870
 -w /etc/passwd -p wa -k audit_account_changes
-
-# RHEL-07-030871
 -w /etc/group -p wa -k audit_account_changes
-
-# RHEL-07-030872
 -w /etc/gshadow -p wa -k audit_account_changes
-
-# RHEL-07-030873
 -w /etc/shadow -p wa -k audit_account_changes
-
-# RHEL-07-030874
 -w /etc/security/opasswd -p wa -k audit_account_changes
-
 -w /etc/passwd- -p wa -k audit_account_changes
 -w /etc/group- -p wa -k audit_account_changes
 -w /etc/shadow- -p wa -k audit_account_changes
 
 ## Audit selinux policy
-# CCE-26657-7
 -w /etc/selinux/ -p wa -k MAC-policy
 -w /usr/share/selinux/ -p wa -k MAC-policy
 
 ## Audit login files
-# CCE-26691-6
-#
-# RHEL-07-030600
 -w /var/log/tallylog -p wa -k logins
-
-# RHEL-07-030610
 -w /var/run/faillock -p wa -k logins
-
-# RHEL-07-030620
 -w /var/log/lastlog -p wa -k logins
-
 -w /var/log/faillog -p wa -k logins
 
 ## Audit session files
-# CCE-26610-6
 -w /var/run/utmp -p wa -k session
 -w /var/log/btmp -p wa -k session
 -w /var/log/wtmp -p wa -k session
 
 ## Audit sudoers configuration files
-# CCE-26662-7
-# RHEL-07-030700
 -w /etc/sudoers -p wa -k CFG_sys
 -w /etc/sudoers.d/ -p wa -k CFG_sys
+
+## Audit accesses to the audit trail
+-w /usr/sbin/aulast -p x -k access-audit-trail
+-w /usr/sbin/aulastlogin -p x -k access-audit-trail
+-w /usr/sbin/aureport -p x -k access-audit-trail
+-w /usr/sbin/ausearch -p x -k access-audit-trail
+-w /usr/sbin/auvirt -p x -k access-audit-trail
+
+## Audit systemd components
+-w /bin/systemctl -p x -k systemd
+-w /usr/bin/systemctl -p x -k systemd
+-w /etc/systemd/ -p wa -k systemd
+
+## Audit suspicious applications
+-w /usr/bin/nc -p x -k suspicious_apps
+-w /usr/bin/ncat -p x -k suspicious_apps
+-w /usr/bin/nmap -p x -k suspicious_apps
+-w /usr/bin/rawshark -p x -k suspicious_apps
+-w /usr/bin/socat -p x -k suspicious_apps
+-w /usr/bin/wireshark -p x -k suspicious_apps
+-w /usr/sbin/tcpdump -p x -k suspicious_apps
+-w /usr/sbin/traceroute -p x -k suspicious_apps
+-w /usr/sbin/traceroute6 -p x -k suspicious_apps
 
 ## Generally good things to audit.
 -w /etc/grub.d -p wa -k CFG_grub
@@ -251,8 +187,6 @@
 -w /etc/hosts.deny -p wa -k CFG_sys
 -w /etc/initlog.conf -p wa -k CFG_sys
 -w /etc/inittab -p wa -k CFG_sys
--w /etc/issue -p wa -k CFG_sys
--w /etc/issue.net -p wa -k CFG_sys
 -w /etc/krb5.conf -p wa -k CFG_sys
 -w /etc/ld.so.conf -p wa -k CFG_sys
 -w /etc/ld.so.conf.d -p wa -k CFG_sys
@@ -295,7 +229,13 @@
 -w /etc/yum -p wa -k yum-config
 -w /etc/yum.conf -p wa -k yum-config
 -w /etc/yum.repos.d -p wa -k yum-config
--a always,exit -F arch=b32 -S ptrace -k paranoid
+-a always,exit -F arch=b64 -S ptrace -F a0=0x4 -k paranoid_code_injection
+-a always,exit -F arch=b64 -S ptrace -F a0=0x5 -k paranoid_data_injection
+-a always,exit -F arch=b64 -S ptrace -F a0=0x6 -k paranoid_register_injection
 -a always,exit -F arch=b64 -S ptrace -k paranoid
--a always,exit -F arch=b32 -S personality -k paranoid
+-a always,exit -F arch=b32 -S ptrace -F a0=0x4 -k paranoid_code_injection
+-a always,exit -F arch=b32 -S ptrace -F a0=0x5 -k paranoid_data_injection
+-a always,exit -F arch=b32 -S ptrace -F a0=0x6 -k paranoid_register_injection
+-a always,exit -F arch=b32 -S ptrace -k paranoid
 -a always,exit -F arch=b64 -S personality -k paranoid
+-a always,exit -F arch=b32 -S personality -k paranoid

--- a/spec/classes/config/audit_profiles/expected/simp_el7_all_rules_custom_tags.txt
+++ b/spec/classes/config/audit_profiles/expected/simp_el7_all_rules_custom_tags.txt
@@ -3,9 +3,7 @@
 # may be a sign of someone exploiting a hole in the API.
 -a exit,always -F arch=b32 -S all -F key=32bit-api
 -a exit,always -F arch=b64 -S accept -F a0=2 -F key=ipv4_in
--a exit,always -F arch=b32 -S accept -F a0=2 -F key=ipv4_in
 -a exit,always -F arch=b64 -S accept -F a0=10 -F key=ipv6_in
--a exit,always -F arch=b32 -S accept -F a0=10 -F key=ipv6_in
 
 ## Audit unsuccessful file operations
 -a exit,always -F arch=b64 -S creat,mkdir,mknod,link,symlink,mkdirat,mknodat,linkat,symlinkat,openat,open_by_handle_at,open,close,rename,renameat,truncate,ftruncate,rmdir,unlink,unlinkat -F exit=-EACCES -k my_unsuccessful_file_operations

--- a/spec/classes/config/audit_profiles/expected/simp_el7_all_rules_custom_tags.txt
+++ b/spec/classes/config/audit_profiles/expected/simp_el7_all_rules_custom_tags.txt
@@ -1,106 +1,106 @@
 #### auditd::config::audit_profiles::simp Audit Rules ####
 # 64-bit systems should generally never call the 32-bit API. 32-bit syscalls
 # may be a sign of someone exploiting a hole in the API.
--a always,exit -F arch=b32 -S all -F key=32bit-api
--a always,exit -F arch=b64 -S accept -F a0=2 -F key=ipv4_in
--a always,exit -F arch=b32 -S accept -F a0=2 -F key=ipv4_in
--a always,exit -F arch=b64 -S accept -F a0=10 -F key=ipv6_in
--a always,exit -F arch=b32 -S accept -F a0=10 -F key=ipv6_in
+-a exit,always -F arch=b32 -S all -F key=32bit-api
+-a exit,always -F arch=b64 -S accept -F a0=2 -F key=ipv4_in
+-a exit,always -F arch=b32 -S accept -F a0=2 -F key=ipv4_in
+-a exit,always -F arch=b64 -S accept -F a0=10 -F key=ipv6_in
+-a exit,always -F arch=b32 -S accept -F a0=10 -F key=ipv6_in
 
 ## Audit unsuccessful file operations
--a always,exit -F arch=b64 -S creat,mkdir,mknod,link,symlink,mkdirat,mknodat,linkat,symlinkat,openat,open_by_handle_at,open,close,rename,renameat,truncate,ftruncate,rmdir,unlink,unlinkat -F exit=-EACCES -k my_unsuccessful_file_operations
--a always,exit -F arch=b64 -S creat,mkdir,mknod,link,symlink,mkdirat,mknodat,linkat,symlinkat,openat,open_by_handle_at,open,close,rename,renameat,truncate,ftruncate,rmdir,unlink,unlinkat -F exit=-EPERM -k my_unsuccessful_file_operations
--a always,exit -F arch=b32 -S creat,mkdir,mknod,link,symlink,mkdirat,mknodat,linkat,symlinkat,openat,open_by_handle_at,open,close,rename,renameat,truncate,ftruncate,rmdir,unlink,unlinkat -F exit=-EACCES -k my_unsuccessful_file_operations
--a always,exit -F arch=b32 -S creat,mkdir,mknod,link,symlink,mkdirat,mknodat,linkat,symlinkat,openat,open_by_handle_at,open,close,rename,renameat,truncate,ftruncate,rmdir,unlink,unlinkat -F exit=-EPERM -k my_unsuccessful_file_operations
+-a exit,always -F arch=b64 -S creat,mkdir,mknod,link,symlink,mkdirat,mknodat,linkat,symlinkat,openat,open_by_handle_at,open,close,rename,renameat,truncate,ftruncate,rmdir,unlink,unlinkat -F exit=-EACCES -k my_unsuccessful_file_operations
+-a exit,always -F arch=b64 -S creat,mkdir,mknod,link,symlink,mkdirat,mknodat,linkat,symlinkat,openat,open_by_handle_at,open,close,rename,renameat,truncate,ftruncate,rmdir,unlink,unlinkat -F exit=-EPERM -k my_unsuccessful_file_operations
+-a exit,always -F arch=b32 -S creat,mkdir,mknod,link,symlink,mkdirat,mknodat,linkat,symlinkat,openat,open_by_handle_at,open,close,rename,renameat,truncate,ftruncate,rmdir,unlink,unlinkat -F exit=-EACCES -k my_unsuccessful_file_operations
+-a exit,always -F arch=b32 -S creat,mkdir,mknod,link,symlink,mkdirat,mknodat,linkat,symlinkat,openat,open_by_handle_at,open,close,rename,renameat,truncate,ftruncate,rmdir,unlink,unlinkat -F exit=-EPERM -k my_unsuccessful_file_operations
 
--a always,exit -F perm=a -F exit=-EACCES -k my_unsuccessful_file_operations
--a always,exit -F perm=a -F exit=-EPERM -k my_unsuccessful_file_operations
+-a exit,always -F perm=a -F exit=-EACCES -k my_unsuccessful_file_operations
+-a exit,always -F perm=a -F exit=-EPERM -k my_unsuccessful_file_operations
 
 ## Audit the execution of password commands
--a always,exit -F path=/usr/bin/passwd -F perm=x -k my_passwd_cmds
--a always,exit -F path=/bin/passwd -F perm=x -k my_passwd_cmds
+-a exit,always -F path=/usr/bin/passwd -F perm=x -k my_passwd_cmds
+-a exit,always -F path=/bin/passwd -F perm=x -k my_passwd_cmds
 
--a always,exit -F path=/usr/sbin/unix_chkpwd -F perm=x -k my_passwd_cmds
--a always,exit -F path=/sbin/unix_chkpwd -F perm=x -k my_passwd_cmds
+-a exit,always -F path=/usr/sbin/unix_chkpwd -F perm=x -k my_passwd_cmds
+-a exit,always -F path=/sbin/unix_chkpwd -F perm=x -k my_passwd_cmds
 
--a always,exit -F path=/usr/bin/gpasswd -F perm=x -k my_passwd_cmds
--a always,exit -F path=/bin/gpasswd -F perm=x -k my_passwd_cmds
+-a exit,always -F path=/usr/bin/gpasswd -F perm=x -k my_passwd_cmds
+-a exit,always -F path=/bin/gpasswd -F perm=x -k my_passwd_cmds
 
--a always,exit -F path=/usr/bin/chage -F perm=x -k my_passwd_cmds
--a always,exit -F path=/bin/chage -F perm=x -k my_passwd_cmds
+-a exit,always -F path=/usr/bin/chage -F perm=x -k my_passwd_cmds
+-a exit,always -F path=/bin/chage -F perm=x -k my_passwd_cmds
 
--a always,exit -F path=/usr/sbin/userhelper -F perm=x -k my_passwd_cmds
--a always,exit -F path=/sbin/userhelper -F perm=x -k my_passwd_cmds
+-a exit,always -F path=/usr/sbin/userhelper -F perm=x -k my_passwd_cmds
+-a exit,always -F path=/sbin/userhelper -F perm=x -k my_passwd_cmds
 
 ## Audit the execution of privilege-related commands
--a always,exit -F path=/usr/bin/su -F perm=x -k my_priv_cmds
--a always,exit -F path=/bin/su -F perm=x -k my_priv_cmds
+-a exit,always -F path=/usr/bin/su -F perm=x -k my_priv_cmds
+-a exit,always -F path=/bin/su -F perm=x -k my_priv_cmds
 
--a always,exit -F path=/usr/bin/sudo -F perm=x -k my_priv_cmds
--a always,exit -F path=/bin/sudo -F perm=x -k my_priv_cmds
+-a exit,always -F path=/usr/bin/sudo -F perm=x -k my_priv_cmds
+-a exit,always -F path=/bin/sudo -F perm=x -k my_priv_cmds
 
--a always,exit -F path=/usr/bin/newgrp -F perm=x -k my_priv_cmds
--a always,exit -F path=/bin/newgrp -F perm=x -k my_priv_cmds
+-a exit,always -F path=/usr/bin/newgrp -F perm=x -k my_priv_cmds
+-a exit,always -F path=/bin/newgrp -F perm=x -k my_priv_cmds
 
--a always,exit -F path=/usr/bin/chsh -F perm=x -k my_priv_cmds
+-a exit,always -F path=/usr/bin/chsh -F perm=x -k my_priv_cmds
 
--a always,exit -F path=/usr/bin/sudoedit -F perm=x -k my_priv_cmds
--a always,exit -F path=/bin/sudoedit -F perm=x -k my_priv_cmds
+-a exit,always -F path=/usr/bin/sudoedit -F perm=x -k my_priv_cmds
+-a exit,always -F path=/bin/sudoedit -F perm=x -k my_priv_cmds
 
 ## Audit the execution of postfix-related commands
--a always,exit -F path=/usr/sbin/postdrop -F perm=x -k my_postfix_cmds
--a always,exit -F path=/sbin/postdrop -F perm=x -k my_postfix_cmds
+-a exit,always -F path=/usr/sbin/postdrop -F perm=x -k my_postfix_cmds
+-a exit,always -F path=/sbin/postdrop -F perm=x -k my_postfix_cmds
 
--a always,exit -F path=/usr/sbin/postqueue -F perm=x -k my_postfix_cmds
--a always,exit -F path=/sbin/postqueue -F perm=x -k my_postfix_cmds
+-a exit,always -F path=/usr/sbin/postqueue -F perm=x -k my_postfix_cmds
+-a exit,always -F path=/sbin/postqueue -F perm=x -k my_postfix_cmds
 
 ## Audit the execution of the ssh-keysign command
--a always,exit -F path=/usr/libexec/openssh/ssh-keysign -F perm=x -k my_ssh_keysign_cmd
+-a exit,always -F path=/usr/libexec/openssh/ssh-keysign -F perm=x -k my_ssh_keysign_cmd
 
 ## Audit the execution of the crontab command
--a always,exit -F path=/usr/bin/crontab -F perm=x -k my_crontab_cmd
--a always,exit -F path=/bin/crontab -F perm=x -k my_crontab_cmd
+-a exit,always -F path=/usr/bin/crontab -F perm=x -k my_crontab_cmd
+-a exit,always -F path=/bin/crontab -F perm=x -k my_crontab_cmd
 
 ## Audit the execution of the pam_timestamp_check command
--a always,exit -F path=/usr/sbin/pam_timestamp_check -F perm=x -k my_pam_timestamp_check_cmd
--a always,exit -F path=/sbin/pam_timestamp_check -F perm=x -k my_pam_timestamp_check_cmd
+-a exit,always -F path=/usr/sbin/pam_timestamp_check -F perm=x -k my_pam_timestamp_check_cmd
+-a exit,always -F path=/sbin/pam_timestamp_check -F perm=x -k my_pam_timestamp_check_cmd
 
 ## Audit selinux commands
 #
--a always,exit -F path=/usr/sbin/semanage -F perm=x -k my_selinux_cmds
--a always,exit -F path=/sbin/semanage -F perm=x -k my_selinux_cmds
+-a exit,always -F path=/usr/sbin/semanage -F perm=x -k my_selinux_cmds
+-a exit,always -F path=/sbin/semanage -F perm=x -k my_selinux_cmds
 
--a always,exit -F path=/usr/sbin/setsebool -F perm=x -k my_selinux_cmds
--a always,exit -F path=/sbin/setsebool -F perm=x -k my_selinux_cmds
+-a exit,always -F path=/usr/sbin/setsebool -F perm=x -k my_selinux_cmds
+-a exit,always -F path=/sbin/setsebool -F perm=x -k my_selinux_cmds
 
--a always,exit -F path=/usr/bin/chcon -F perm=x -k my_selinux_cmds
--a always,exit -F path=/bin/chcon -F perm=x -k my_selinux_cmds
+-a exit,always -F path=/usr/bin/chcon -F perm=x -k my_selinux_cmds
+-a exit,always -F path=/bin/chcon -F perm=x -k my_selinux_cmds
 
--a always,exit -F path=/usr/sbin/setfiles -F perm=x -k my_selinux_cmds
--a always,exit -F path=/sbin/setfiles -F perm=x -k my_selinux_cmds
+-a exit,always -F path=/usr/sbin/setfiles -F perm=x -k my_selinux_cmds
+-a exit,always -F path=/sbin/setfiles -F perm=x -k my_selinux_cmds
 
 ## Permissions auditing separated by chown, chmod, and attr
 
--a always,exit -F arch=b64 -S chown,fchown,fchownat,lchown -k my_chown
--a always,exit -F arch=b32 -S chown,fchown,fchownat,lchown -k my_chown
+-a exit,always -F arch=b64 -S chown,fchown,fchownat,lchown -k my_chown
+-a exit,always -F arch=b32 -S chown,fchown,fchownat,lchown -k my_chown
 
--a always,exit -F arch=b64 -S chmod,fchmod,fchmodat -k my_chmod
--a always,exit -F arch=b32 -S chmod,fchmod,fchmodat -k my_chmod
+-a exit,always -F arch=b64 -S chmod,fchmod,fchmodat -k my_chmod
+-a exit,always -F arch=b32 -S chmod,fchmod,fchmodat -k my_chmod
 
--a always,exit -F arch=b64 -S setxattr,lsetxattr,fsetxattr,removexattr,lremovexattr,fremovexattr -k my_attr
--a always,exit -F arch=b32 -S setxattr,lsetxattr,fsetxattr,removexattr,lremovexattr,fremovexattr -k my_attr
+-a exit,always -F arch=b64 -S setxattr,lsetxattr,fsetxattr,removexattr,lremovexattr,fremovexattr -k my_attr
+-a exit,always -F arch=b32 -S setxattr,lsetxattr,fsetxattr,removexattr,lremovexattr,fremovexattr -k my_attr
 
 ## Audit rename/removal operations
--a always,exit -F arch=b64 -S rename,renameat,rmdir,unlink,unlinkat -F perm=x -k my_rename_remove
--a always,exit -F arch=b32 -S rename,renameat,rmdir,unlink,unlinkat -F perm=x -k my_rename_remove
+-a exit,always -F arch=b64 -S rename,renameat,rmdir,unlink,unlinkat -F perm=x -k my_rename_remove
+-a exit,always -F arch=b32 -S rename,renameat,rmdir,unlink,unlinkat -F perm=x -k my_rename_remove
 
 ## Audit useful items that someone does when su'ing to root.
--a always,exit -F arch=b64 -F auid!=0 -F uid=0 -S capset,mknod,mknodat,pivot_root,quotactl,setsid,adjtimex,settimeofday,setuid,swapoff,swapon,execve,rename,renameat,rmdir,unlink,unlinkat,write,chown,fchown,fchownat,lchown,creat,fork,vfork,link,linkat,symlink,symlinkat,mkdir,mkdirat -k my_su_root_activity
--a always,exit -F arch=b32 -F auid!=0 -F uid=0 -S capset,mknod,mknodat,pivot_root,quotactl,setsid,adjtimex,settimeofday,setuid,swapoff,swapon,execve,rename,renameat,rmdir,unlink,unlinkat,write,chown,fchown,fchownat,lchown,creat,fork,vfork,link,linkat,symlink,symlinkat,mkdir,mkdirat -k my_su_root_activity
+-a exit,always -F arch=b64 -F auid!=0 -F uid=0 -S capset,mknod,mknodat,pivot_root,quotactl,setsid,adjtimex,settimeofday,setuid,swapoff,swapon,execve,rename,renameat,rmdir,unlink,unlinkat,write,chown,fchown,fchownat,lchown,creat,fork,vfork,link,linkat,symlink,symlinkat,mkdir,mkdirat -k my_su_root_activity
+-a exit,always -F arch=b32 -F auid!=0 -F uid=0 -S capset,mknod,mknodat,pivot_root,quotactl,setsid,adjtimex,settimeofday,setuid,swapoff,swapon,execve,rename,renameat,rmdir,unlink,unlinkat,write,chown,fchown,fchownat,lchown,creat,fork,vfork,link,linkat,symlink,symlinkat,mkdir,mkdirat -k my_su_root_activity
 
 ## Audit the execution of suid and sgid binaries.
--a always,exit -F arch=b64 -F euid=0 -F uid!=0 -S execve -k my_suid_sgid
--a always,exit -F arch=b32 -F euid=0 -F uid!=0 -S execve -k my_suid_sgid
+-a exit,always -F arch=b64 -F euid=0 -F uid!=0 -S execve -k my_suid_sgid
+-a exit,always -F arch=b32 -F euid=0 -F uid!=0 -S execve -k my_suid_sgid
 
 ## Audit the loading and unloading of kernel modules.
 -w /usr/bin/kmod -p x -k my_kernel_modules
@@ -112,42 +112,42 @@
 -w /usr/sbin/modprobe -p x -k my_kernel_modules
 -w /sbin/modprobe -p x -k my_kernel_modules
 
--a always,exit -F arch=b64 -S create_module,init_module,finit_module,delete_module -k my_kernel_modules
--a always,exit -F arch=b32 -S create_module,init_module,finit_module,delete_module -k my_kernel_modules
+-a exit,always -F arch=b64 -S create_module,init_module,finit_module,delete_module -k my_kernel_modules
+-a exit,always -F arch=b32 -S create_module,init_module,finit_module,delete_module -k my_kernel_modules
 
 ## Audit things that could affect time
--a always,exit -F arch=b64 -S adjtimex,settimeofday -k my_time
--a always,exit -F arch=b64 -S clock_settime -F a0=0x0 -k my_time
--a always,exit -F arch=b32 -S adjtimex,stime,settimeofday -k my_time
--a always,exit -F arch=b32 -S clock_settime -F a0=0x0 -k my_time
+-a exit,always -F arch=b64 -S adjtimex,settimeofday -k my_time
+-a exit,always -F arch=b64 -S clock_settime -F a0=0x0 -k my_time
+-a exit,always -F arch=b32 -S adjtimex,stime,settimeofday -k my_time
+-a exit,always -F arch=b32 -S clock_settime -F a0=0x0 -k my_time
 
 -w /etc/localtime -p wa -k my_time
 
 ## Audit things that could affect system locale
--a always,exit -F arch=b64 -S sethostname,setdomainname -k my_locale
--a always,exit -F arch=b32 -S sethostname,setdomainname -k my_locale
+-a exit,always -F arch=b64 -S sethostname,setdomainname -k my_locale
+-a exit,always -F arch=b32 -S sethostname,setdomainname -k my_locale
 
 -w /etc/issue -p wa -k my_locale
 -w /etc/issue.net -p wa -k my_locale
 -w /etc/hosts -p wa -k my_locale
 -w /etc/hostname -p wa -k my_locale
 -w /etc/sysconfig/network -p wa -k my_locale
--a always,exit -F dir=/etc/NetworkManager/ -F perm=wa -k my_locale
+-a exit,always -F dir=/etc/NetworkManager/ -F perm=wa -k my_locale
 
 ## Audit mount operations
--a always,exit -F arch=b64 -S mount,umount2 -k my_mount
--a always,exit -F arch=b32 -S mount,umount,umount2 -k my_mount
+-a exit,always -F arch=b64 -S mount,umount2 -k my_mount
+-a exit,always -F arch=b32 -S mount,umount,umount2 -k my_mount
 
--a always,exit -F arch=b64 -F path=/usr/bin/mount -k my_mount
--a always,exit -F arch=b64 -F path=/bin/mount -k my_mount
--a always,exit -F arch=b32 -F path=/usr/bin/mount -k my_mount
--a always,exit -F arch=b32 -F path=/bin/mount -k my_mount
--a always,exit -F path=/usr/bin/umount -F perm=x -k my_mount
--a always,exit -F path=/bin/umount -F perm=x -k my_mount
+-a exit,always -F arch=b64 -F path=/usr/bin/mount -k my_mount
+-a exit,always -F arch=b64 -F path=/bin/mount -k my_mount
+-a exit,always -F arch=b32 -F path=/usr/bin/mount -k my_mount
+-a exit,always -F arch=b32 -F path=/bin/mount -k my_mount
+-a exit,always -F path=/usr/bin/umount -F perm=x -k my_mount
+-a exit,always -F path=/bin/umount -F perm=x -k my_mount
 
 ## Audit umask changes.
--a always,exit -F arch=b64 -S umask -k my_umask
--a always,exit -F arch=b32 -S umask -k my_umask
+-a exit,always -F arch=b64 -S umask -k my_umask
+-a exit,always -F arch=b32 -S umask -k my_umask
 
 ## Audit local accounts
 -w /etc/passwd -p wa -k my_local_account
@@ -257,15 +257,15 @@
 -w /bin/yum -p x -k my_yum_cmd
 -w /usr/bin/rpm -p x -k my_rpm_cmd
 -w /bin/rpm -p x -k my_rpm_cmd
--a always,exit -F arch=b64 -S ptrace -F a0=0x4 -k paranoid_code_injection
--a always,exit -F arch=b64 -S ptrace -F a0=0x5 -k paranoid_data_injection
--a always,exit -F arch=b64 -S ptrace -F a0=0x6 -k paranoid_register_injection
--a always,exit -F arch=b64 -S ptrace -k paranoid
--a always,exit -F arch=b32 -S ptrace -F a0=0x4 -k paranoid_code_injection
--a always,exit -F arch=b32 -S ptrace -F a0=0x5 -k paranoid_data_injection
--a always,exit -F arch=b32 -S ptrace -F a0=0x6 -k paranoid_register_injection
--a always,exit -F arch=b32 -S ptrace -k paranoid
--a always,exit -F arch=b64 -S personality -k paranoid
--a always,exit -F arch=b32 -S personality -k paranoid
--a always,exit -F arch=b64 -S personality -k my_personality
--a always,exit -F arch=b32 -S personality -k my_personality
+-a exit,always -F arch=b64 -S ptrace -F a0=0x4 -k paranoid_code_injection
+-a exit,always -F arch=b64 -S ptrace -F a0=0x5 -k paranoid_data_injection
+-a exit,always -F arch=b64 -S ptrace -F a0=0x6 -k paranoid_register_injection
+-a exit,always -F arch=b64 -S ptrace -k paranoid
+-a exit,always -F arch=b32 -S ptrace -F a0=0x4 -k paranoid_code_injection
+-a exit,always -F arch=b32 -S ptrace -F a0=0x5 -k paranoid_data_injection
+-a exit,always -F arch=b32 -S ptrace -F a0=0x6 -k paranoid_register_injection
+-a exit,always -F arch=b32 -S ptrace -k paranoid
+-a exit,always -F arch=b64 -S personality -k paranoid
+-a exit,always -F arch=b32 -S personality -k paranoid
+-a exit,always -F arch=b64 -S personality -k my_personality
+-a exit,always -F arch=b32 -S personality -k my_personality

--- a/spec/classes/config/audit_profiles/expected/simp_el7_all_rules_custom_tags.txt
+++ b/spec/classes/config/audit_profiles/expected/simp_el7_all_rules_custom_tags.txt
@@ -1,14 +1,13 @@
 #### auditd::config::audit_profiles::simp Audit Rules ####
+# 64-bit systems should generally never call the 32-bit API. 32-bit syscalls
+# may be a sign of someone exploiting a hole in the API.
+-a always,exit -F arch=b32 -S all -F key=32bit-api
+-a always,exit -F arch=b64 -S accept -F a0=2 -F key=ipv4_in
+-a always,exit -F arch=b32 -S accept -F a0=2 -F key=ipv4_in
+-a always,exit -F arch=b64 -S accept -F a0=10 -F key=ipv6_in
+-a always,exit -F arch=b32 -S accept -F a0=10 -F key=ipv6_in
 
 ## Audit unsuccessful file operations
-# CCE-26712-0
-# CCE-26651-0
-# RHEL-07-030500
-# RHEL-07-030510
-# RHEL-07-030520
-# RHEL-07-030530
-# RHEL-07-030540
-# RHEL-07-030550
 -a always,exit -F arch=b64 -S creat,mkdir,mknod,link,symlink,mkdirat,mknodat,linkat,symlinkat,openat,open_by_handle_at,open,close,rename,renameat,truncate,ftruncate,rmdir,unlink,unlinkat -F exit=-EACCES -k my_unsuccessful_file_operations
 -a always,exit -F arch=b64 -S creat,mkdir,mknod,link,symlink,mkdirat,mknodat,linkat,symlinkat,openat,open_by_handle_at,open,close,rename,renameat,truncate,ftruncate,rmdir,unlink,unlinkat -F exit=-EPERM -k my_unsuccessful_file_operations
 -a always,exit -F arch=b32 -S creat,mkdir,mknod,link,symlink,mkdirat,mknodat,linkat,symlinkat,openat,open_by_handle_at,open,close,rename,renameat,truncate,ftruncate,rmdir,unlink,unlinkat -F exit=-EACCES -k my_unsuccessful_file_operations
@@ -18,189 +17,116 @@
 -a always,exit -F perm=a -F exit=-EPERM -k my_unsuccessful_file_operations
 
 ## Audit the execution of password commands
-# RHEL-07-030630
 -a always,exit -F path=/usr/bin/passwd -F perm=x -k my_passwd_cmds
 -a always,exit -F path=/bin/passwd -F perm=x -k my_passwd_cmds
 
-# RHEL-07-030640
 -a always,exit -F path=/usr/sbin/unix_chkpwd -F perm=x -k my_passwd_cmds
 -a always,exit -F path=/sbin/unix_chkpwd -F perm=x -k my_passwd_cmds
 
-# RHEL-07-030650
 -a always,exit -F path=/usr/bin/gpasswd -F perm=x -k my_passwd_cmds
 -a always,exit -F path=/bin/gpasswd -F perm=x -k my_passwd_cmds
 
-# RHEL-07-030660
 -a always,exit -F path=/usr/bin/chage -F perm=x -k my_passwd_cmds
 -a always,exit -F path=/bin/chage -F perm=x -k my_passwd_cmds
 
-# RHEL-07-030670
 -a always,exit -F path=/usr/sbin/userhelper -F perm=x -k my_passwd_cmds
 -a always,exit -F path=/sbin/userhelper -F perm=x -k my_passwd_cmds
 
 ## Audit the execution of privilege-related commands
-# RHEL-07-030680
 -a always,exit -F path=/usr/bin/su -F perm=x -k my_priv_cmds
 -a always,exit -F path=/bin/su -F perm=x -k my_priv_cmds
 
-# RHEL-07-030690
 -a always,exit -F path=/usr/bin/sudo -F perm=x -k my_priv_cmds
 -a always,exit -F path=/bin/sudo -F perm=x -k my_priv_cmds
 
-# RHEL-07-030710
 -a always,exit -F path=/usr/bin/newgrp -F perm=x -k my_priv_cmds
 -a always,exit -F path=/bin/newgrp -F perm=x -k my_priv_cmds
 
-# RHEL-07-030720
 -a always,exit -F path=/usr/bin/chsh -F perm=x -k my_priv_cmds
 
-# RHEL-07-030730
 -a always,exit -F path=/usr/bin/sudoedit -F perm=x -k my_priv_cmds
 -a always,exit -F path=/bin/sudoedit -F perm=x -k my_priv_cmds
 
 ## Audit the execution of postfix-related commands
-# RHEL-07-030760
 -a always,exit -F path=/usr/sbin/postdrop -F perm=x -k my_postfix_cmds
 -a always,exit -F path=/sbin/postdrop -F perm=x -k my_postfix_cmds
 
-# RHEL-07-030770
 -a always,exit -F path=/usr/sbin/postqueue -F perm=x -k my_postfix_cmds
 -a always,exit -F path=/sbin/postqueue -F perm=x -k my_postfix_cmds
 
 ## Audit the execution of the ssh-keysign command
-# RHEL-07-030780
 -a always,exit -F path=/usr/libexec/openssh/ssh-keysign -F perm=x -k my_ssh_keysign_cmd
 
 ## Audit the execution of the crontab command
-# RHEL-07-030800
 -a always,exit -F path=/usr/bin/crontab -F perm=x -k my_crontab_cmd
 -a always,exit -F path=/bin/crontab -F perm=x -k my_crontab_cmd
 
 ## Audit the execution of the pam_timestamp_check command
-# RHEL-07-030810
 -a always,exit -F path=/usr/sbin/pam_timestamp_check -F perm=x -k my_pam_timestamp_check_cmd
 -a always,exit -F path=/sbin/pam_timestamp_check -F perm=x -k my_pam_timestamp_check_cmd
 
 ## Audit selinux commands
-# NOTE:  These rules come before the *xattr* checks, to ensure the
-#        correct tag is recorded.
 #
-# RHEL-07-030560
 -a always,exit -F path=/usr/sbin/semanage -F perm=x -k my_selinux_cmds
 -a always,exit -F path=/sbin/semanage -F perm=x -k my_selinux_cmds
 
-# RHEL-07-030570
 -a always,exit -F path=/usr/sbin/setsebool -F perm=x -k my_selinux_cmds
 -a always,exit -F path=/sbin/setsebool -F perm=x -k my_selinux_cmds
 
-# RHEL-07-030580
 -a always,exit -F path=/usr/bin/chcon -F perm=x -k my_selinux_cmds
 -a always,exit -F path=/bin/chcon -F perm=x -k my_selinux_cmds
 
-# RHEL-07-030590
 -a always,exit -F path=/usr/sbin/setfiles -F perm=x -k my_selinux_cmds
 -a always,exit -F path=/sbin/setfiles -F perm=x -k my_selinux_cmds
 
 ## Permissions auditing separated by chown, chmod, and attr
-# CCE-26280-8
-# CCE-27173-4
-# CCE-27174-2
-# CCE-27175-9
-# CCE-27177-5
-# CCE-27178-3
-# CCE-27179-1
-# CCE-27180-9
-# CCE-27181-7
-# CCE-27182-5
-# CCE-27183-3
-# CCE-27184-1
-# CCE-27185-8
 
-# RHEL-07-030370
-# RHEL-07-030380
-# RHEL-07-030390
-# RHEL-07-030400
 -a always,exit -F arch=b64 -S chown,fchown,fchownat,lchown -k my_chown
 -a always,exit -F arch=b32 -S chown,fchown,fchownat,lchown -k my_chown
 
-# RHEL-07-030410
-# RHEL-07-030420
-# RHEL-07-030430
 -a always,exit -F arch=b64 -S chmod,fchmod,fchmodat -k my_chmod
 -a always,exit -F arch=b32 -S chmod,fchmod,fchmodat -k my_chmod
 
-# RHEL-07-030440
-# RHEL-07-030450
-# RHEL-07-030460
-# RHEL-07-030470
-# RHEL-07-030480
-# RHEL-07-030490
 -a always,exit -F arch=b64 -S setxattr,lsetxattr,fsetxattr,removexattr,lremovexattr,fremovexattr -k my_attr
 -a always,exit -F arch=b32 -S setxattr,lsetxattr,fsetxattr,removexattr,lremovexattr,fremovexattr -k my_attr
 
 ## Audit rename/removal operations
-# RHEL-07-030880
-# RHEL-07-030890
-# RHEL-07-030900
-# RHEL-07-030910
-# RHEL-07-030920
 -a always,exit -F arch=b64 -S rename,renameat,rmdir,unlink,unlinkat -F perm=x -k my_rename_remove
 -a always,exit -F arch=b32 -S rename,renameat,rmdir,unlink,unlinkat -F perm=x -k my_rename_remove
 
 ## Audit useful items that someone does when su'ing to root.
-# Had to add an entry in the default_drop rules file for getting rid of
-# anonymous records.  They are only moderately useful and contain *way*
-# too much noise since this covers things like cron as well.
 -a always,exit -F arch=b64 -F auid!=0 -F uid=0 -S capset,mknod,mknodat,pivot_root,quotactl,setsid,adjtimex,settimeofday,setuid,swapoff,swapon,execve,rename,renameat,rmdir,unlink,unlinkat,write,chown,fchown,fchownat,lchown,creat,fork,vfork,link,linkat,symlink,symlinkat,mkdir,mkdirat -k my_su_root_activity
 -a always,exit -F arch=b32 -F auid!=0 -F uid=0 -S capset,mknod,mknodat,pivot_root,quotactl,setsid,adjtimex,settimeofday,setuid,swapoff,swapon,execve,rename,renameat,rmdir,unlink,unlinkat,write,chown,fchown,fchownat,lchown,creat,fork,vfork,link,linkat,symlink,symlinkat,mkdir,mkdirat -k my_su_root_activity
 
 ## Audit the execution of suid and sgid binaries.
-# CCE-26457-2
-# RHEL-07-030360
 -a always,exit -F arch=b64 -F euid=0 -F uid!=0 -S execve -k my_suid_sgid
 -a always,exit -F arch=b32 -F euid=0 -F uid!=0 -S execve -k my_suid_sgid
 
 ## Audit the loading and unloading of kernel modules.
-# CCE-26611-4
 -w /usr/bin/kmod -p x -k my_kernel_modules
 -w /bin/kmod -p x -k my_kernel_modules
-
-# RHEL-07-030840
 -w /usr/sbin/insmod -p x -k my_kernel_modules
 -w /sbin/insmod -p x -k my_kernel_modules
-
-# RHEL-07-030850
 -w /usr/sbin/rmmod -p x -k my_kernel_modules
 -w /sbin/rmmod -p x -k my_kernel_modules
-
-# RHEL-07-030860
 -w /usr/sbin/modprobe -p x -k my_kernel_modules
 -w /sbin/modprobe -p x -k my_kernel_modules
 
-# RHEL-07-030819
-# RHEL-07-030820
-# RHEL-07-030821
-# RHEL-07-030830
 -a always,exit -F arch=b64 -S create_module,init_module,finit_module,delete_module -k my_kernel_modules
 -a always,exit -F arch=b32 -S create_module,init_module,finit_module,delete_module -k my_kernel_modules
 
 ## Audit things that could affect time
-# CCE-27172-6
-# CCE-27203-9
-# CCE-27169-2
-# CCE-27170-0
--a always,exit -F arch=b32 -S adjtimex,stime,settimeofday -k my_time
 -a always,exit -F arch=b64 -S adjtimex,settimeofday -k my_time
--a always,exit -F arch=b32 -S clock_settime -F a0=0x0 -k my_time
 -a always,exit -F arch=b64 -S clock_settime -F a0=0x0 -k my_time
+-a always,exit -F arch=b32 -S adjtimex,stime,settimeofday -k my_time
+-a always,exit -F arch=b32 -S clock_settime -F a0=0x0 -k my_time
 
-# CCE-27172-6
 -w /etc/localtime -p wa -k my_time
 
 ## Audit things that could affect system locale
-# CCE-26648-6
--a always,exit -F arch=b32 -S sethostname,setdomainname -k my_locale
 -a always,exit -F arch=b64 -S sethostname,setdomainname -k my_locale
+-a always,exit -F arch=b32 -S sethostname,setdomainname -k my_locale
+
 -w /etc/issue -p wa -k my_locale
 -w /etc/issue.net -p wa -k my_locale
 -w /etc/hosts -p wa -k my_locale
@@ -209,12 +135,9 @@
 -a always,exit -F dir=/etc/NetworkManager/ -F perm=wa -k my_locale
 
 ## Audit mount operations
-# CCE-26573-6
-#
-# RHEL-07-030740
-# RHEL-07-030750
--a always,exit -F arch=b32 -S mount,umount,umount2 -k my_mount
 -a always,exit -F arch=b64 -S mount,umount2 -k my_mount
+-a always,exit -F arch=b32 -S mount,umount,umount2 -k my_mount
+
 -a always,exit -F arch=b64 -F path=/usr/bin/mount -k my_mount
 -a always,exit -F arch=b64 -F path=/bin/mount -k my_mount
 -a always,exit -F arch=b32 -F path=/usr/bin/mount -k my_mount
@@ -223,62 +146,60 @@
 -a always,exit -F path=/bin/umount -F perm=x -k my_mount
 
 ## Audit umask changes.
-# This is uselessly noisy.
 -a always,exit -F arch=b64 -S umask -k my_umask
 -a always,exit -F arch=b32 -S umask -k my_umask
 
 ## Audit local accounts
-# CCE-26664-3
-#
-# RHEL-07-030870
 -w /etc/passwd -p wa -k my_local_account
-
-# RHEL-07-030871
 -w /etc/group -p wa -k my_local_account
-
-# RHEL-07-030872
 -w /etc/gshadow -p wa -k my_local_account
-
-# RHEL-07-030873
 -w /etc/shadow -p wa -k my_local_account
-
-# RHEL-07-030874
 -w /etc/security/opasswd -p wa -k my_local_account
-
 -w /etc/passwd- -p wa -k my_local_account
 -w /etc/group- -p wa -k my_local_account
 -w /etc/shadow- -p wa -k my_local_account
 
 ## Audit selinux policy
-# CCE-26657-7
 -w /etc/selinux/ -p wa -k my_selinux_policy
 -w /usr/share/selinux/ -p wa -k my_selinux_policy
 
 ## Audit login files
-# CCE-26691-6
-#
-# RHEL-07-030600
 -w /var/log/tallylog -p wa -k my_login_files
-
-# RHEL-07-030610
 -w /var/run/faillock -p wa -k my_login_files
-
-# RHEL-07-030620
 -w /var/log/lastlog -p wa -k my_login_files
-
 -w /var/log/faillog -p wa -k my_login_files
 
 ## Audit session files
-# CCE-26610-6
 -w /var/run/utmp -p wa -k my_session_files
 -w /var/log/btmp -p wa -k my_session_files
 -w /var/log/wtmp -p wa -k my_session_files
 
 ## Audit sudoers configuration files
-# CCE-26662-7
-# RHEL-07-030700
 -w /etc/sudoers -p wa -k my_cfg_sudoers
 -w /etc/sudoers.d/ -p wa -k my_cfg_sudoers
+
+## Audit accesses to the audit trail
+-w /usr/sbin/aulast -p x -k access-audit-trail
+-w /usr/sbin/aulastlogin -p x -k access-audit-trail
+-w /usr/sbin/aureport -p x -k access-audit-trail
+-w /usr/sbin/ausearch -p x -k access-audit-trail
+-w /usr/sbin/auvirt -p x -k access-audit-trail
+
+## Audit systemd components
+-w /bin/systemctl -p x -k systemd
+-w /usr/bin/systemctl -p x -k systemd
+-w /etc/systemd/ -p wa -k systemd
+
+## Audit suspicious applications
+-w /usr/bin/nc -p x -k suspicious_apps
+-w /usr/bin/ncat -p x -k suspicious_apps
+-w /usr/bin/nmap -p x -k suspicious_apps
+-w /usr/bin/rawshark -p x -k suspicious_apps
+-w /usr/bin/socat -p x -k suspicious_apps
+-w /usr/bin/wireshark -p x -k suspicious_apps
+-w /usr/sbin/tcpdump -p x -k suspicious_apps
+-w /usr/sbin/traceroute -p x -k suspicious_apps
+-w /usr/sbin/traceroute6 -p x -k suspicious_apps
 
 ## Generally good things to audit.
 -w /etc/grub.d -p wa -k my_cfg_grub
@@ -290,8 +211,6 @@
 -w /etc/hosts.deny -p wa -k my_cfg_sys
 -w /etc/initlog.conf -p wa -k my_cfg_sys
 -w /etc/inittab -p wa -k my_cfg_sys
--w /etc/issue -p wa -k my_cfg_sys
--w /etc/issue.net -p wa -k my_cfg_sys
 -w /etc/krb5.conf -p wa -k my_cfg_sys
 -w /etc/ld.so.conf -p wa -k my_cfg_sys
 -w /etc/ld.so.conf.d -p wa -k my_cfg_sys
@@ -338,7 +257,15 @@
 -w /bin/yum -p x -k my_yum_cmd
 -w /usr/bin/rpm -p x -k my_rpm_cmd
 -w /bin/rpm -p x -k my_rpm_cmd
--a always,exit -F arch=b32 -S ptrace -k my_ptrace
--a always,exit -F arch=b64 -S ptrace -k my_ptrace
--a always,exit -F arch=b32 -S personality -k my_personality
+-a always,exit -F arch=b64 -S ptrace -F a0=0x4 -k paranoid_code_injection
+-a always,exit -F arch=b64 -S ptrace -F a0=0x5 -k paranoid_data_injection
+-a always,exit -F arch=b64 -S ptrace -F a0=0x6 -k paranoid_register_injection
+-a always,exit -F arch=b64 -S ptrace -k paranoid
+-a always,exit -F arch=b32 -S ptrace -F a0=0x4 -k paranoid_code_injection
+-a always,exit -F arch=b32 -S ptrace -F a0=0x5 -k paranoid_data_injection
+-a always,exit -F arch=b32 -S ptrace -F a0=0x6 -k paranoid_register_injection
+-a always,exit -F arch=b32 -S ptrace -k paranoid
+-a always,exit -F arch=b64 -S personality -k paranoid
+-a always,exit -F arch=b32 -S personality -k paranoid
 -a always,exit -F arch=b64 -S personality -k my_personality
+-a always,exit -F arch=b32 -S personality -k my_personality

--- a/spec/classes/config/audit_profiles/expected/simp_el7_basic_rules.txt
+++ b/spec/classes/config/audit_profiles/expected/simp_el7_basic_rules.txt
@@ -1,14 +1,13 @@
 #### auditd::config::audit_profiles::simp Audit Rules ####
+# 64-bit systems should generally never call the 32-bit API. 32-bit syscalls
+# may be a sign of someone exploiting a hole in the API.
+-a always,exit -F arch=b32 -S all -F key=32bit-api
+-a always,exit -F arch=b64 -S accept -F a0=2 -F key=ipv4_in
+-a always,exit -F arch=b32 -S accept -F a0=2 -F key=ipv4_in
+-a always,exit -F arch=b64 -S accept -F a0=10 -F key=ipv6_in
+-a always,exit -F arch=b32 -S accept -F a0=10 -F key=ipv6_in
 
 ## Audit unsuccessful file operations
-# CCE-26712-0
-# CCE-26651-0
-# RHEL-07-030500
-# RHEL-07-030510
-# RHEL-07-030520
-# RHEL-07-030530
-# RHEL-07-030540
-# RHEL-07-030550
 -a always,exit -F arch=b64 -S creat,mkdir,mknod,link,symlink,mkdirat,mknodat,linkat,symlinkat,openat,open_by_handle_at,open,close,rename,renameat,truncate,ftruncate,rmdir,unlink,unlinkat -F exit=-EACCES -k access
 -a always,exit -F arch=b64 -S creat,mkdir,mknod,link,symlink,mkdirat,mknodat,linkat,symlinkat,openat,open_by_handle_at,open,close,rename,renameat,truncate,ftruncate,rmdir,unlink,unlinkat -F exit=-EPERM -k access
 -a always,exit -F arch=b32 -S creat,mkdir,mknod,link,symlink,mkdirat,mknodat,linkat,symlinkat,openat,open_by_handle_at,open,close,rename,renameat,truncate,ftruncate,rmdir,unlink,unlinkat -F exit=-EACCES -k access
@@ -18,155 +17,96 @@
 -a always,exit -F perm=a -F exit=-EPERM -k access
 
 ## Audit the execution of password commands
-# RHEL-07-030630
 -a always,exit -F path=/usr/bin/passwd -F perm=x -k privileged-passwd
 -a always,exit -F path=/bin/passwd -F perm=x -k privileged-passwd
 
-# RHEL-07-030640
 -a always,exit -F path=/usr/sbin/unix_chkpwd -F perm=x -k privileged-passwd
 -a always,exit -F path=/sbin/unix_chkpwd -F perm=x -k privileged-passwd
 
-# RHEL-07-030650
 -a always,exit -F path=/usr/bin/gpasswd -F perm=x -k privileged-passwd
 -a always,exit -F path=/bin/gpasswd -F perm=x -k privileged-passwd
 
-# RHEL-07-030660
 -a always,exit -F path=/usr/bin/chage -F perm=x -k privileged-passwd
 -a always,exit -F path=/bin/chage -F perm=x -k privileged-passwd
 
-# RHEL-07-030670
 -a always,exit -F path=/usr/sbin/userhelper -F perm=x -k privileged-passwd
 -a always,exit -F path=/sbin/userhelper -F perm=x -k privileged-passwd
 
 ## Audit the execution of privilege-related commands
-# RHEL-07-030680
 -a always,exit -F path=/usr/bin/su -F perm=x -k privileged-priv_change
 -a always,exit -F path=/bin/su -F perm=x -k privileged-priv_change
 
-# RHEL-07-030690
 -a always,exit -F path=/usr/bin/sudo -F perm=x -k privileged-priv_change
 -a always,exit -F path=/bin/sudo -F perm=x -k privileged-priv_change
 
-# RHEL-07-030710
 -a always,exit -F path=/usr/bin/newgrp -F perm=x -k privileged-priv_change
 -a always,exit -F path=/bin/newgrp -F perm=x -k privileged-priv_change
 
-# RHEL-07-030720
 -a always,exit -F path=/usr/bin/chsh -F perm=x -k privileged-priv_change
 -a always,exit -F path=/bin/chsh -F perm=x -k privileged-priv_change
 
-# RHEL-07-030730
 -a always,exit -F path=/usr/bin/sudoedit -F perm=x -k privileged-priv_change
 -a always,exit -F path=/bin/sudoedit -F perm=x -k privileged-priv_change
 
 ## Audit the execution of postfix-related commands
-# RHEL-07-030760
 -a always,exit -F path=/usr/sbin/postdrop -F perm=x -k privileged-postfix
 -a always,exit -F path=/sbin/postdrop -F perm=x -k privileged-postfix
 
-# RHEL-07-030770
 -a always,exit -F path=/usr/sbin/postqueue -F perm=x -k privileged-postfix
 -a always,exit -F path=/sbin/postqueue -F perm=x -k privileged-postfix
 
 ## Audit the execution of the ssh-keysign command
-# RHEL-07-030780
 -a always,exit -F path=/usr/libexec/openssh/ssh-keysign -F perm=x -k privileged-ssh
 
 ## Audit the execution of the crontab command
-# RHEL-07-030800
 -a always,exit -F path=/usr/bin/crontab -F perm=x -k privileged-cron
 -a always,exit -F path=/bin/crontab -F perm=x -k privileged-cron
 
 ## Audit the execution of the pam_timestamp_check command
-# RHEL-07-030810
 -a always,exit -F path=/usr/sbin/pam_timestamp_check -F perm=x -k privileged-pam
 -a always,exit -F path=/sbin/pam_timestamp_check -F perm=x -k privileged-pam
 
 ## Permissions auditing separated by chown, chmod, and attr
-# CCE-26280-8
-# CCE-27173-4
-# CCE-27174-2
-# CCE-27175-9
-# CCE-27177-5
-# CCE-27178-3
-# CCE-27179-1
-# CCE-27180-9
-# CCE-27181-7
-# CCE-27182-5
-# CCE-27183-3
-# CCE-27184-1
-# CCE-27185-8
 
-# RHEL-07-030370
-# RHEL-07-030380
-# RHEL-07-030390
-# RHEL-07-030400
 -a always,exit -F arch=b64 -S chown,fchown,fchownat,lchown -k chown
 -a always,exit -F arch=b32 -S chown,fchown,fchownat,lchown -k chown
 
-# RHEL-07-030440
-# RHEL-07-030450
-# RHEL-07-030460
-# RHEL-07-030470
-# RHEL-07-030480
-# RHEL-07-030490
 -a always,exit -F arch=b64 -S setxattr,lsetxattr,fsetxattr,removexattr,lremovexattr,fremovexattr -k attr
 -a always,exit -F arch=b32 -S setxattr,lsetxattr,fsetxattr,removexattr,lremovexattr,fremovexattr -k attr
 
 ## Audit useful items that someone does when su'ing to root.
-# Had to add an entry in the default_drop rules file for getting rid of
-# anonymous records.  They are only moderately useful and contain *way*
-# too much noise since this covers things like cron as well.
 -a always,exit -F arch=b64 -F auid!=0 -F uid=0 -S capset,mknod,mknodat,pivot_root,quotactl,setsid,adjtimex,settimeofday,setuid,swapoff,swapon -k su-root-activity
 -a always,exit -F arch=b32 -F auid!=0 -F uid=0 -S capset,mknod,mknodat,pivot_root,quotactl,setsid,adjtimex,settimeofday,setuid,swapoff,swapon -k su-root-activity
 
 ## Audit the execution of suid and sgid binaries.
-# CCE-26457-2
-# RHEL-07-030360
 -a always,exit -F arch=b64 -F euid=0 -F uid!=0 -S execve -k suid-root-exec
 -a always,exit -F arch=b32 -F euid=0 -F uid!=0 -S execve -k suid-root-exec
 
 ## Audit the loading and unloading of kernel modules.
-# CCE-26611-4
 -w /usr/bin/kmod -p x -k modules
 -w /bin/kmod -p x -k modules
-
-# RHEL-07-030840
 -w /usr/sbin/insmod -p x -k modules
 -w /sbin/insmod -p x -k modules
-
-# RHEL-07-030850
 -w /usr/sbin/rmmod -p x -k modules
 -w /sbin/rmmod -p x -k modules
-
-# RHEL-07-030860
 -w /usr/sbin/modprobe -p x -k modules
 -w /sbin/modprobe -p x -k modules
 
-# RHEL-07-030819
-# RHEL-07-030820
-# RHEL-07-030821
-# RHEL-07-030830
 -a always,exit -F arch=b64 -S create_module,init_module,finit_module,delete_module -k modules
 -a always,exit -F arch=b32 -S create_module,init_module,finit_module,delete_module -k modules
 
 ## Audit things that could affect time
-# CCE-27172-6
-# CCE-27203-9
-# CCE-27169-2
-# CCE-27170-0
--a always,exit -F arch=b32 -S adjtimex,stime,settimeofday -k audit_time_rules
 -a always,exit -F arch=b64 -S adjtimex,settimeofday -k audit_time_rules
--a always,exit -F arch=b32 -S clock_settime -F a0=0x0 -k audit_time_rules
 -a always,exit -F arch=b64 -S clock_settime -F a0=0x0 -k audit_time_rules
+-a always,exit -F arch=b32 -S adjtimex,stime,settimeofday -k audit_time_rules
+-a always,exit -F arch=b32 -S clock_settime -F a0=0x0 -k audit_time_rules
 
-# CCE-27172-6
 -w /etc/localtime -p wa -k audit_time_rules
 
 ## Audit things that could affect system locale
-# CCE-26648-6
--a always,exit -F arch=b32 -S sethostname,setdomainname -k audit_network_modifications
 -a always,exit -F arch=b64 -S sethostname,setdomainname -k audit_network_modifications
+-a always,exit -F arch=b32 -S sethostname,setdomainname -k audit_network_modifications
+
 -w /etc/issue -p wa -k audit_network_modifications
 -w /etc/issue.net -p wa -k audit_network_modifications
 -w /etc/hosts -p wa -k audit_network_modifications
@@ -175,12 +115,9 @@
 -a always,exit -F dir=/etc/NetworkManager/ -F perm=wa -k audit_network_modifications
 
 ## Audit mount operations
-# CCE-26573-6
-#
-# RHEL-07-030740
-# RHEL-07-030750
--a always,exit -F arch=b32 -S mount,umount,umount2 -k mount
 -a always,exit -F arch=b64 -S mount,umount2 -k mount
+-a always,exit -F arch=b32 -S mount,umount,umount2 -k mount
+
 -a always,exit -F arch=b64 -F path=/usr/bin/mount -k mount
 -a always,exit -F arch=b64 -F path=/bin/mount -k mount
 -a always,exit -F arch=b32 -F path=/usr/bin/mount -k mount
@@ -189,57 +126,56 @@
 -a always,exit -F path=/bin/umount -F perm=x -k mount
 
 ## Audit local accounts
-# CCE-26664-3
-#
-# RHEL-07-030870
 -w /etc/passwd -p wa -k audit_account_changes
-
-# RHEL-07-030871
 -w /etc/group -p wa -k audit_account_changes
-
-# RHEL-07-030872
 -w /etc/gshadow -p wa -k audit_account_changes
-
-# RHEL-07-030873
 -w /etc/shadow -p wa -k audit_account_changes
-
-# RHEL-07-030874
 -w /etc/security/opasswd -p wa -k audit_account_changes
-
 -w /etc/passwd- -p wa -k audit_account_changes
 -w /etc/group- -p wa -k audit_account_changes
 -w /etc/shadow- -p wa -k audit_account_changes
 
 ## Audit selinux policy
-# CCE-26657-7
 -w /etc/selinux/ -p wa -k MAC-policy
 -w /usr/share/selinux/ -p wa -k MAC-policy
 
 ## Audit login files
-# CCE-26691-6
-#
-# RHEL-07-030600
 -w /var/log/tallylog -p wa -k logins
-
-# RHEL-07-030610
 -w /var/run/faillock -p wa -k logins
-
-# RHEL-07-030620
 -w /var/log/lastlog -p wa -k logins
-
 -w /var/log/faillog -p wa -k logins
 
 ## Audit session files
-# CCE-26610-6
 -w /var/run/utmp -p wa -k session
 -w /var/log/btmp -p wa -k session
 -w /var/log/wtmp -p wa -k session
 
 ## Audit sudoers configuration files
-# CCE-26662-7
-# RHEL-07-030700
 -w /etc/sudoers -p wa -k CFG_sys
 -w /etc/sudoers.d/ -p wa -k CFG_sys
+
+## Audit accesses to the audit trail
+-w /usr/sbin/aulast -p x -k access-audit-trail
+-w /usr/sbin/aulastlogin -p x -k access-audit-trail
+-w /usr/sbin/aureport -p x -k access-audit-trail
+-w /usr/sbin/ausearch -p x -k access-audit-trail
+-w /usr/sbin/auvirt -p x -k access-audit-trail
+
+## Audit systemd components
+-w /bin/systemctl -p x -k systemd
+-w /usr/bin/systemctl -p x -k systemd
+-w /etc/systemd/ -p wa -k systemd
+
+## Audit suspicious applications
+-w /usr/bin/nc -p x -k suspicious_apps
+-w /usr/bin/ncat -p x -k suspicious_apps
+-w /usr/bin/nmap -p x -k suspicious_apps
+-w /usr/bin/rawshark -p x -k suspicious_apps
+-w /usr/bin/socat -p x -k suspicious_apps
+-w /usr/bin/wireshark -p x -k suspicious_apps
+-w /usr/sbin/tcpdump -p x -k suspicious_apps
+-w /usr/sbin/traceroute -p x -k suspicious_apps
+-w /usr/sbin/traceroute6 -p x -k suspicious_apps
 
 ## Generally good things to audit.
 -w /etc/grub.d -p wa -k CFG_grub
@@ -251,8 +187,6 @@
 -w /etc/hosts.deny -p wa -k CFG_sys
 -w /etc/initlog.conf -p wa -k CFG_sys
 -w /etc/inittab -p wa -k CFG_sys
--w /etc/issue -p wa -k CFG_sys
--w /etc/issue.net -p wa -k CFG_sys
 -w /etc/krb5.conf -p wa -k CFG_sys
 -w /etc/ld.so.conf -p wa -k CFG_sys
 -w /etc/ld.so.conf.d -p wa -k CFG_sys
@@ -295,7 +229,13 @@
 -w /etc/yum -p wa -k yum-config
 -w /etc/yum.conf -p wa -k yum-config
 -w /etc/yum.repos.d -p wa -k yum-config
--a always,exit -F arch=b32 -S ptrace -k paranoid
+-a always,exit -F arch=b64 -S ptrace -F a0=0x4 -k paranoid_code_injection
+-a always,exit -F arch=b64 -S ptrace -F a0=0x5 -k paranoid_data_injection
+-a always,exit -F arch=b64 -S ptrace -F a0=0x6 -k paranoid_register_injection
 -a always,exit -F arch=b64 -S ptrace -k paranoid
--a always,exit -F arch=b32 -S personality -k paranoid
+-a always,exit -F arch=b32 -S ptrace -F a0=0x4 -k paranoid_code_injection
+-a always,exit -F arch=b32 -S ptrace -F a0=0x5 -k paranoid_data_injection
+-a always,exit -F arch=b32 -S ptrace -F a0=0x6 -k paranoid_register_injection
+-a always,exit -F arch=b32 -S ptrace -k paranoid
 -a always,exit -F arch=b64 -S personality -k paranoid
+-a always,exit -F arch=b32 -S personality -k paranoid

--- a/spec/classes/config/audit_profiles/expected/simp_el7_basic_rules.txt
+++ b/spec/classes/config/audit_profiles/expected/simp_el7_basic_rules.txt
@@ -1,86 +1,86 @@
 #### auditd::config::audit_profiles::simp Audit Rules ####
 # 64-bit systems should generally never call the 32-bit API. 32-bit syscalls
 # may be a sign of someone exploiting a hole in the API.
--a always,exit -F arch=b32 -S all -F key=32bit-api
--a always,exit -F arch=b64 -S accept -F a0=2 -F key=ipv4_in
--a always,exit -F arch=b32 -S accept -F a0=2 -F key=ipv4_in
--a always,exit -F arch=b64 -S accept -F a0=10 -F key=ipv6_in
--a always,exit -F arch=b32 -S accept -F a0=10 -F key=ipv6_in
+-a exit,always -F arch=b32 -S all -F key=32bit-api
+-a exit,always -F arch=b64 -S accept -F a0=2 -F key=ipv4_in
+-a exit,always -F arch=b32 -S accept -F a0=2 -F key=ipv4_in
+-a exit,always -F arch=b64 -S accept -F a0=10 -F key=ipv6_in
+-a exit,always -F arch=b32 -S accept -F a0=10 -F key=ipv6_in
 
 ## Audit unsuccessful file operations
--a always,exit -F arch=b64 -S creat,mkdir,mknod,link,symlink,mkdirat,mknodat,linkat,symlinkat,openat,open_by_handle_at,open,close,rename,renameat,truncate,ftruncate,rmdir,unlink,unlinkat -F exit=-EACCES -k access
--a always,exit -F arch=b64 -S creat,mkdir,mknod,link,symlink,mkdirat,mknodat,linkat,symlinkat,openat,open_by_handle_at,open,close,rename,renameat,truncate,ftruncate,rmdir,unlink,unlinkat -F exit=-EPERM -k access
--a always,exit -F arch=b32 -S creat,mkdir,mknod,link,symlink,mkdirat,mknodat,linkat,symlinkat,openat,open_by_handle_at,open,close,rename,renameat,truncate,ftruncate,rmdir,unlink,unlinkat -F exit=-EACCES -k access
--a always,exit -F arch=b32 -S creat,mkdir,mknod,link,symlink,mkdirat,mknodat,linkat,symlinkat,openat,open_by_handle_at,open,close,rename,renameat,truncate,ftruncate,rmdir,unlink,unlinkat -F exit=-EPERM -k access
+-a exit,always -F arch=b64 -S creat,mkdir,mknod,link,symlink,mkdirat,mknodat,linkat,symlinkat,openat,open_by_handle_at,open,close,rename,renameat,truncate,ftruncate,rmdir,unlink,unlinkat -F exit=-EACCES -k access
+-a exit,always -F arch=b64 -S creat,mkdir,mknod,link,symlink,mkdirat,mknodat,linkat,symlinkat,openat,open_by_handle_at,open,close,rename,renameat,truncate,ftruncate,rmdir,unlink,unlinkat -F exit=-EPERM -k access
+-a exit,always -F arch=b32 -S creat,mkdir,mknod,link,symlink,mkdirat,mknodat,linkat,symlinkat,openat,open_by_handle_at,open,close,rename,renameat,truncate,ftruncate,rmdir,unlink,unlinkat -F exit=-EACCES -k access
+-a exit,always -F arch=b32 -S creat,mkdir,mknod,link,symlink,mkdirat,mknodat,linkat,symlinkat,openat,open_by_handle_at,open,close,rename,renameat,truncate,ftruncate,rmdir,unlink,unlinkat -F exit=-EPERM -k access
 
--a always,exit -F perm=a -F exit=-EACCES -k access
--a always,exit -F perm=a -F exit=-EPERM -k access
+-a exit,always -F perm=a -F exit=-EACCES -k access
+-a exit,always -F perm=a -F exit=-EPERM -k access
 
 ## Audit the execution of password commands
--a always,exit -F path=/usr/bin/passwd -F perm=x -k privileged-passwd
--a always,exit -F path=/bin/passwd -F perm=x -k privileged-passwd
+-a exit,always -F path=/usr/bin/passwd -F perm=x -k privileged-passwd
+-a exit,always -F path=/bin/passwd -F perm=x -k privileged-passwd
 
--a always,exit -F path=/usr/sbin/unix_chkpwd -F perm=x -k privileged-passwd
--a always,exit -F path=/sbin/unix_chkpwd -F perm=x -k privileged-passwd
+-a exit,always -F path=/usr/sbin/unix_chkpwd -F perm=x -k privileged-passwd
+-a exit,always -F path=/sbin/unix_chkpwd -F perm=x -k privileged-passwd
 
--a always,exit -F path=/usr/bin/gpasswd -F perm=x -k privileged-passwd
--a always,exit -F path=/bin/gpasswd -F perm=x -k privileged-passwd
+-a exit,always -F path=/usr/bin/gpasswd -F perm=x -k privileged-passwd
+-a exit,always -F path=/bin/gpasswd -F perm=x -k privileged-passwd
 
--a always,exit -F path=/usr/bin/chage -F perm=x -k privileged-passwd
--a always,exit -F path=/bin/chage -F perm=x -k privileged-passwd
+-a exit,always -F path=/usr/bin/chage -F perm=x -k privileged-passwd
+-a exit,always -F path=/bin/chage -F perm=x -k privileged-passwd
 
--a always,exit -F path=/usr/sbin/userhelper -F perm=x -k privileged-passwd
--a always,exit -F path=/sbin/userhelper -F perm=x -k privileged-passwd
+-a exit,always -F path=/usr/sbin/userhelper -F perm=x -k privileged-passwd
+-a exit,always -F path=/sbin/userhelper -F perm=x -k privileged-passwd
 
 ## Audit the execution of privilege-related commands
--a always,exit -F path=/usr/bin/su -F perm=x -k privileged-priv_change
--a always,exit -F path=/bin/su -F perm=x -k privileged-priv_change
+-a exit,always -F path=/usr/bin/su -F perm=x -k privileged-priv_change
+-a exit,always -F path=/bin/su -F perm=x -k privileged-priv_change
 
--a always,exit -F path=/usr/bin/sudo -F perm=x -k privileged-priv_change
--a always,exit -F path=/bin/sudo -F perm=x -k privileged-priv_change
+-a exit,always -F path=/usr/bin/sudo -F perm=x -k privileged-priv_change
+-a exit,always -F path=/bin/sudo -F perm=x -k privileged-priv_change
 
--a always,exit -F path=/usr/bin/newgrp -F perm=x -k privileged-priv_change
--a always,exit -F path=/bin/newgrp -F perm=x -k privileged-priv_change
+-a exit,always -F path=/usr/bin/newgrp -F perm=x -k privileged-priv_change
+-a exit,always -F path=/bin/newgrp -F perm=x -k privileged-priv_change
 
--a always,exit -F path=/usr/bin/chsh -F perm=x -k privileged-priv_change
--a always,exit -F path=/bin/chsh -F perm=x -k privileged-priv_change
+-a exit,always -F path=/usr/bin/chsh -F perm=x -k privileged-priv_change
+-a exit,always -F path=/bin/chsh -F perm=x -k privileged-priv_change
 
--a always,exit -F path=/usr/bin/sudoedit -F perm=x -k privileged-priv_change
--a always,exit -F path=/bin/sudoedit -F perm=x -k privileged-priv_change
+-a exit,always -F path=/usr/bin/sudoedit -F perm=x -k privileged-priv_change
+-a exit,always -F path=/bin/sudoedit -F perm=x -k privileged-priv_change
 
 ## Audit the execution of postfix-related commands
--a always,exit -F path=/usr/sbin/postdrop -F perm=x -k privileged-postfix
--a always,exit -F path=/sbin/postdrop -F perm=x -k privileged-postfix
+-a exit,always -F path=/usr/sbin/postdrop -F perm=x -k privileged-postfix
+-a exit,always -F path=/sbin/postdrop -F perm=x -k privileged-postfix
 
--a always,exit -F path=/usr/sbin/postqueue -F perm=x -k privileged-postfix
--a always,exit -F path=/sbin/postqueue -F perm=x -k privileged-postfix
+-a exit,always -F path=/usr/sbin/postqueue -F perm=x -k privileged-postfix
+-a exit,always -F path=/sbin/postqueue -F perm=x -k privileged-postfix
 
 ## Audit the execution of the ssh-keysign command
--a always,exit -F path=/usr/libexec/openssh/ssh-keysign -F perm=x -k privileged-ssh
+-a exit,always -F path=/usr/libexec/openssh/ssh-keysign -F perm=x -k privileged-ssh
 
 ## Audit the execution of the crontab command
--a always,exit -F path=/usr/bin/crontab -F perm=x -k privileged-cron
--a always,exit -F path=/bin/crontab -F perm=x -k privileged-cron
+-a exit,always -F path=/usr/bin/crontab -F perm=x -k privileged-cron
+-a exit,always -F path=/bin/crontab -F perm=x -k privileged-cron
 
 ## Audit the execution of the pam_timestamp_check command
--a always,exit -F path=/usr/sbin/pam_timestamp_check -F perm=x -k privileged-pam
--a always,exit -F path=/sbin/pam_timestamp_check -F perm=x -k privileged-pam
+-a exit,always -F path=/usr/sbin/pam_timestamp_check -F perm=x -k privileged-pam
+-a exit,always -F path=/sbin/pam_timestamp_check -F perm=x -k privileged-pam
 
 ## Permissions auditing separated by chown, chmod, and attr
 
--a always,exit -F arch=b64 -S chown,fchown,fchownat,lchown -k chown
--a always,exit -F arch=b32 -S chown,fchown,fchownat,lchown -k chown
+-a exit,always -F arch=b64 -S chown,fchown,fchownat,lchown -k chown
+-a exit,always -F arch=b32 -S chown,fchown,fchownat,lchown -k chown
 
--a always,exit -F arch=b64 -S setxattr,lsetxattr,fsetxattr,removexattr,lremovexattr,fremovexattr -k attr
--a always,exit -F arch=b32 -S setxattr,lsetxattr,fsetxattr,removexattr,lremovexattr,fremovexattr -k attr
+-a exit,always -F arch=b64 -S setxattr,lsetxattr,fsetxattr,removexattr,lremovexattr,fremovexattr -k attr
+-a exit,always -F arch=b32 -S setxattr,lsetxattr,fsetxattr,removexattr,lremovexattr,fremovexattr -k attr
 
 ## Audit useful items that someone does when su'ing to root.
--a always,exit -F arch=b64 -F auid!=0 -F uid=0 -S capset,mknod,mknodat,pivot_root,quotactl,setsid,adjtimex,settimeofday,setuid,swapoff,swapon -k su-root-activity
--a always,exit -F arch=b32 -F auid!=0 -F uid=0 -S capset,mknod,mknodat,pivot_root,quotactl,setsid,adjtimex,settimeofday,setuid,swapoff,swapon -k su-root-activity
+-a exit,always -F arch=b64 -F auid!=0 -F uid=0 -S capset,mknod,mknodat,pivot_root,quotactl,setsid,adjtimex,settimeofday,setuid,swapoff,swapon -k su-root-activity
+-a exit,always -F arch=b32 -F auid!=0 -F uid=0 -S capset,mknod,mknodat,pivot_root,quotactl,setsid,adjtimex,settimeofday,setuid,swapoff,swapon -k su-root-activity
 
 ## Audit the execution of suid and sgid binaries.
--a always,exit -F arch=b64 -F euid=0 -F uid!=0 -S execve -k suid-root-exec
--a always,exit -F arch=b32 -F euid=0 -F uid!=0 -S execve -k suid-root-exec
+-a exit,always -F arch=b64 -F euid=0 -F uid!=0 -S execve -k suid-root-exec
+-a exit,always -F arch=b32 -F euid=0 -F uid!=0 -S execve -k suid-root-exec
 
 ## Audit the loading and unloading of kernel modules.
 -w /usr/bin/kmod -p x -k modules
@@ -92,38 +92,38 @@
 -w /usr/sbin/modprobe -p x -k modules
 -w /sbin/modprobe -p x -k modules
 
--a always,exit -F arch=b64 -S create_module,init_module,finit_module,delete_module -k modules
--a always,exit -F arch=b32 -S create_module,init_module,finit_module,delete_module -k modules
+-a exit,always -F arch=b64 -S create_module,init_module,finit_module,delete_module -k modules
+-a exit,always -F arch=b32 -S create_module,init_module,finit_module,delete_module -k modules
 
 ## Audit things that could affect time
--a always,exit -F arch=b64 -S adjtimex,settimeofday -k audit_time_rules
--a always,exit -F arch=b64 -S clock_settime -F a0=0x0 -k audit_time_rules
--a always,exit -F arch=b32 -S adjtimex,stime,settimeofday -k audit_time_rules
--a always,exit -F arch=b32 -S clock_settime -F a0=0x0 -k audit_time_rules
+-a exit,always -F arch=b64 -S adjtimex,settimeofday -k audit_time_rules
+-a exit,always -F arch=b64 -S clock_settime -F a0=0x0 -k audit_time_rules
+-a exit,always -F arch=b32 -S adjtimex,stime,settimeofday -k audit_time_rules
+-a exit,always -F arch=b32 -S clock_settime -F a0=0x0 -k audit_time_rules
 
 -w /etc/localtime -p wa -k audit_time_rules
 
 ## Audit things that could affect system locale
--a always,exit -F arch=b64 -S sethostname,setdomainname -k audit_network_modifications
--a always,exit -F arch=b32 -S sethostname,setdomainname -k audit_network_modifications
+-a exit,always -F arch=b64 -S sethostname,setdomainname -k audit_network_modifications
+-a exit,always -F arch=b32 -S sethostname,setdomainname -k audit_network_modifications
 
 -w /etc/issue -p wa -k audit_network_modifications
 -w /etc/issue.net -p wa -k audit_network_modifications
 -w /etc/hosts -p wa -k audit_network_modifications
 -w /etc/hostname -p wa -k audit_network_modifications
 -w /etc/sysconfig/network -p wa -k audit_network_modifications
--a always,exit -F dir=/etc/NetworkManager/ -F perm=wa -k audit_network_modifications
+-a exit,always -F dir=/etc/NetworkManager/ -F perm=wa -k audit_network_modifications
 
 ## Audit mount operations
--a always,exit -F arch=b64 -S mount,umount2 -k mount
--a always,exit -F arch=b32 -S mount,umount,umount2 -k mount
+-a exit,always -F arch=b64 -S mount,umount2 -k mount
+-a exit,always -F arch=b32 -S mount,umount,umount2 -k mount
 
--a always,exit -F arch=b64 -F path=/usr/bin/mount -k mount
--a always,exit -F arch=b64 -F path=/bin/mount -k mount
--a always,exit -F arch=b32 -F path=/usr/bin/mount -k mount
--a always,exit -F arch=b32 -F path=/bin/mount -k mount
--a always,exit -F path=/usr/bin/umount -F perm=x -k mount
--a always,exit -F path=/bin/umount -F perm=x -k mount
+-a exit,always -F arch=b64 -F path=/usr/bin/mount -k mount
+-a exit,always -F arch=b64 -F path=/bin/mount -k mount
+-a exit,always -F arch=b32 -F path=/usr/bin/mount -k mount
+-a exit,always -F arch=b32 -F path=/bin/mount -k mount
+-a exit,always -F path=/usr/bin/umount -F perm=x -k mount
+-a exit,always -F path=/bin/umount -F perm=x -k mount
 
 ## Audit local accounts
 -w /etc/passwd -p wa -k audit_account_changes
@@ -229,13 +229,13 @@
 -w /etc/yum -p wa -k yum-config
 -w /etc/yum.conf -p wa -k yum-config
 -w /etc/yum.repos.d -p wa -k yum-config
--a always,exit -F arch=b64 -S ptrace -F a0=0x4 -k paranoid_code_injection
--a always,exit -F arch=b64 -S ptrace -F a0=0x5 -k paranoid_data_injection
--a always,exit -F arch=b64 -S ptrace -F a0=0x6 -k paranoid_register_injection
--a always,exit -F arch=b64 -S ptrace -k paranoid
--a always,exit -F arch=b32 -S ptrace -F a0=0x4 -k paranoid_code_injection
--a always,exit -F arch=b32 -S ptrace -F a0=0x5 -k paranoid_data_injection
--a always,exit -F arch=b32 -S ptrace -F a0=0x6 -k paranoid_register_injection
--a always,exit -F arch=b32 -S ptrace -k paranoid
--a always,exit -F arch=b64 -S personality -k paranoid
--a always,exit -F arch=b32 -S personality -k paranoid
+-a exit,always -F arch=b64 -S ptrace -F a0=0x4 -k paranoid_code_injection
+-a exit,always -F arch=b64 -S ptrace -F a0=0x5 -k paranoid_data_injection
+-a exit,always -F arch=b64 -S ptrace -F a0=0x6 -k paranoid_register_injection
+-a exit,always -F arch=b64 -S ptrace -k paranoid
+-a exit,always -F arch=b32 -S ptrace -F a0=0x4 -k paranoid_code_injection
+-a exit,always -F arch=b32 -S ptrace -F a0=0x5 -k paranoid_data_injection
+-a exit,always -F arch=b32 -S ptrace -F a0=0x6 -k paranoid_register_injection
+-a exit,always -F arch=b32 -S ptrace -k paranoid
+-a exit,always -F arch=b64 -S personality -k paranoid
+-a exit,always -F arch=b32 -S personality -k paranoid

--- a/spec/classes/config/audit_profiles/expected/simp_el7_basic_rules.txt
+++ b/spec/classes/config/audit_profiles/expected/simp_el7_basic_rules.txt
@@ -3,9 +3,7 @@
 # may be a sign of someone exploiting a hole in the API.
 -a exit,always -F arch=b32 -S all -F key=32bit-api
 -a exit,always -F arch=b64 -S accept -F a0=2 -F key=ipv4_in
--a exit,always -F arch=b32 -S accept -F a0=2 -F key=ipv4_in
 -a exit,always -F arch=b64 -S accept -F a0=10 -F key=ipv6_in
--a exit,always -F arch=b32 -S accept -F a0=10 -F key=ipv6_in
 
 ## Audit unsuccessful file operations
 -a exit,always -F arch=b64 -S creat,mkdir,mknod,link,symlink,mkdirat,mknodat,linkat,symlinkat,openat,open_by_handle_at,open,close,rename,renameat,truncate,ftruncate,rmdir,unlink,unlinkat -F exit=-EACCES -k access

--- a/spec/classes/config/audit_profiles/expected/simp_el7_insane_rules.txt
+++ b/spec/classes/config/audit_profiles/expected/simp_el7_insane_rules.txt
@@ -1,86 +1,86 @@
 #### auditd::config::audit_profiles::simp Audit Rules ####
 # 64-bit systems should generally never call the 32-bit API. 32-bit syscalls
 # may be a sign of someone exploiting a hole in the API.
--a always,exit -F arch=b32 -S all -F key=32bit-api
--a always,exit -F arch=b64 -S accept -F a0=2 -F key=ipv4_in
--a always,exit -F arch=b32 -S accept -F a0=2 -F key=ipv4_in
--a always,exit -F arch=b64 -S accept -F a0=10 -F key=ipv6_in
--a always,exit -F arch=b32 -S accept -F a0=10 -F key=ipv6_in
+-a exit,always -F arch=b32 -S all -F key=32bit-api
+-a exit,always -F arch=b64 -S accept -F a0=2 -F key=ipv4_in
+-a exit,always -F arch=b32 -S accept -F a0=2 -F key=ipv4_in
+-a exit,always -F arch=b64 -S accept -F a0=10 -F key=ipv6_in
+-a exit,always -F arch=b32 -S accept -F a0=10 -F key=ipv6_in
 
 ## Audit unsuccessful file operations
--a always,exit -F arch=b64 -S creat,mkdir,mknod,link,symlink,mkdirat,mknodat,linkat,symlinkat,openat,open_by_handle_at,open,close,rename,renameat,truncate,ftruncate,rmdir,unlink,unlinkat -F exit=-EACCES -k access
--a always,exit -F arch=b64 -S creat,mkdir,mknod,link,symlink,mkdirat,mknodat,linkat,symlinkat,openat,open_by_handle_at,open,close,rename,renameat,truncate,ftruncate,rmdir,unlink,unlinkat -F exit=-EPERM -k access
--a always,exit -F arch=b32 -S creat,mkdir,mknod,link,symlink,mkdirat,mknodat,linkat,symlinkat,openat,open_by_handle_at,open,close,rename,renameat,truncate,ftruncate,rmdir,unlink,unlinkat -F exit=-EACCES -k access
--a always,exit -F arch=b32 -S creat,mkdir,mknod,link,symlink,mkdirat,mknodat,linkat,symlinkat,openat,open_by_handle_at,open,close,rename,renameat,truncate,ftruncate,rmdir,unlink,unlinkat -F exit=-EPERM -k access
+-a exit,always -F arch=b64 -S creat,mkdir,mknod,link,symlink,mkdirat,mknodat,linkat,symlinkat,openat,open_by_handle_at,open,close,rename,renameat,truncate,ftruncate,rmdir,unlink,unlinkat -F exit=-EACCES -k access
+-a exit,always -F arch=b64 -S creat,mkdir,mknod,link,symlink,mkdirat,mknodat,linkat,symlinkat,openat,open_by_handle_at,open,close,rename,renameat,truncate,ftruncate,rmdir,unlink,unlinkat -F exit=-EPERM -k access
+-a exit,always -F arch=b32 -S creat,mkdir,mknod,link,symlink,mkdirat,mknodat,linkat,symlinkat,openat,open_by_handle_at,open,close,rename,renameat,truncate,ftruncate,rmdir,unlink,unlinkat -F exit=-EACCES -k access
+-a exit,always -F arch=b32 -S creat,mkdir,mknod,link,symlink,mkdirat,mknodat,linkat,symlinkat,openat,open_by_handle_at,open,close,rename,renameat,truncate,ftruncate,rmdir,unlink,unlinkat -F exit=-EPERM -k access
 
--a always,exit -F perm=a -F exit=-EACCES -k access
--a always,exit -F perm=a -F exit=-EPERM -k access
+-a exit,always -F perm=a -F exit=-EACCES -k access
+-a exit,always -F perm=a -F exit=-EPERM -k access
 
 ## Audit the execution of password commands
--a always,exit -F path=/usr/bin/passwd -F perm=x -k privileged-passwd
--a always,exit -F path=/bin/passwd -F perm=x -k privileged-passwd
+-a exit,always -F path=/usr/bin/passwd -F perm=x -k privileged-passwd
+-a exit,always -F path=/bin/passwd -F perm=x -k privileged-passwd
 
--a always,exit -F path=/usr/sbin/unix_chkpwd -F perm=x -k privileged-passwd
--a always,exit -F path=/sbin/unix_chkpwd -F perm=x -k privileged-passwd
+-a exit,always -F path=/usr/sbin/unix_chkpwd -F perm=x -k privileged-passwd
+-a exit,always -F path=/sbin/unix_chkpwd -F perm=x -k privileged-passwd
 
--a always,exit -F path=/usr/bin/gpasswd -F perm=x -k privileged-passwd
--a always,exit -F path=/bin/gpasswd -F perm=x -k privileged-passwd
+-a exit,always -F path=/usr/bin/gpasswd -F perm=x -k privileged-passwd
+-a exit,always -F path=/bin/gpasswd -F perm=x -k privileged-passwd
 
--a always,exit -F path=/usr/bin/chage -F perm=x -k privileged-passwd
--a always,exit -F path=/bin/chage -F perm=x -k privileged-passwd
+-a exit,always -F path=/usr/bin/chage -F perm=x -k privileged-passwd
+-a exit,always -F path=/bin/chage -F perm=x -k privileged-passwd
 
--a always,exit -F path=/usr/sbin/userhelper -F perm=x -k privileged-passwd
--a always,exit -F path=/sbin/userhelper -F perm=x -k privileged-passwd
+-a exit,always -F path=/usr/sbin/userhelper -F perm=x -k privileged-passwd
+-a exit,always -F path=/sbin/userhelper -F perm=x -k privileged-passwd
 
 ## Audit the execution of privilege-related commands
--a always,exit -F path=/usr/bin/su -F perm=x -k privileged-priv_change
--a always,exit -F path=/bin/su -F perm=x -k privileged-priv_change
+-a exit,always -F path=/usr/bin/su -F perm=x -k privileged-priv_change
+-a exit,always -F path=/bin/su -F perm=x -k privileged-priv_change
 
--a always,exit -F path=/usr/bin/sudo -F perm=x -k privileged-priv_change
--a always,exit -F path=/bin/sudo -F perm=x -k privileged-priv_change
+-a exit,always -F path=/usr/bin/sudo -F perm=x -k privileged-priv_change
+-a exit,always -F path=/bin/sudo -F perm=x -k privileged-priv_change
 
--a always,exit -F path=/usr/bin/newgrp -F perm=x -k privileged-priv_change
--a always,exit -F path=/bin/newgrp -F perm=x -k privileged-priv_change
+-a exit,always -F path=/usr/bin/newgrp -F perm=x -k privileged-priv_change
+-a exit,always -F path=/bin/newgrp -F perm=x -k privileged-priv_change
 
--a always,exit -F path=/usr/bin/chsh -F perm=x -k privileged-priv_change
--a always,exit -F path=/bin/chsh -F perm=x -k privileged-priv_change
+-a exit,always -F path=/usr/bin/chsh -F perm=x -k privileged-priv_change
+-a exit,always -F path=/bin/chsh -F perm=x -k privileged-priv_change
 
--a always,exit -F path=/usr/bin/sudoedit -F perm=x -k privileged-priv_change
--a always,exit -F path=/bin/sudoedit -F perm=x -k privileged-priv_change
+-a exit,always -F path=/usr/bin/sudoedit -F perm=x -k privileged-priv_change
+-a exit,always -F path=/bin/sudoedit -F perm=x -k privileged-priv_change
 
 ## Audit the execution of postfix-related commands
--a always,exit -F path=/usr/sbin/postdrop -F perm=x -k privileged-postfix
--a always,exit -F path=/sbin/postdrop -F perm=x -k privileged-postfix
+-a exit,always -F path=/usr/sbin/postdrop -F perm=x -k privileged-postfix
+-a exit,always -F path=/sbin/postdrop -F perm=x -k privileged-postfix
 
--a always,exit -F path=/usr/sbin/postqueue -F perm=x -k privileged-postfix
--a always,exit -F path=/sbin/postqueue -F perm=x -k privileged-postfix
+-a exit,always -F path=/usr/sbin/postqueue -F perm=x -k privileged-postfix
+-a exit,always -F path=/sbin/postqueue -F perm=x -k privileged-postfix
 
 ## Audit the execution of the ssh-keysign command
--a always,exit -F path=/usr/libexec/openssh/ssh-keysign -F perm=x -k privileged-ssh
+-a exit,always -F path=/usr/libexec/openssh/ssh-keysign -F perm=x -k privileged-ssh
 
 ## Audit the execution of the crontab command
--a always,exit -F path=/usr/bin/crontab -F perm=x -k privileged-cron
--a always,exit -F path=/bin/crontab -F perm=x -k privileged-cron
+-a exit,always -F path=/usr/bin/crontab -F perm=x -k privileged-cron
+-a exit,always -F path=/bin/crontab -F perm=x -k privileged-cron
 
 ## Audit the execution of the pam_timestamp_check command
--a always,exit -F path=/usr/sbin/pam_timestamp_check -F perm=x -k privileged-pam
--a always,exit -F path=/sbin/pam_timestamp_check -F perm=x -k privileged-pam
+-a exit,always -F path=/usr/sbin/pam_timestamp_check -F perm=x -k privileged-pam
+-a exit,always -F path=/sbin/pam_timestamp_check -F perm=x -k privileged-pam
 
 ## Permissions auditing separated by chown, chmod, and attr
 
--a always,exit -F arch=b64 -S chown,fchown,fchownat,lchown -k chown
--a always,exit -F arch=b32 -S chown,fchown,fchownat,lchown -k chown
+-a exit,always -F arch=b64 -S chown,fchown,fchownat,lchown -k chown
+-a exit,always -F arch=b32 -S chown,fchown,fchownat,lchown -k chown
 
--a always,exit -F arch=b64 -S setxattr,lsetxattr,fsetxattr,removexattr,lremovexattr,fremovexattr -k attr
--a always,exit -F arch=b32 -S setxattr,lsetxattr,fsetxattr,removexattr,lremovexattr,fremovexattr -k attr
+-a exit,always -F arch=b64 -S setxattr,lsetxattr,fsetxattr,removexattr,lremovexattr,fremovexattr -k attr
+-a exit,always -F arch=b32 -S setxattr,lsetxattr,fsetxattr,removexattr,lremovexattr,fremovexattr -k attr
 
 ## Audit useful items that someone does when su'ing to root.
--a always,exit -F arch=b64 -F auid!=0 -F uid=0 -S capset,mknod,mknodat,pivot_root,quotactl,setsid,adjtimex,settimeofday,setuid,swapoff,swapon,execve,rename,renameat,rmdir,unlink,unlinkat,write,chown,fchown,fchownat,lchown,creat,fork,vfork,link,linkat,symlink,symlinkat,mkdir,mkdirat -k su-root-activity
--a always,exit -F arch=b32 -F auid!=0 -F uid=0 -S capset,mknod,mknodat,pivot_root,quotactl,setsid,adjtimex,settimeofday,setuid,swapoff,swapon,execve,rename,renameat,rmdir,unlink,unlinkat,write,chown,fchown,fchownat,lchown,creat,fork,vfork,link,linkat,symlink,symlinkat,mkdir,mkdirat -k su-root-activity
+-a exit,always -F arch=b64 -F auid!=0 -F uid=0 -S capset,mknod,mknodat,pivot_root,quotactl,setsid,adjtimex,settimeofday,setuid,swapoff,swapon,execve,rename,renameat,rmdir,unlink,unlinkat,write,chown,fchown,fchownat,lchown,creat,fork,vfork,link,linkat,symlink,symlinkat,mkdir,mkdirat -k su-root-activity
+-a exit,always -F arch=b32 -F auid!=0 -F uid=0 -S capset,mknod,mknodat,pivot_root,quotactl,setsid,adjtimex,settimeofday,setuid,swapoff,swapon,execve,rename,renameat,rmdir,unlink,unlinkat,write,chown,fchown,fchownat,lchown,creat,fork,vfork,link,linkat,symlink,symlinkat,mkdir,mkdirat -k su-root-activity
 
 ## Audit the execution of suid and sgid binaries.
--a always,exit -F arch=b64 -F euid=0 -F uid!=0 -S execve -k suid-root-exec
--a always,exit -F arch=b32 -F euid=0 -F uid!=0 -S execve -k suid-root-exec
+-a exit,always -F arch=b64 -F euid=0 -F uid!=0 -S execve -k suid-root-exec
+-a exit,always -F arch=b32 -F euid=0 -F uid!=0 -S execve -k suid-root-exec
 
 ## Audit the loading and unloading of kernel modules.
 -w /usr/bin/kmod -p x -k modules
@@ -92,38 +92,38 @@
 -w /usr/sbin/modprobe -p x -k modules
 -w /sbin/modprobe -p x -k modules
 
--a always,exit -F arch=b64 -S create_module,init_module,finit_module,delete_module -k modules
--a always,exit -F arch=b32 -S create_module,init_module,finit_module,delete_module -k modules
+-a exit,always -F arch=b64 -S create_module,init_module,finit_module,delete_module -k modules
+-a exit,always -F arch=b32 -S create_module,init_module,finit_module,delete_module -k modules
 
 ## Audit things that could affect time
--a always,exit -F arch=b64 -S adjtimex,settimeofday -k audit_time_rules
--a always,exit -F arch=b64 -S clock_settime -F a0=0x0 -k audit_time_rules
--a always,exit -F arch=b32 -S adjtimex,stime,settimeofday -k audit_time_rules
--a always,exit -F arch=b32 -S clock_settime -F a0=0x0 -k audit_time_rules
+-a exit,always -F arch=b64 -S adjtimex,settimeofday -k audit_time_rules
+-a exit,always -F arch=b64 -S clock_settime -F a0=0x0 -k audit_time_rules
+-a exit,always -F arch=b32 -S adjtimex,stime,settimeofday -k audit_time_rules
+-a exit,always -F arch=b32 -S clock_settime -F a0=0x0 -k audit_time_rules
 
 -w /etc/localtime -p wa -k audit_time_rules
 
 ## Audit things that could affect system locale
--a always,exit -F arch=b64 -S sethostname,setdomainname -k audit_network_modifications
--a always,exit -F arch=b32 -S sethostname,setdomainname -k audit_network_modifications
+-a exit,always -F arch=b64 -S sethostname,setdomainname -k audit_network_modifications
+-a exit,always -F arch=b32 -S sethostname,setdomainname -k audit_network_modifications
 
 -w /etc/issue -p wa -k audit_network_modifications
 -w /etc/issue.net -p wa -k audit_network_modifications
 -w /etc/hosts -p wa -k audit_network_modifications
 -w /etc/hostname -p wa -k audit_network_modifications
 -w /etc/sysconfig/network -p wa -k audit_network_modifications
--a always,exit -F dir=/etc/NetworkManager/ -F perm=wa -k audit_network_modifications
+-a exit,always -F dir=/etc/NetworkManager/ -F perm=wa -k audit_network_modifications
 
 ## Audit mount operations
--a always,exit -F arch=b64 -S mount,umount2 -k mount
--a always,exit -F arch=b32 -S mount,umount,umount2 -k mount
+-a exit,always -F arch=b64 -S mount,umount2 -k mount
+-a exit,always -F arch=b32 -S mount,umount,umount2 -k mount
 
--a always,exit -F arch=b64 -F path=/usr/bin/mount -k mount
--a always,exit -F arch=b64 -F path=/bin/mount -k mount
--a always,exit -F arch=b32 -F path=/usr/bin/mount -k mount
--a always,exit -F arch=b32 -F path=/bin/mount -k mount
--a always,exit -F path=/usr/bin/umount -F perm=x -k mount
--a always,exit -F path=/bin/umount -F perm=x -k mount
+-a exit,always -F arch=b64 -F path=/usr/bin/mount -k mount
+-a exit,always -F arch=b64 -F path=/bin/mount -k mount
+-a exit,always -F arch=b32 -F path=/usr/bin/mount -k mount
+-a exit,always -F arch=b32 -F path=/bin/mount -k mount
+-a exit,always -F path=/usr/bin/umount -F perm=x -k mount
+-a exit,always -F path=/bin/umount -F perm=x -k mount
 
 ## Audit local accounts
 -w /etc/passwd -p wa -k audit_account_changes
@@ -229,13 +229,13 @@
 -w /etc/yum -p wa -k yum-config
 -w /etc/yum.conf -p wa -k yum-config
 -w /etc/yum.repos.d -p wa -k yum-config
--a always,exit -F arch=b64 -S ptrace -F a0=0x4 -k paranoid_code_injection
--a always,exit -F arch=b64 -S ptrace -F a0=0x5 -k paranoid_data_injection
--a always,exit -F arch=b64 -S ptrace -F a0=0x6 -k paranoid_register_injection
--a always,exit -F arch=b64 -S ptrace -k paranoid
--a always,exit -F arch=b32 -S ptrace -F a0=0x4 -k paranoid_code_injection
--a always,exit -F arch=b32 -S ptrace -F a0=0x5 -k paranoid_data_injection
--a always,exit -F arch=b32 -S ptrace -F a0=0x6 -k paranoid_register_injection
--a always,exit -F arch=b32 -S ptrace -k paranoid
--a always,exit -F arch=b64 -S personality -k paranoid
--a always,exit -F arch=b32 -S personality -k paranoid
+-a exit,always -F arch=b64 -S ptrace -F a0=0x4 -k paranoid_code_injection
+-a exit,always -F arch=b64 -S ptrace -F a0=0x5 -k paranoid_data_injection
+-a exit,always -F arch=b64 -S ptrace -F a0=0x6 -k paranoid_register_injection
+-a exit,always -F arch=b64 -S ptrace -k paranoid
+-a exit,always -F arch=b32 -S ptrace -F a0=0x4 -k paranoid_code_injection
+-a exit,always -F arch=b32 -S ptrace -F a0=0x5 -k paranoid_data_injection
+-a exit,always -F arch=b32 -S ptrace -F a0=0x6 -k paranoid_register_injection
+-a exit,always -F arch=b32 -S ptrace -k paranoid
+-a exit,always -F arch=b64 -S personality -k paranoid
+-a exit,always -F arch=b32 -S personality -k paranoid

--- a/spec/classes/config/audit_profiles/expected/simp_el7_insane_rules.txt
+++ b/spec/classes/config/audit_profiles/expected/simp_el7_insane_rules.txt
@@ -3,9 +3,7 @@
 # may be a sign of someone exploiting a hole in the API.
 -a exit,always -F arch=b32 -S all -F key=32bit-api
 -a exit,always -F arch=b64 -S accept -F a0=2 -F key=ipv4_in
--a exit,always -F arch=b32 -S accept -F a0=2 -F key=ipv4_in
 -a exit,always -F arch=b64 -S accept -F a0=10 -F key=ipv6_in
--a exit,always -F arch=b32 -S accept -F a0=10 -F key=ipv6_in
 
 ## Audit unsuccessful file operations
 -a exit,always -F arch=b64 -S creat,mkdir,mknod,link,symlink,mkdirat,mknodat,linkat,symlinkat,openat,open_by_handle_at,open,close,rename,renameat,truncate,ftruncate,rmdir,unlink,unlinkat -F exit=-EACCES -k access

--- a/spec/classes/config/audit_profiles/expected/simp_el7_insane_rules.txt
+++ b/spec/classes/config/audit_profiles/expected/simp_el7_insane_rules.txt
@@ -1,14 +1,13 @@
 #### auditd::config::audit_profiles::simp Audit Rules ####
+# 64-bit systems should generally never call the 32-bit API. 32-bit syscalls
+# may be a sign of someone exploiting a hole in the API.
+-a always,exit -F arch=b32 -S all -F key=32bit-api
+-a always,exit -F arch=b64 -S accept -F a0=2 -F key=ipv4_in
+-a always,exit -F arch=b32 -S accept -F a0=2 -F key=ipv4_in
+-a always,exit -F arch=b64 -S accept -F a0=10 -F key=ipv6_in
+-a always,exit -F arch=b32 -S accept -F a0=10 -F key=ipv6_in
 
 ## Audit unsuccessful file operations
-# CCE-26712-0
-# CCE-26651-0
-# RHEL-07-030500
-# RHEL-07-030510
-# RHEL-07-030520
-# RHEL-07-030530
-# RHEL-07-030540
-# RHEL-07-030550
 -a always,exit -F arch=b64 -S creat,mkdir,mknod,link,symlink,mkdirat,mknodat,linkat,symlinkat,openat,open_by_handle_at,open,close,rename,renameat,truncate,ftruncate,rmdir,unlink,unlinkat -F exit=-EACCES -k access
 -a always,exit -F arch=b64 -S creat,mkdir,mknod,link,symlink,mkdirat,mknodat,linkat,symlinkat,openat,open_by_handle_at,open,close,rename,renameat,truncate,ftruncate,rmdir,unlink,unlinkat -F exit=-EPERM -k access
 -a always,exit -F arch=b32 -S creat,mkdir,mknod,link,symlink,mkdirat,mknodat,linkat,symlinkat,openat,open_by_handle_at,open,close,rename,renameat,truncate,ftruncate,rmdir,unlink,unlinkat -F exit=-EACCES -k access
@@ -18,155 +17,96 @@
 -a always,exit -F perm=a -F exit=-EPERM -k access
 
 ## Audit the execution of password commands
-# RHEL-07-030630
 -a always,exit -F path=/usr/bin/passwd -F perm=x -k privileged-passwd
 -a always,exit -F path=/bin/passwd -F perm=x -k privileged-passwd
 
-# RHEL-07-030640
 -a always,exit -F path=/usr/sbin/unix_chkpwd -F perm=x -k privileged-passwd
 -a always,exit -F path=/sbin/unix_chkpwd -F perm=x -k privileged-passwd
 
-# RHEL-07-030650
 -a always,exit -F path=/usr/bin/gpasswd -F perm=x -k privileged-passwd
 -a always,exit -F path=/bin/gpasswd -F perm=x -k privileged-passwd
 
-# RHEL-07-030660
 -a always,exit -F path=/usr/bin/chage -F perm=x -k privileged-passwd
 -a always,exit -F path=/bin/chage -F perm=x -k privileged-passwd
 
-# RHEL-07-030670
 -a always,exit -F path=/usr/sbin/userhelper -F perm=x -k privileged-passwd
 -a always,exit -F path=/sbin/userhelper -F perm=x -k privileged-passwd
 
 ## Audit the execution of privilege-related commands
-# RHEL-07-030680
 -a always,exit -F path=/usr/bin/su -F perm=x -k privileged-priv_change
 -a always,exit -F path=/bin/su -F perm=x -k privileged-priv_change
 
-# RHEL-07-030690
 -a always,exit -F path=/usr/bin/sudo -F perm=x -k privileged-priv_change
 -a always,exit -F path=/bin/sudo -F perm=x -k privileged-priv_change
 
-# RHEL-07-030710
 -a always,exit -F path=/usr/bin/newgrp -F perm=x -k privileged-priv_change
 -a always,exit -F path=/bin/newgrp -F perm=x -k privileged-priv_change
 
-# RHEL-07-030720
 -a always,exit -F path=/usr/bin/chsh -F perm=x -k privileged-priv_change
 -a always,exit -F path=/bin/chsh -F perm=x -k privileged-priv_change
 
-# RHEL-07-030730
 -a always,exit -F path=/usr/bin/sudoedit -F perm=x -k privileged-priv_change
 -a always,exit -F path=/bin/sudoedit -F perm=x -k privileged-priv_change
 
 ## Audit the execution of postfix-related commands
-# RHEL-07-030760
 -a always,exit -F path=/usr/sbin/postdrop -F perm=x -k privileged-postfix
 -a always,exit -F path=/sbin/postdrop -F perm=x -k privileged-postfix
 
-# RHEL-07-030770
 -a always,exit -F path=/usr/sbin/postqueue -F perm=x -k privileged-postfix
 -a always,exit -F path=/sbin/postqueue -F perm=x -k privileged-postfix
 
 ## Audit the execution of the ssh-keysign command
-# RHEL-07-030780
 -a always,exit -F path=/usr/libexec/openssh/ssh-keysign -F perm=x -k privileged-ssh
 
 ## Audit the execution of the crontab command
-# RHEL-07-030800
 -a always,exit -F path=/usr/bin/crontab -F perm=x -k privileged-cron
 -a always,exit -F path=/bin/crontab -F perm=x -k privileged-cron
 
 ## Audit the execution of the pam_timestamp_check command
-# RHEL-07-030810
 -a always,exit -F path=/usr/sbin/pam_timestamp_check -F perm=x -k privileged-pam
 -a always,exit -F path=/sbin/pam_timestamp_check -F perm=x -k privileged-pam
 
 ## Permissions auditing separated by chown, chmod, and attr
-# CCE-26280-8
-# CCE-27173-4
-# CCE-27174-2
-# CCE-27175-9
-# CCE-27177-5
-# CCE-27178-3
-# CCE-27179-1
-# CCE-27180-9
-# CCE-27181-7
-# CCE-27182-5
-# CCE-27183-3
-# CCE-27184-1
-# CCE-27185-8
 
-# RHEL-07-030370
-# RHEL-07-030380
-# RHEL-07-030390
-# RHEL-07-030400
 -a always,exit -F arch=b64 -S chown,fchown,fchownat,lchown -k chown
 -a always,exit -F arch=b32 -S chown,fchown,fchownat,lchown -k chown
 
-# RHEL-07-030440
-# RHEL-07-030450
-# RHEL-07-030460
-# RHEL-07-030470
-# RHEL-07-030480
-# RHEL-07-030490
 -a always,exit -F arch=b64 -S setxattr,lsetxattr,fsetxattr,removexattr,lremovexattr,fremovexattr -k attr
 -a always,exit -F arch=b32 -S setxattr,lsetxattr,fsetxattr,removexattr,lremovexattr,fremovexattr -k attr
 
 ## Audit useful items that someone does when su'ing to root.
-# Had to add an entry in the default_drop rules file for getting rid of
-# anonymous records.  They are only moderately useful and contain *way*
-# too much noise since this covers things like cron as well.
 -a always,exit -F arch=b64 -F auid!=0 -F uid=0 -S capset,mknod,mknodat,pivot_root,quotactl,setsid,adjtimex,settimeofday,setuid,swapoff,swapon,execve,rename,renameat,rmdir,unlink,unlinkat,write,chown,fchown,fchownat,lchown,creat,fork,vfork,link,linkat,symlink,symlinkat,mkdir,mkdirat -k su-root-activity
 -a always,exit -F arch=b32 -F auid!=0 -F uid=0 -S capset,mknod,mknodat,pivot_root,quotactl,setsid,adjtimex,settimeofday,setuid,swapoff,swapon,execve,rename,renameat,rmdir,unlink,unlinkat,write,chown,fchown,fchownat,lchown,creat,fork,vfork,link,linkat,symlink,symlinkat,mkdir,mkdirat -k su-root-activity
 
 ## Audit the execution of suid and sgid binaries.
-# CCE-26457-2
-# RHEL-07-030360
 -a always,exit -F arch=b64 -F euid=0 -F uid!=0 -S execve -k suid-root-exec
 -a always,exit -F arch=b32 -F euid=0 -F uid!=0 -S execve -k suid-root-exec
 
 ## Audit the loading and unloading of kernel modules.
-# CCE-26611-4
 -w /usr/bin/kmod -p x -k modules
 -w /bin/kmod -p x -k modules
-
-# RHEL-07-030840
 -w /usr/sbin/insmod -p x -k modules
 -w /sbin/insmod -p x -k modules
-
-# RHEL-07-030850
 -w /usr/sbin/rmmod -p x -k modules
 -w /sbin/rmmod -p x -k modules
-
-# RHEL-07-030860
 -w /usr/sbin/modprobe -p x -k modules
 -w /sbin/modprobe -p x -k modules
 
-# RHEL-07-030819
-# RHEL-07-030820
-# RHEL-07-030821
-# RHEL-07-030830
 -a always,exit -F arch=b64 -S create_module,init_module,finit_module,delete_module -k modules
 -a always,exit -F arch=b32 -S create_module,init_module,finit_module,delete_module -k modules
 
 ## Audit things that could affect time
-# CCE-27172-6
-# CCE-27203-9
-# CCE-27169-2
-# CCE-27170-0
--a always,exit -F arch=b32 -S adjtimex,stime,settimeofday -k audit_time_rules
 -a always,exit -F arch=b64 -S adjtimex,settimeofday -k audit_time_rules
--a always,exit -F arch=b32 -S clock_settime -F a0=0x0 -k audit_time_rules
 -a always,exit -F arch=b64 -S clock_settime -F a0=0x0 -k audit_time_rules
+-a always,exit -F arch=b32 -S adjtimex,stime,settimeofday -k audit_time_rules
+-a always,exit -F arch=b32 -S clock_settime -F a0=0x0 -k audit_time_rules
 
-# CCE-27172-6
 -w /etc/localtime -p wa -k audit_time_rules
 
 ## Audit things that could affect system locale
-# CCE-26648-6
--a always,exit -F arch=b32 -S sethostname,setdomainname -k audit_network_modifications
 -a always,exit -F arch=b64 -S sethostname,setdomainname -k audit_network_modifications
+-a always,exit -F arch=b32 -S sethostname,setdomainname -k audit_network_modifications
+
 -w /etc/issue -p wa -k audit_network_modifications
 -w /etc/issue.net -p wa -k audit_network_modifications
 -w /etc/hosts -p wa -k audit_network_modifications
@@ -175,12 +115,9 @@
 -a always,exit -F dir=/etc/NetworkManager/ -F perm=wa -k audit_network_modifications
 
 ## Audit mount operations
-# CCE-26573-6
-#
-# RHEL-07-030740
-# RHEL-07-030750
--a always,exit -F arch=b32 -S mount,umount,umount2 -k mount
 -a always,exit -F arch=b64 -S mount,umount2 -k mount
+-a always,exit -F arch=b32 -S mount,umount,umount2 -k mount
+
 -a always,exit -F arch=b64 -F path=/usr/bin/mount -k mount
 -a always,exit -F arch=b64 -F path=/bin/mount -k mount
 -a always,exit -F arch=b32 -F path=/usr/bin/mount -k mount
@@ -189,57 +126,56 @@
 -a always,exit -F path=/bin/umount -F perm=x -k mount
 
 ## Audit local accounts
-# CCE-26664-3
-#
-# RHEL-07-030870
 -w /etc/passwd -p wa -k audit_account_changes
-
-# RHEL-07-030871
 -w /etc/group -p wa -k audit_account_changes
-
-# RHEL-07-030872
 -w /etc/gshadow -p wa -k audit_account_changes
-
-# RHEL-07-030873
 -w /etc/shadow -p wa -k audit_account_changes
-
-# RHEL-07-030874
 -w /etc/security/opasswd -p wa -k audit_account_changes
-
 -w /etc/passwd- -p wa -k audit_account_changes
 -w /etc/group- -p wa -k audit_account_changes
 -w /etc/shadow- -p wa -k audit_account_changes
 
 ## Audit selinux policy
-# CCE-26657-7
 -w /etc/selinux/ -p wa -k MAC-policy
 -w /usr/share/selinux/ -p wa -k MAC-policy
 
 ## Audit login files
-# CCE-26691-6
-#
-# RHEL-07-030600
 -w /var/log/tallylog -p wa -k logins
-
-# RHEL-07-030610
 -w /var/run/faillock -p wa -k logins
-
-# RHEL-07-030620
 -w /var/log/lastlog -p wa -k logins
-
 -w /var/log/faillog -p wa -k logins
 
 ## Audit session files
-# CCE-26610-6
 -w /var/run/utmp -p wa -k session
 -w /var/log/btmp -p wa -k session
 -w /var/log/wtmp -p wa -k session
 
 ## Audit sudoers configuration files
-# CCE-26662-7
-# RHEL-07-030700
 -w /etc/sudoers -p wa -k CFG_sys
 -w /etc/sudoers.d/ -p wa -k CFG_sys
+
+## Audit accesses to the audit trail
+-w /usr/sbin/aulast -p x -k access-audit-trail
+-w /usr/sbin/aulastlogin -p x -k access-audit-trail
+-w /usr/sbin/aureport -p x -k access-audit-trail
+-w /usr/sbin/ausearch -p x -k access-audit-trail
+-w /usr/sbin/auvirt -p x -k access-audit-trail
+
+## Audit systemd components
+-w /bin/systemctl -p x -k systemd
+-w /usr/bin/systemctl -p x -k systemd
+-w /etc/systemd/ -p wa -k systemd
+
+## Audit suspicious applications
+-w /usr/bin/nc -p x -k suspicious_apps
+-w /usr/bin/ncat -p x -k suspicious_apps
+-w /usr/bin/nmap -p x -k suspicious_apps
+-w /usr/bin/rawshark -p x -k suspicious_apps
+-w /usr/bin/socat -p x -k suspicious_apps
+-w /usr/bin/wireshark -p x -k suspicious_apps
+-w /usr/sbin/tcpdump -p x -k suspicious_apps
+-w /usr/sbin/traceroute -p x -k suspicious_apps
+-w /usr/sbin/traceroute6 -p x -k suspicious_apps
 
 ## Generally good things to audit.
 -w /etc/grub.d -p wa -k CFG_grub
@@ -251,8 +187,6 @@
 -w /etc/hosts.deny -p wa -k CFG_sys
 -w /etc/initlog.conf -p wa -k CFG_sys
 -w /etc/inittab -p wa -k CFG_sys
--w /etc/issue -p wa -k CFG_sys
--w /etc/issue.net -p wa -k CFG_sys
 -w /etc/krb5.conf -p wa -k CFG_sys
 -w /etc/ld.so.conf -p wa -k CFG_sys
 -w /etc/ld.so.conf.d -p wa -k CFG_sys
@@ -295,7 +229,13 @@
 -w /etc/yum -p wa -k yum-config
 -w /etc/yum.conf -p wa -k yum-config
 -w /etc/yum.repos.d -p wa -k yum-config
--a always,exit -F arch=b32 -S ptrace -k paranoid
+-a always,exit -F arch=b64 -S ptrace -F a0=0x4 -k paranoid_code_injection
+-a always,exit -F arch=b64 -S ptrace -F a0=0x5 -k paranoid_data_injection
+-a always,exit -F arch=b64 -S ptrace -F a0=0x6 -k paranoid_register_injection
 -a always,exit -F arch=b64 -S ptrace -k paranoid
--a always,exit -F arch=b32 -S personality -k paranoid
+-a always,exit -F arch=b32 -S ptrace -F a0=0x4 -k paranoid_code_injection
+-a always,exit -F arch=b32 -S ptrace -F a0=0x5 -k paranoid_data_injection
+-a always,exit -F arch=b32 -S ptrace -F a0=0x6 -k paranoid_register_injection
+-a always,exit -F arch=b32 -S ptrace -k paranoid
 -a always,exit -F arch=b64 -S personality -k paranoid
+-a always,exit -F arch=b32 -S personality -k paranoid

--- a/spec/classes/config/audit_profiles/expected/stig_el6_all_custom_tags.txt
+++ b/spec/classes/config/audit_profiles/expected/stig_el6_all_custom_tags.txt
@@ -1,185 +1,140 @@
 #### auditd::config::audit_profiles::stig Audit Rules ####
 
 ## Audit unsuccessful file operations
-# RHEL-07-030500
 -a always,exit -F arch=b64 -S creat -F exit=-EPERM -F auid>=500 -F auid!=4294967295 -k my_unsuccessful_file_operations
 -a always,exit -F arch=b64 -S creat -F exit=-EACCES -F auid>=500 -F auid!=4294967295 -k my_unsuccessful_file_operations
 -a always,exit -F arch=b32 -S creat -F exit=-EPERM -F auid>=500 -F auid!=4294967295 -k my_unsuccessful_file_operations
 -a always,exit -F arch=b32 -S creat -F exit=-EACCES -F auid>=500 -F auid!=4294967295 -k my_unsuccessful_file_operations
 
-# RHEL-07-030510
 -a always,exit -F arch=b64 -S open -F exit=-EPERM -F auid>=500 -F auid!=4294967295 -k my_unsuccessful_file_operations
 -a always,exit -F arch=b64 -S open -F exit=-EACCES -F auid>=500 -F auid!=4294967295 -k my_unsuccessful_file_operations
 -a always,exit -F arch=b32 -S open -F exit=-EPERM -F auid>=500 -F auid!=4294967295 -k my_unsuccessful_file_operations
 -a always,exit -F arch=b32 -S open -F exit=-EACCES -F auid>=500 -F auid!=4294967295 -k my_unsuccessful_file_operations
 
-# RHEL-07-030520
 -a always,exit -F arch=b64 -S openat -F exit=-EPERM -F auid>=500 -F auid!=4294967295 -k my_unsuccessful_file_operations
 -a always,exit -F arch=b64 -S openat -F exit=-EACCES -F auid>=500 -F auid!=4294967295 -k my_unsuccessful_file_operations
 -a always,exit -F arch=b32 -S openat -F exit=-EPERM -F auid>=500 -F auid!=4294967295 -k my_unsuccessful_file_operations
 -a always,exit -F arch=b32 -S openat -F exit=-EACCES -F auid>=500 -F auid!=4294967295 -k my_unsuccessful_file_operations
 
-# RHEL-07-030530
 -a always,exit -F arch=b64 -S open_by_handle_at -F exit=-EPERM -F auid>=500 -F auid!=4294967295 -k my_unsuccessful_file_operations
 -a always,exit -F arch=b64 -S open_by_handle_at -F exit=-EACCES -F auid>=500 -F auid!=4294967295 -k my_unsuccessful_file_operations
 -a always,exit -F arch=b32 -S open_by_handle_at -F exit=-EPERM -F auid>=500 -F auid!=4294967295 -k my_unsuccessful_file_operations
 -a always,exit -F arch=b32 -S open_by_handle_at -F exit=-EACCES -F auid>=500 -F auid!=4294967295 -k my_unsuccessful_file_operations
 
-# RHEL-07-030540
 -a always,exit -F arch=b64 -S truncate -F exit=-EPERM -F auid>=500 -F auid!=4294967295 -k my_unsuccessful_file_operations
 -a always,exit -F arch=b64 -S truncate -F exit=-EACCES -F auid>=500 -F auid!=4294967295 -k my_unsuccessful_file_operations
 -a always,exit -F arch=b32 -S truncate -F exit=-EPERM -F auid>=500 -F auid!=4294967295 -k my_unsuccessful_file_operations
 -a always,exit -F arch=b32 -S truncate -F exit=-EACCES -F auid>=500 -F auid!=4294967295 -k my_unsuccessful_file_operations
 
-# RHEL-07-030550
 -a always,exit -F arch=b64 -S ftruncate -F exit=-EPERM -F auid>=500 -F auid!=4294967295 -k my_unsuccessful_file_operations
 -a always,exit -F arch=b64 -S ftruncate -F exit=-EACCES -F auid>=500 -F auid!=4294967295 -k my_unsuccessful_file_operations
 -a always,exit -F arch=b32 -S ftruncate -F exit=-EPERM -F auid>=500 -F auid!=4294967295 -k my_unsuccessful_file_operations
 -a always,exit -F arch=b32 -S ftruncate -F exit=-EACCES -F auid>=500 -F auid!=4294967295 -k my_unsuccessful_file_operations
 
 ## Audit the execution of password commands
-# RHEL-07-030630
 -a always,exit -F path=/usr/bin/passwd -F perm=x -F auid>=500 -F auid!=4294967295 -k my_passwd_cmds
 
-# RHEL-07-030640
 -a always,exit -F path=/sbin/unix_chkpwd -F perm=x -F auid>=500 -F auid!=4294967295 -k my_passwd_cmds
 
-# RHEL-07-030650
 -a always,exit -F path=/usr/bin/gpasswd -F perm=x -F auid>=500 -F auid!=4294967295 -k my_passwd_cmds
 
-# RHEL-07-030660
 -a always,exit -F path=/usr/bin/chage -F perm=x -F auid>=500 -F auid!=4294967295 -k my_passwd_cmds
 
-# RHEL-07-030670
 -a always,exit -F path=/usr/sbin/userhelper -F perm=x -F auid>=500 -F auid!=4294967295 -k my_passwd_cmds
 
 ## Audit the execution of privilege-related commands
-# RHEL-07-030680
 -a always,exit -F path=/bin/su -F perm=x -F auid>=500 -F auid!=4294967295 -k my_priv_cmds
 
-# RHEL-07-030690
 -a always,exit -F path=/usr/bin/sudo -F perm=x -F auid>=500 -F auid!=4294967295 -k my_priv_cmds
 
-# RHEL-07-030710
 -a always,exit -F path=/usr/bin/newgrp -F perm=x -F auid>=500 -F auid!=4294967295 -k my_priv_cmds
 
-# RHEL-07-030720
 -a always,exit -F path=/usr/bin/chsh -F perm=x -F auid>=500 -F auid!=4294967295 -k my_priv_cmds
 
-# RHEL-07-030730
 -a always,exit -F path=/usr/bin/sudoedit -F perm=x -F auid>=500 -F auid!=4294967295 -k my_priv_cmds
 
 ## Audit the execution of postfix-related commands
-# RHEL-07-030760
 -a always,exit -F path=/usr/sbin/postdrop -F perm=x -F auid>=500 -F auid!=4294967295 -k my_postfix_cmds
 
-# RHEL-07-030770
 -a always,exit -F path=/usr/sbin/postqueue -F perm=x -F auid>=500 -F auid!=4294967295 -k my_postfix_cmds
 
 ## Audit the execution of the ssh-keysign command
-# RHEL-07-030780
 -a always,exit -F path=/usr/libexec/openssh/ssh-keysign -F perm=x -F auid>=500 -F auid!=4294967295 -k my_ssh_keysign_cmd
 
 ## Audit the execution of the crontab command
-# RHEL-07-030800
 -a always,exit -F path=/usr/bin/crontab -F perm=x -F auid>=500 -F auid!=4294967295 -k my_crontab
 
 ## Audit the execution of the pam_timestamp_check command
-# RHEL-07-030810
 -a always,exit -F path=/sbin/pam_timestamp_check -F perm=x -F auid>=500 -F auid!=4294967295 -k my_pam_timestamp_check_cmd
 
 ## Audit selinux commands
-# RHEL-07-030560
 -a always,exit -F path=/usr/sbin/semanage -F perm=x -F auid>=500 -F auid!=4294967295 -k my_selinux_cmds
 
-# RHEL-07-030570
 -a always,exit -F path=/usr/sbin/setsebool -F perm=x -F auid>=500 -F auid!=4294967295 -k my_selinux_cmds
 
-# RHEL-07-030580
 -a always,exit -F path=/usr/bin/chcon -F perm=x -F auid>=500 -F auid!=4294967295 -k my_selinux_cmds
 
-# RHEL-07-030590
 -a always,exit -F path=/sbin/setfiles -F perm=x -F auid>=500 -F auid!=4294967295 -k my_selinux_cmds
 
-# RHEL-07-030590
 -a always,exit -F path=/sbin/restorecon -F perm=x -F auid>=500 -F auid!=4294967295 -k my_selinux_cmds
 
 ## Permissions auditing separated by chown, chmod, and attr
-# RHEL-07-030370
 -a always,exit -F arch=b64 -S chown -F auid>=500 -F auid!=4294967295 -k my_chown
 -a always,exit -F arch=b32 -S chown -F auid>=500 -F auid!=4294967295 -k my_chown
 
-# RHEL-07-030380
 -a always,exit -F arch=b64 -S fchown -F auid>=500 -F auid!=4294967295 -k my_chown
 -a always,exit -F arch=b32 -S fchown -F auid>=500 -F auid!=4294967295 -k my_chown
 
-# RHEL-07-030390
 -a always,exit -F arch=b64 -S lchown -F auid>=500 -F auid!=4294967295 -k my_chown
 -a always,exit -F arch=b32 -S lchown -F auid>=500 -F auid!=4294967295 -k my_chown
 
-# RHEL-07-030400
 -a always,exit -F arch=b64 -S fchownat -F auid>=500 -F auid!=4294967295 -k my_chown
 -a always,exit -F arch=b32 -S fchownat -F auid>=500 -F auid!=4294967295 -k my_chown
 
-# RHEL-07-030410
 -a always,exit -F arch=b64 -S chmod -F auid>=500 -F auid!=4294967295 -k my_chmod
 -a always,exit -F arch=b32 -S chmod -F auid>=500 -F auid!=4294967295 -k my_chmod
 
-# RHEL-07-030420
 -a always,exit -F arch=b64 -S fchmod -F auid>=500 -F auid!=4294967295 -k my_chmod
 -a always,exit -F arch=b32 -S fchmod -F auid>=500 -F auid!=4294967295 -k my_chmod
 
-# RHEL-07-030430
 -a always,exit -F arch=b64 -S fchmodat -F auid>=500 -F auid!=4294967295 -k my_chmod
 -a always,exit -F arch=b32 -S fchmodat -F auid>=500 -F auid!=4294967295 -k my_chmod
 
-# RHEL-07-030440
 -a always,exit -F arch=b64 -S setxattr -F auid>=500 -F auid!=4294967295 -k my_attr
 -a always,exit -F arch=b32 -S setxattr -F auid>=500 -F auid!=4294967295 -k my_attr
 
-# RHEL-07-030450
 -a always,exit -F arch=b64 -S fsetxattr -F auid>=500 -F auid!=4294967295 -k my_attr
 -a always,exit -F arch=b32 -S fsetxattr -F auid>=500 -F auid!=4294967295 -k my_attr
 
-# RHEL-07-030460
 -a always,exit -F arch=b64 -S lsetxattr -F auid>=500 -F auid!=4294967295 -k my_attr
 -a always,exit -F arch=b32 -S lsetxattr -F auid>=500 -F auid!=4294967295 -k my_attr
 
-# RHEL-07-030470
 -a always,exit -F arch=b64 -S removexattr -F auid>=500 -F auid!=4294967295 -k my_attr
 -a always,exit -F arch=b32 -S removexattr -F auid>=500 -F auid!=4294967295 -k my_attr
 
-# RHEL-07-030480
 -a always,exit -F arch=b64 -S fremovexattr -F auid>=500 -F auid!=4294967295 -k my_attr
 -a always,exit -F arch=b32 -S fremovexattr -F auid>=500 -F auid!=4294967295 -k my_attr
 
-# RHEL-07-030490
 -a always,exit -F arch=b64 -S lremovexattr -F auid>=500 -F auid!=4294967295 -k my_attr
 -a always,exit -F arch=b32 -S lremovexattr -F auid>=500 -F auid!=4294967295 -k my_attr
 
 ## Audit rename/removal operations
-# RHEL-07-030880
 -a always,exit -F arch=b64 -S rename -F perm=x -F auid>=500 -F auid!=4294967295 -k my_rename_remove
 -a always,exit -F arch=b32 -S rename -F perm=x -F auid>=500 -F auid!=4294967295 -k my_rename_remove
 
-# RHEL-07-030890
 -a always,exit -F arch=b64 -S renameat -F perm=x -F auid>=500 -F auid!=4294967295 -k my_rename_remove
 -a always,exit -F arch=b32 -S renameat -F perm=x -F auid>=500 -F auid!=4294967295 -k my_rename_remove
 
-# RHEL-07-030900
 -a always,exit -F arch=b64 -S rmdir -F perm=x -F auid>=500 -F auid!=4294967295 -k my_rename_remove
 -a always,exit -F arch=b32 -S rmdir -F perm=x -F auid>=500 -F auid!=4294967295 -k my_rename_remove
 
-# RHEL-07-030910
 -a always,exit -F arch=b64 -S unlink -F perm=x -F auid>=500 -F auid!=4294967295 -k my_rename_remove
 -a always,exit -F arch=b32 -S unlink -F perm=x -F auid>=500 -F auid!=4294967295 -k my_rename_remove
 
-# RHEL-07-030920
 -a always,exit -F arch=b64 -S unlinkat -F perm=x -F auid>=500 -F auid!=4294967295 -k my_rename_remove
 -a always,exit -F arch=b32 -S unlinkat -F perm=x -F auid>=500 -F auid!=4294967295 -k my_rename_remove
 
 ## Audit the execution of suid and sgid binaries.
-# RHEL-07-030360
 -a always,exit -F path=/bin/cgclassify -F perm=x -F auid>=500 -F auid!=4294967295 -k my_suid_sgid
 -a always,exit -F path=/bin/cgexec -F perm=x -F auid>=500 -F auid!=4294967295 -k my_suid_sgid
 -a always,exit -F path=/bin/ping -F perm=x -F auid>=500 -F auid!=4294967295 -k my_suid_sgid
@@ -231,68 +186,50 @@
 -a always,exit -F path=/usr/sbin/usernetctl -F perm=x -F auid>=500 -F auid!=4294967295 -k my_suid_sgid
 
 ## Audit the loading and unloading of kernel modules.
-# RHEL-07-030840
 -w /sbin/insmod -p x -F auid!=4294967295 -k my_kernel_modules
 
-# RHEL-07-030850
 -w /sbin/rmmod -p x -F auid!=4294967295 -k my_kernel_modules
 
-# RHEL-07-030860
 -w /sbin/modprobe -p x -F auid!=4294967295 -k my_kernel_modules
 
-# RHEL-07-030819
 -a always,exit -F arch=b64 -S create_module -k my_kernel_modules
 -a always,exit -F arch=b32 -S create_module -k my_kernel_modules
 
-# RHEL-07-030820
 -a always,exit -F arch=b64 -S init_module -k my_kernel_modules
 -a always,exit -F arch=b32 -S init_module -k my_kernel_modules
 
-# RHEL-07-030821
 -a always,exit -F arch=b64 -S finit_module -k my_kernel_modules
 -a always,exit -F arch=b32 -S finit_module -k my_kernel_modules
 
-# RHEL-07-030830
 -a always,exit -F arch=b64 -S delete_module -k my_kernel_modules
 -a always,exit -F arch=b32 -S delete_module -k my_kernel_modules
 
 ## Audit mount operations
-# RHEL-07-030740
 -a always,exit -F arch=b64 -S mount -F auid>=500 -F auid!=4294967295 -k my_mount
 -a always,exit -F arch=b64 -F path=/bin/mount -F auid>=500 -F auid!=4294967295 -k my_mount
 -a always,exit -F arch=b32 -S mount -F auid>=500 -F auid!=4294967295 -k my_mount
 -a always,exit -F arch=b32 -F path=/bin/mount -F auid>=500 -F auid!=4294967295 -k my_mount
 
-# RHEL-07-030750
 -a always,exit -F path=/bin/umount -F perm=x -F auid>=500 -F auid!=4294967295 -k my_mount
 
 ## Audit local accounts
-# RHEL-07-030870
 -w /etc/passwd -p wa -k my_local_account
 
-# RHEL-07-030871
 -w /etc/group -p wa -k my_local_account
 
-# RHEL-07-030872
 -w /etc/gshadow -p wa -k my_local_account
 
-# RHEL-07-030873
 -w /etc/shadow -p wa -k my_local_account
 
-# RHEL-07-030874
 -w /etc/security/opasswd -p wa -k my_local_account
 
 ## Audit login files
-# RHEL-07-030600
 -w /var/log/tallylog -p wa -k my_login_files
 
-# RHEL-07-030610
 -w /var/run/faillock -p wa -k my_login_files
 
-# RHEL-07-030620
 -w /var/log/lastlog -p wa -k my_login_files
 
 ## Audit sudoers configuration files
-# RHEL-07-030700
 -w /etc/sudoers -p wa -k my_cfg_sudoers
 -w /etc/sudoers.d/ -p wa -k my_cfg_sudoers

--- a/spec/classes/config/audit_profiles/expected/stig_el6_all_custom_tags.txt
+++ b/spec/classes/config/audit_profiles/expected/stig_el6_all_custom_tags.txt
@@ -1,189 +1,189 @@
 #### auditd::config::audit_profiles::stig Audit Rules ####
 
 ## Audit unsuccessful file operations
--a always,exit -F arch=b64 -S creat -F exit=-EPERM -F auid>=500 -F auid!=4294967295 -k my_unsuccessful_file_operations
--a always,exit -F arch=b64 -S creat -F exit=-EACCES -F auid>=500 -F auid!=4294967295 -k my_unsuccessful_file_operations
--a always,exit -F arch=b32 -S creat -F exit=-EPERM -F auid>=500 -F auid!=4294967295 -k my_unsuccessful_file_operations
--a always,exit -F arch=b32 -S creat -F exit=-EACCES -F auid>=500 -F auid!=4294967295 -k my_unsuccessful_file_operations
+-a exit,always -F arch=b64 -S creat -F exit=-EPERM -F auid>=500 -F auid!=4294967295 -k my_unsuccessful_file_operations
+-a exit,always -F arch=b64 -S creat -F exit=-EACCES -F auid>=500 -F auid!=4294967295 -k my_unsuccessful_file_operations
+-a exit,always -F arch=b32 -S creat -F exit=-EPERM -F auid>=500 -F auid!=4294967295 -k my_unsuccessful_file_operations
+-a exit,always -F arch=b32 -S creat -F exit=-EACCES -F auid>=500 -F auid!=4294967295 -k my_unsuccessful_file_operations
 
--a always,exit -F arch=b64 -S open -F exit=-EPERM -F auid>=500 -F auid!=4294967295 -k my_unsuccessful_file_operations
--a always,exit -F arch=b64 -S open -F exit=-EACCES -F auid>=500 -F auid!=4294967295 -k my_unsuccessful_file_operations
--a always,exit -F arch=b32 -S open -F exit=-EPERM -F auid>=500 -F auid!=4294967295 -k my_unsuccessful_file_operations
--a always,exit -F arch=b32 -S open -F exit=-EACCES -F auid>=500 -F auid!=4294967295 -k my_unsuccessful_file_operations
+-a exit,always -F arch=b64 -S open -F exit=-EPERM -F auid>=500 -F auid!=4294967295 -k my_unsuccessful_file_operations
+-a exit,always -F arch=b64 -S open -F exit=-EACCES -F auid>=500 -F auid!=4294967295 -k my_unsuccessful_file_operations
+-a exit,always -F arch=b32 -S open -F exit=-EPERM -F auid>=500 -F auid!=4294967295 -k my_unsuccessful_file_operations
+-a exit,always -F arch=b32 -S open -F exit=-EACCES -F auid>=500 -F auid!=4294967295 -k my_unsuccessful_file_operations
 
--a always,exit -F arch=b64 -S openat -F exit=-EPERM -F auid>=500 -F auid!=4294967295 -k my_unsuccessful_file_operations
--a always,exit -F arch=b64 -S openat -F exit=-EACCES -F auid>=500 -F auid!=4294967295 -k my_unsuccessful_file_operations
--a always,exit -F arch=b32 -S openat -F exit=-EPERM -F auid>=500 -F auid!=4294967295 -k my_unsuccessful_file_operations
--a always,exit -F arch=b32 -S openat -F exit=-EACCES -F auid>=500 -F auid!=4294967295 -k my_unsuccessful_file_operations
+-a exit,always -F arch=b64 -S openat -F exit=-EPERM -F auid>=500 -F auid!=4294967295 -k my_unsuccessful_file_operations
+-a exit,always -F arch=b64 -S openat -F exit=-EACCES -F auid>=500 -F auid!=4294967295 -k my_unsuccessful_file_operations
+-a exit,always -F arch=b32 -S openat -F exit=-EPERM -F auid>=500 -F auid!=4294967295 -k my_unsuccessful_file_operations
+-a exit,always -F arch=b32 -S openat -F exit=-EACCES -F auid>=500 -F auid!=4294967295 -k my_unsuccessful_file_operations
 
--a always,exit -F arch=b64 -S open_by_handle_at -F exit=-EPERM -F auid>=500 -F auid!=4294967295 -k my_unsuccessful_file_operations
--a always,exit -F arch=b64 -S open_by_handle_at -F exit=-EACCES -F auid>=500 -F auid!=4294967295 -k my_unsuccessful_file_operations
--a always,exit -F arch=b32 -S open_by_handle_at -F exit=-EPERM -F auid>=500 -F auid!=4294967295 -k my_unsuccessful_file_operations
--a always,exit -F arch=b32 -S open_by_handle_at -F exit=-EACCES -F auid>=500 -F auid!=4294967295 -k my_unsuccessful_file_operations
+-a exit,always -F arch=b64 -S open_by_handle_at -F exit=-EPERM -F auid>=500 -F auid!=4294967295 -k my_unsuccessful_file_operations
+-a exit,always -F arch=b64 -S open_by_handle_at -F exit=-EACCES -F auid>=500 -F auid!=4294967295 -k my_unsuccessful_file_operations
+-a exit,always -F arch=b32 -S open_by_handle_at -F exit=-EPERM -F auid>=500 -F auid!=4294967295 -k my_unsuccessful_file_operations
+-a exit,always -F arch=b32 -S open_by_handle_at -F exit=-EACCES -F auid>=500 -F auid!=4294967295 -k my_unsuccessful_file_operations
 
--a always,exit -F arch=b64 -S truncate -F exit=-EPERM -F auid>=500 -F auid!=4294967295 -k my_unsuccessful_file_operations
--a always,exit -F arch=b64 -S truncate -F exit=-EACCES -F auid>=500 -F auid!=4294967295 -k my_unsuccessful_file_operations
--a always,exit -F arch=b32 -S truncate -F exit=-EPERM -F auid>=500 -F auid!=4294967295 -k my_unsuccessful_file_operations
--a always,exit -F arch=b32 -S truncate -F exit=-EACCES -F auid>=500 -F auid!=4294967295 -k my_unsuccessful_file_operations
+-a exit,always -F arch=b64 -S truncate -F exit=-EPERM -F auid>=500 -F auid!=4294967295 -k my_unsuccessful_file_operations
+-a exit,always -F arch=b64 -S truncate -F exit=-EACCES -F auid>=500 -F auid!=4294967295 -k my_unsuccessful_file_operations
+-a exit,always -F arch=b32 -S truncate -F exit=-EPERM -F auid>=500 -F auid!=4294967295 -k my_unsuccessful_file_operations
+-a exit,always -F arch=b32 -S truncate -F exit=-EACCES -F auid>=500 -F auid!=4294967295 -k my_unsuccessful_file_operations
 
--a always,exit -F arch=b64 -S ftruncate -F exit=-EPERM -F auid>=500 -F auid!=4294967295 -k my_unsuccessful_file_operations
--a always,exit -F arch=b64 -S ftruncate -F exit=-EACCES -F auid>=500 -F auid!=4294967295 -k my_unsuccessful_file_operations
--a always,exit -F arch=b32 -S ftruncate -F exit=-EPERM -F auid>=500 -F auid!=4294967295 -k my_unsuccessful_file_operations
--a always,exit -F arch=b32 -S ftruncate -F exit=-EACCES -F auid>=500 -F auid!=4294967295 -k my_unsuccessful_file_operations
+-a exit,always -F arch=b64 -S ftruncate -F exit=-EPERM -F auid>=500 -F auid!=4294967295 -k my_unsuccessful_file_operations
+-a exit,always -F arch=b64 -S ftruncate -F exit=-EACCES -F auid>=500 -F auid!=4294967295 -k my_unsuccessful_file_operations
+-a exit,always -F arch=b32 -S ftruncate -F exit=-EPERM -F auid>=500 -F auid!=4294967295 -k my_unsuccessful_file_operations
+-a exit,always -F arch=b32 -S ftruncate -F exit=-EACCES -F auid>=500 -F auid!=4294967295 -k my_unsuccessful_file_operations
 
 ## Audit the execution of password commands
--a always,exit -F path=/usr/bin/passwd -F perm=x -F auid>=500 -F auid!=4294967295 -k my_passwd_cmds
+-a exit,always -F path=/usr/bin/passwd -F perm=x -F auid>=500 -F auid!=4294967295 -k my_passwd_cmds
 
--a always,exit -F path=/sbin/unix_chkpwd -F perm=x -F auid>=500 -F auid!=4294967295 -k my_passwd_cmds
+-a exit,always -F path=/sbin/unix_chkpwd -F perm=x -F auid>=500 -F auid!=4294967295 -k my_passwd_cmds
 
--a always,exit -F path=/usr/bin/gpasswd -F perm=x -F auid>=500 -F auid!=4294967295 -k my_passwd_cmds
+-a exit,always -F path=/usr/bin/gpasswd -F perm=x -F auid>=500 -F auid!=4294967295 -k my_passwd_cmds
 
--a always,exit -F path=/usr/bin/chage -F perm=x -F auid>=500 -F auid!=4294967295 -k my_passwd_cmds
+-a exit,always -F path=/usr/bin/chage -F perm=x -F auid>=500 -F auid!=4294967295 -k my_passwd_cmds
 
--a always,exit -F path=/usr/sbin/userhelper -F perm=x -F auid>=500 -F auid!=4294967295 -k my_passwd_cmds
+-a exit,always -F path=/usr/sbin/userhelper -F perm=x -F auid>=500 -F auid!=4294967295 -k my_passwd_cmds
 
 ## Audit the execution of privilege-related commands
--a always,exit -F path=/bin/su -F perm=x -F auid>=500 -F auid!=4294967295 -k my_priv_cmds
+-a exit,always -F path=/bin/su -F perm=x -F auid>=500 -F auid!=4294967295 -k my_priv_cmds
 
--a always,exit -F path=/usr/bin/sudo -F perm=x -F auid>=500 -F auid!=4294967295 -k my_priv_cmds
+-a exit,always -F path=/usr/bin/sudo -F perm=x -F auid>=500 -F auid!=4294967295 -k my_priv_cmds
 
--a always,exit -F path=/usr/bin/newgrp -F perm=x -F auid>=500 -F auid!=4294967295 -k my_priv_cmds
+-a exit,always -F path=/usr/bin/newgrp -F perm=x -F auid>=500 -F auid!=4294967295 -k my_priv_cmds
 
--a always,exit -F path=/usr/bin/chsh -F perm=x -F auid>=500 -F auid!=4294967295 -k my_priv_cmds
+-a exit,always -F path=/usr/bin/chsh -F perm=x -F auid>=500 -F auid!=4294967295 -k my_priv_cmds
 
--a always,exit -F path=/usr/bin/sudoedit -F perm=x -F auid>=500 -F auid!=4294967295 -k my_priv_cmds
+-a exit,always -F path=/usr/bin/sudoedit -F perm=x -F auid>=500 -F auid!=4294967295 -k my_priv_cmds
 
 ## Audit the execution of postfix-related commands
--a always,exit -F path=/usr/sbin/postdrop -F perm=x -F auid>=500 -F auid!=4294967295 -k my_postfix_cmds
+-a exit,always -F path=/usr/sbin/postdrop -F perm=x -F auid>=500 -F auid!=4294967295 -k my_postfix_cmds
 
--a always,exit -F path=/usr/sbin/postqueue -F perm=x -F auid>=500 -F auid!=4294967295 -k my_postfix_cmds
+-a exit,always -F path=/usr/sbin/postqueue -F perm=x -F auid>=500 -F auid!=4294967295 -k my_postfix_cmds
 
 ## Audit the execution of the ssh-keysign command
--a always,exit -F path=/usr/libexec/openssh/ssh-keysign -F perm=x -F auid>=500 -F auid!=4294967295 -k my_ssh_keysign_cmd
+-a exit,always -F path=/usr/libexec/openssh/ssh-keysign -F perm=x -F auid>=500 -F auid!=4294967295 -k my_ssh_keysign_cmd
 
 ## Audit the execution of the crontab command
--a always,exit -F path=/usr/bin/crontab -F perm=x -F auid>=500 -F auid!=4294967295 -k my_crontab
+-a exit,always -F path=/usr/bin/crontab -F perm=x -F auid>=500 -F auid!=4294967295 -k my_crontab
 
 ## Audit the execution of the pam_timestamp_check command
--a always,exit -F path=/sbin/pam_timestamp_check -F perm=x -F auid>=500 -F auid!=4294967295 -k my_pam_timestamp_check_cmd
+-a exit,always -F path=/sbin/pam_timestamp_check -F perm=x -F auid>=500 -F auid!=4294967295 -k my_pam_timestamp_check_cmd
 
 ## Audit selinux commands
--a always,exit -F path=/usr/sbin/semanage -F perm=x -F auid>=500 -F auid!=4294967295 -k my_selinux_cmds
+-a exit,always -F path=/usr/sbin/semanage -F perm=x -F auid>=500 -F auid!=4294967295 -k my_selinux_cmds
 
--a always,exit -F path=/usr/sbin/setsebool -F perm=x -F auid>=500 -F auid!=4294967295 -k my_selinux_cmds
+-a exit,always -F path=/usr/sbin/setsebool -F perm=x -F auid>=500 -F auid!=4294967295 -k my_selinux_cmds
 
--a always,exit -F path=/usr/bin/chcon -F perm=x -F auid>=500 -F auid!=4294967295 -k my_selinux_cmds
+-a exit,always -F path=/usr/bin/chcon -F perm=x -F auid>=500 -F auid!=4294967295 -k my_selinux_cmds
 
--a always,exit -F path=/sbin/setfiles -F perm=x -F auid>=500 -F auid!=4294967295 -k my_selinux_cmds
+-a exit,always -F path=/sbin/setfiles -F perm=x -F auid>=500 -F auid!=4294967295 -k my_selinux_cmds
 
--a always,exit -F path=/sbin/restorecon -F perm=x -F auid>=500 -F auid!=4294967295 -k my_selinux_cmds
+-a exit,always -F path=/sbin/restorecon -F perm=x -F auid>=500 -F auid!=4294967295 -k my_selinux_cmds
 
 ## Permissions auditing separated by chown, chmod, and attr
--a always,exit -F arch=b64 -S chown -F auid>=500 -F auid!=4294967295 -k my_chown
--a always,exit -F arch=b32 -S chown -F auid>=500 -F auid!=4294967295 -k my_chown
+-a exit,always -F arch=b64 -S chown -F auid>=500 -F auid!=4294967295 -k my_chown
+-a exit,always -F arch=b32 -S chown -F auid>=500 -F auid!=4294967295 -k my_chown
 
--a always,exit -F arch=b64 -S fchown -F auid>=500 -F auid!=4294967295 -k my_chown
--a always,exit -F arch=b32 -S fchown -F auid>=500 -F auid!=4294967295 -k my_chown
+-a exit,always -F arch=b64 -S fchown -F auid>=500 -F auid!=4294967295 -k my_chown
+-a exit,always -F arch=b32 -S fchown -F auid>=500 -F auid!=4294967295 -k my_chown
 
--a always,exit -F arch=b64 -S lchown -F auid>=500 -F auid!=4294967295 -k my_chown
--a always,exit -F arch=b32 -S lchown -F auid>=500 -F auid!=4294967295 -k my_chown
+-a exit,always -F arch=b64 -S lchown -F auid>=500 -F auid!=4294967295 -k my_chown
+-a exit,always -F arch=b32 -S lchown -F auid>=500 -F auid!=4294967295 -k my_chown
 
--a always,exit -F arch=b64 -S fchownat -F auid>=500 -F auid!=4294967295 -k my_chown
--a always,exit -F arch=b32 -S fchownat -F auid>=500 -F auid!=4294967295 -k my_chown
+-a exit,always -F arch=b64 -S fchownat -F auid>=500 -F auid!=4294967295 -k my_chown
+-a exit,always -F arch=b32 -S fchownat -F auid>=500 -F auid!=4294967295 -k my_chown
 
--a always,exit -F arch=b64 -S chmod -F auid>=500 -F auid!=4294967295 -k my_chmod
--a always,exit -F arch=b32 -S chmod -F auid>=500 -F auid!=4294967295 -k my_chmod
+-a exit,always -F arch=b64 -S chmod -F auid>=500 -F auid!=4294967295 -k my_chmod
+-a exit,always -F arch=b32 -S chmod -F auid>=500 -F auid!=4294967295 -k my_chmod
 
--a always,exit -F arch=b64 -S fchmod -F auid>=500 -F auid!=4294967295 -k my_chmod
--a always,exit -F arch=b32 -S fchmod -F auid>=500 -F auid!=4294967295 -k my_chmod
+-a exit,always -F arch=b64 -S fchmod -F auid>=500 -F auid!=4294967295 -k my_chmod
+-a exit,always -F arch=b32 -S fchmod -F auid>=500 -F auid!=4294967295 -k my_chmod
 
--a always,exit -F arch=b64 -S fchmodat -F auid>=500 -F auid!=4294967295 -k my_chmod
--a always,exit -F arch=b32 -S fchmodat -F auid>=500 -F auid!=4294967295 -k my_chmod
+-a exit,always -F arch=b64 -S fchmodat -F auid>=500 -F auid!=4294967295 -k my_chmod
+-a exit,always -F arch=b32 -S fchmodat -F auid>=500 -F auid!=4294967295 -k my_chmod
 
--a always,exit -F arch=b64 -S setxattr -F auid>=500 -F auid!=4294967295 -k my_attr
--a always,exit -F arch=b32 -S setxattr -F auid>=500 -F auid!=4294967295 -k my_attr
+-a exit,always -F arch=b64 -S setxattr -F auid>=500 -F auid!=4294967295 -k my_attr
+-a exit,always -F arch=b32 -S setxattr -F auid>=500 -F auid!=4294967295 -k my_attr
 
--a always,exit -F arch=b64 -S fsetxattr -F auid>=500 -F auid!=4294967295 -k my_attr
--a always,exit -F arch=b32 -S fsetxattr -F auid>=500 -F auid!=4294967295 -k my_attr
+-a exit,always -F arch=b64 -S fsetxattr -F auid>=500 -F auid!=4294967295 -k my_attr
+-a exit,always -F arch=b32 -S fsetxattr -F auid>=500 -F auid!=4294967295 -k my_attr
 
--a always,exit -F arch=b64 -S lsetxattr -F auid>=500 -F auid!=4294967295 -k my_attr
--a always,exit -F arch=b32 -S lsetxattr -F auid>=500 -F auid!=4294967295 -k my_attr
+-a exit,always -F arch=b64 -S lsetxattr -F auid>=500 -F auid!=4294967295 -k my_attr
+-a exit,always -F arch=b32 -S lsetxattr -F auid>=500 -F auid!=4294967295 -k my_attr
 
--a always,exit -F arch=b64 -S removexattr -F auid>=500 -F auid!=4294967295 -k my_attr
--a always,exit -F arch=b32 -S removexattr -F auid>=500 -F auid!=4294967295 -k my_attr
+-a exit,always -F arch=b64 -S removexattr -F auid>=500 -F auid!=4294967295 -k my_attr
+-a exit,always -F arch=b32 -S removexattr -F auid>=500 -F auid!=4294967295 -k my_attr
 
--a always,exit -F arch=b64 -S fremovexattr -F auid>=500 -F auid!=4294967295 -k my_attr
--a always,exit -F arch=b32 -S fremovexattr -F auid>=500 -F auid!=4294967295 -k my_attr
+-a exit,always -F arch=b64 -S fremovexattr -F auid>=500 -F auid!=4294967295 -k my_attr
+-a exit,always -F arch=b32 -S fremovexattr -F auid>=500 -F auid!=4294967295 -k my_attr
 
--a always,exit -F arch=b64 -S lremovexattr -F auid>=500 -F auid!=4294967295 -k my_attr
--a always,exit -F arch=b32 -S lremovexattr -F auid>=500 -F auid!=4294967295 -k my_attr
+-a exit,always -F arch=b64 -S lremovexattr -F auid>=500 -F auid!=4294967295 -k my_attr
+-a exit,always -F arch=b32 -S lremovexattr -F auid>=500 -F auid!=4294967295 -k my_attr
 
 ## Audit rename/removal operations
--a always,exit -F arch=b64 -S rename -F perm=x -F auid>=500 -F auid!=4294967295 -k my_rename_remove
--a always,exit -F arch=b32 -S rename -F perm=x -F auid>=500 -F auid!=4294967295 -k my_rename_remove
+-a exit,always -F arch=b64 -S rename -F perm=x -F auid>=500 -F auid!=4294967295 -k my_rename_remove
+-a exit,always -F arch=b32 -S rename -F perm=x -F auid>=500 -F auid!=4294967295 -k my_rename_remove
 
--a always,exit -F arch=b64 -S renameat -F perm=x -F auid>=500 -F auid!=4294967295 -k my_rename_remove
--a always,exit -F arch=b32 -S renameat -F perm=x -F auid>=500 -F auid!=4294967295 -k my_rename_remove
+-a exit,always -F arch=b64 -S renameat -F perm=x -F auid>=500 -F auid!=4294967295 -k my_rename_remove
+-a exit,always -F arch=b32 -S renameat -F perm=x -F auid>=500 -F auid!=4294967295 -k my_rename_remove
 
--a always,exit -F arch=b64 -S rmdir -F perm=x -F auid>=500 -F auid!=4294967295 -k my_rename_remove
--a always,exit -F arch=b32 -S rmdir -F perm=x -F auid>=500 -F auid!=4294967295 -k my_rename_remove
+-a exit,always -F arch=b64 -S rmdir -F perm=x -F auid>=500 -F auid!=4294967295 -k my_rename_remove
+-a exit,always -F arch=b32 -S rmdir -F perm=x -F auid>=500 -F auid!=4294967295 -k my_rename_remove
 
--a always,exit -F arch=b64 -S unlink -F perm=x -F auid>=500 -F auid!=4294967295 -k my_rename_remove
--a always,exit -F arch=b32 -S unlink -F perm=x -F auid>=500 -F auid!=4294967295 -k my_rename_remove
+-a exit,always -F arch=b64 -S unlink -F perm=x -F auid>=500 -F auid!=4294967295 -k my_rename_remove
+-a exit,always -F arch=b32 -S unlink -F perm=x -F auid>=500 -F auid!=4294967295 -k my_rename_remove
 
--a always,exit -F arch=b64 -S unlinkat -F perm=x -F auid>=500 -F auid!=4294967295 -k my_rename_remove
--a always,exit -F arch=b32 -S unlinkat -F perm=x -F auid>=500 -F auid!=4294967295 -k my_rename_remove
+-a exit,always -F arch=b64 -S unlinkat -F perm=x -F auid>=500 -F auid!=4294967295 -k my_rename_remove
+-a exit,always -F arch=b32 -S unlinkat -F perm=x -F auid>=500 -F auid!=4294967295 -k my_rename_remove
 
 ## Audit the execution of suid and sgid binaries.
--a always,exit -F path=/bin/cgclassify -F perm=x -F auid>=500 -F auid!=4294967295 -k my_suid_sgid
--a always,exit -F path=/bin/cgexec -F perm=x -F auid>=500 -F auid!=4294967295 -k my_suid_sgid
--a always,exit -F path=/bin/ping -F perm=x -F auid>=500 -F auid!=4294967295 -k my_suid_sgid
--a always,exit -F path=/bin/ping6 -F perm=x -F auid>=500 -F auid!=4294967295 -k my_suid_sgid
--a always,exit -F path=/sbin/mount.nfs -F perm=x -F auid>=500 -F auid!=4294967295 -k my_suid_sgid
--a always,exit -F path=/sbin/netreport -F perm=x -F auid>=500 -F auid!=4294967295 -k my_suid_sgid
--a always,exit -F path=/usr/bin/at -F perm=x -F auid>=500 -F auid!=4294967295 -k my_suid_sgid
--a always,exit -F path=/usr/bin/chage -F perm=x -F auid>=500 -F auid!=4294967295 -k my_suid_sgid
--a always,exit -F path=/usr/bin/chcon -F perm=x -F auid>=500 -F auid!=4294967295 -k my_suid_sgid
--a always,exit -F path=/usr/bin/chfn -F perm=x -F auid>=500 -F auid!=4294967295 -k my_suid_sgid
--a always,exit -F path=/usr/bin/chsh -F perm=x -F auid>=500 -F auid!=4294967295 -k my_suid_sgid
--a always,exit -F path=/usr/bin/crontab -F perm=x -F auid>=500 -F auid!=4294967295 -k my_suid_sgid
--a always,exit -F path=/usr/bin/fusermount -F perm=x -F auid>=500 -F auid!=4294967295 -k my_suid_sgid
--a always,exit -F path=/usr/bin/gpasswd -F perm=x -F auid>=500 -F auid!=4294967295 -k my_suid_sgid
--a always,exit -F path=/usr/bin/incrontab -F perm=x -F auid>=500 -F auid!=4294967295 -k my_suid_sgid
--a always,exit -F path=/usr/bin/ksu -F perm=x -F auid>=500 -F auid!=4294967295 -k my_suid_sgid
--a always,exit -F path=/usr/bin/locate -F perm=x -F auid>=500 -F auid!=4294967295 -k my_suid_sgid
--a always,exit -F path=/usr/bin/mount -F perm=x -F auid>=500 -F auid!=4294967295 -k my_suid_sgid
--a always,exit -F path=/usr/bin/newgidmap -F perm=x -F auid>=500 -F auid!=4294967295 -k my_suid_sgid
--a always,exit -F path=/usr/bin/newgrp -F perm=x -F auid>=500 -F auid!=4294967295 -k my_suid_sgid
--a always,exit -F path=/usr/bin/newuidmap -F perm=x -F auid>=500 -F auid!=4294967295 -k my_suid_sgid
--a always,exit -F path=/usr/bin/passwd -F perm=x -F auid>=500 -F auid!=4294967295 -k my_suid_sgid
--a always,exit -F path=/usr/bin/pkexec -F perm=x -F auid>=500 -F auid!=4294967295 -k my_suid_sgid
--a always,exit -F path=/usr/bin/screen -F perm=x -F auid>=500 -F auid!=4294967295 -k my_suid_sgid
--a always,exit -F path=/usr/bin/ssh-agent -F perm=x -F auid>=500 -F auid!=4294967295 -k my_suid_sgid
--a always,exit -F path=/usr/bin/su -F perm=x -F auid>=500 -F auid!=4294967295 -k my_suid_sgid
--a always,exit -F path=/usr/bin/sudo -F perm=x -F auid>=500 -F auid!=4294967295 -k my_suid_sgid
--a always,exit -F path=/usr/bin/sudoedit -F perm=x -F auid>=500 -F auid!=4294967295 -k my_suid_sgid
--a always,exit -F path=/usr/bin/umount -F perm=x -F auid>=500 -F auid!=4294967295 -k my_suid_sgid
--a always,exit -F path=/usr/bin/wall -F perm=x -F auid>=500 -F auid!=4294967295 -k my_suid_sgid
--a always,exit -F path=/usr/bin/write -F perm=x -F auid>=500 -F auid!=4294967295 -k my_suid_sgid
--a always,exit -F path=/usr/bin/Xorg -F perm=x -F auid>=500 -F auid!=4294967295 -k my_suid_sgid
--a always,exit -F path=/usr/libexec/dbus-1/dbus-daemon-launch-helper -F perm=x -F auid>=500 -F auid!=4294967295 -k my_suid_sgid
--a always,exit -F path=/usr/libexec/openssh/ssh-keysign -F perm=x -F auid>=500 -F auid!=4294967295 -k my_suid_sgid
--a always,exit -F path=/usr/libexec/polkit-1/polkit-agent-helper-1 -F perm=x -F auid>=500 -F auid!=4294967295 -k my_suid_sgid
--a always,exit -F path=/usr/libexec/pt_chown -F perm=x -F auid>=500 -F auid!=4294967295 -k my_suid_sgid
--a always,exit -F path=/usr/libexec/utempter/utempter -F perm=x -F auid>=500 -F auid!=4294967295 -k my_suid_sgid
--a always,exit -F path=/usr/sbin/pam_timestamp_check -F perm=x -F auid>=500 -F auid!=4294967295 -k my_suid_sgid
--a always,exit -F path=/usr/sbin/postdrop -F perm=x -F auid>=500 -F auid!=4294967295 -k my_suid_sgid
--a always,exit -F path=/usr/sbin/postqueue -F perm=x -F auid>=500 -F auid!=4294967295 -k my_suid_sgid
--a always,exit -F path=/usr/sbin/restorecon -F perm=x -F auid>=500 -F auid!=4294967295 -k my_suid_sgid
--a always,exit -F path=/usr/sbin/semanage -F perm=x -F auid>=500 -F auid!=4294967295 -k my_suid_sgid
--a always,exit -F path=/usr/sbin/setfiles -F perm=x -F auid>=500 -F auid!=4294967295 -k my_suid_sgid
--a always,exit -F path=/usr/sbin/setsebool -F perm=x -F auid>=500 -F auid!=4294967295 -k my_suid_sgid
--a always,exit -F path=/usr/sbin/seunshare -F perm=x -F auid>=500 -F auid!=4294967295 -k my_suid_sgid
--a always,exit -F path=/usr/sbin/suexec -F perm=x -F auid>=500 -F auid!=4294967295 -k my_suid_sgid
--a always,exit -F path=/usr/sbin/unix_chkpwd -F perm=x -F auid>=500 -F auid!=4294967295 -k my_suid_sgid
--a always,exit -F path=/usr/sbin/userhelper -F perm=x -F auid>=500 -F auid!=4294967295 -k my_suid_sgid
--a always,exit -F path=/usr/sbin/usernetctl -F perm=x -F auid>=500 -F auid!=4294967295 -k my_suid_sgid
+-a exit,always -F path=/bin/cgclassify -F perm=x -F auid>=500 -F auid!=4294967295 -k my_suid_sgid
+-a exit,always -F path=/bin/cgexec -F perm=x -F auid>=500 -F auid!=4294967295 -k my_suid_sgid
+-a exit,always -F path=/bin/ping -F perm=x -F auid>=500 -F auid!=4294967295 -k my_suid_sgid
+-a exit,always -F path=/bin/ping6 -F perm=x -F auid>=500 -F auid!=4294967295 -k my_suid_sgid
+-a exit,always -F path=/sbin/mount.nfs -F perm=x -F auid>=500 -F auid!=4294967295 -k my_suid_sgid
+-a exit,always -F path=/sbin/netreport -F perm=x -F auid>=500 -F auid!=4294967295 -k my_suid_sgid
+-a exit,always -F path=/usr/bin/at -F perm=x -F auid>=500 -F auid!=4294967295 -k my_suid_sgid
+-a exit,always -F path=/usr/bin/chage -F perm=x -F auid>=500 -F auid!=4294967295 -k my_suid_sgid
+-a exit,always -F path=/usr/bin/chcon -F perm=x -F auid>=500 -F auid!=4294967295 -k my_suid_sgid
+-a exit,always -F path=/usr/bin/chfn -F perm=x -F auid>=500 -F auid!=4294967295 -k my_suid_sgid
+-a exit,always -F path=/usr/bin/chsh -F perm=x -F auid>=500 -F auid!=4294967295 -k my_suid_sgid
+-a exit,always -F path=/usr/bin/crontab -F perm=x -F auid>=500 -F auid!=4294967295 -k my_suid_sgid
+-a exit,always -F path=/usr/bin/fusermount -F perm=x -F auid>=500 -F auid!=4294967295 -k my_suid_sgid
+-a exit,always -F path=/usr/bin/gpasswd -F perm=x -F auid>=500 -F auid!=4294967295 -k my_suid_sgid
+-a exit,always -F path=/usr/bin/incrontab -F perm=x -F auid>=500 -F auid!=4294967295 -k my_suid_sgid
+-a exit,always -F path=/usr/bin/ksu -F perm=x -F auid>=500 -F auid!=4294967295 -k my_suid_sgid
+-a exit,always -F path=/usr/bin/locate -F perm=x -F auid>=500 -F auid!=4294967295 -k my_suid_sgid
+-a exit,always -F path=/usr/bin/mount -F perm=x -F auid>=500 -F auid!=4294967295 -k my_suid_sgid
+-a exit,always -F path=/usr/bin/newgidmap -F perm=x -F auid>=500 -F auid!=4294967295 -k my_suid_sgid
+-a exit,always -F path=/usr/bin/newgrp -F perm=x -F auid>=500 -F auid!=4294967295 -k my_suid_sgid
+-a exit,always -F path=/usr/bin/newuidmap -F perm=x -F auid>=500 -F auid!=4294967295 -k my_suid_sgid
+-a exit,always -F path=/usr/bin/passwd -F perm=x -F auid>=500 -F auid!=4294967295 -k my_suid_sgid
+-a exit,always -F path=/usr/bin/pkexec -F perm=x -F auid>=500 -F auid!=4294967295 -k my_suid_sgid
+-a exit,always -F path=/usr/bin/screen -F perm=x -F auid>=500 -F auid!=4294967295 -k my_suid_sgid
+-a exit,always -F path=/usr/bin/ssh-agent -F perm=x -F auid>=500 -F auid!=4294967295 -k my_suid_sgid
+-a exit,always -F path=/usr/bin/su -F perm=x -F auid>=500 -F auid!=4294967295 -k my_suid_sgid
+-a exit,always -F path=/usr/bin/sudo -F perm=x -F auid>=500 -F auid!=4294967295 -k my_suid_sgid
+-a exit,always -F path=/usr/bin/sudoedit -F perm=x -F auid>=500 -F auid!=4294967295 -k my_suid_sgid
+-a exit,always -F path=/usr/bin/umount -F perm=x -F auid>=500 -F auid!=4294967295 -k my_suid_sgid
+-a exit,always -F path=/usr/bin/wall -F perm=x -F auid>=500 -F auid!=4294967295 -k my_suid_sgid
+-a exit,always -F path=/usr/bin/write -F perm=x -F auid>=500 -F auid!=4294967295 -k my_suid_sgid
+-a exit,always -F path=/usr/bin/Xorg -F perm=x -F auid>=500 -F auid!=4294967295 -k my_suid_sgid
+-a exit,always -F path=/usr/libexec/dbus-1/dbus-daemon-launch-helper -F perm=x -F auid>=500 -F auid!=4294967295 -k my_suid_sgid
+-a exit,always -F path=/usr/libexec/openssh/ssh-keysign -F perm=x -F auid>=500 -F auid!=4294967295 -k my_suid_sgid
+-a exit,always -F path=/usr/libexec/polkit-1/polkit-agent-helper-1 -F perm=x -F auid>=500 -F auid!=4294967295 -k my_suid_sgid
+-a exit,always -F path=/usr/libexec/pt_chown -F perm=x -F auid>=500 -F auid!=4294967295 -k my_suid_sgid
+-a exit,always -F path=/usr/libexec/utempter/utempter -F perm=x -F auid>=500 -F auid!=4294967295 -k my_suid_sgid
+-a exit,always -F path=/usr/sbin/pam_timestamp_check -F perm=x -F auid>=500 -F auid!=4294967295 -k my_suid_sgid
+-a exit,always -F path=/usr/sbin/postdrop -F perm=x -F auid>=500 -F auid!=4294967295 -k my_suid_sgid
+-a exit,always -F path=/usr/sbin/postqueue -F perm=x -F auid>=500 -F auid!=4294967295 -k my_suid_sgid
+-a exit,always -F path=/usr/sbin/restorecon -F perm=x -F auid>=500 -F auid!=4294967295 -k my_suid_sgid
+-a exit,always -F path=/usr/sbin/semanage -F perm=x -F auid>=500 -F auid!=4294967295 -k my_suid_sgid
+-a exit,always -F path=/usr/sbin/setfiles -F perm=x -F auid>=500 -F auid!=4294967295 -k my_suid_sgid
+-a exit,always -F path=/usr/sbin/setsebool -F perm=x -F auid>=500 -F auid!=4294967295 -k my_suid_sgid
+-a exit,always -F path=/usr/sbin/seunshare -F perm=x -F auid>=500 -F auid!=4294967295 -k my_suid_sgid
+-a exit,always -F path=/usr/sbin/suexec -F perm=x -F auid>=500 -F auid!=4294967295 -k my_suid_sgid
+-a exit,always -F path=/usr/sbin/unix_chkpwd -F perm=x -F auid>=500 -F auid!=4294967295 -k my_suid_sgid
+-a exit,always -F path=/usr/sbin/userhelper -F perm=x -F auid>=500 -F auid!=4294967295 -k my_suid_sgid
+-a exit,always -F path=/usr/sbin/usernetctl -F perm=x -F auid>=500 -F auid!=4294967295 -k my_suid_sgid
 
 ## Audit the loading and unloading of kernel modules.
 -w /sbin/insmod -p x -F auid!=4294967295 -k my_kernel_modules
@@ -192,25 +192,25 @@
 
 -w /sbin/modprobe -p x -F auid!=4294967295 -k my_kernel_modules
 
--a always,exit -F arch=b64 -S create_module -k my_kernel_modules
--a always,exit -F arch=b32 -S create_module -k my_kernel_modules
+-a exit,always -F arch=b64 -S create_module -k my_kernel_modules
+-a exit,always -F arch=b32 -S create_module -k my_kernel_modules
 
--a always,exit -F arch=b64 -S init_module -k my_kernel_modules
--a always,exit -F arch=b32 -S init_module -k my_kernel_modules
+-a exit,always -F arch=b64 -S init_module -k my_kernel_modules
+-a exit,always -F arch=b32 -S init_module -k my_kernel_modules
 
--a always,exit -F arch=b64 -S finit_module -k my_kernel_modules
--a always,exit -F arch=b32 -S finit_module -k my_kernel_modules
+-a exit,always -F arch=b64 -S finit_module -k my_kernel_modules
+-a exit,always -F arch=b32 -S finit_module -k my_kernel_modules
 
--a always,exit -F arch=b64 -S delete_module -k my_kernel_modules
--a always,exit -F arch=b32 -S delete_module -k my_kernel_modules
+-a exit,always -F arch=b64 -S delete_module -k my_kernel_modules
+-a exit,always -F arch=b32 -S delete_module -k my_kernel_modules
 
 ## Audit mount operations
--a always,exit -F arch=b64 -S mount -F auid>=500 -F auid!=4294967295 -k my_mount
--a always,exit -F arch=b64 -F path=/bin/mount -F auid>=500 -F auid!=4294967295 -k my_mount
--a always,exit -F arch=b32 -S mount -F auid>=500 -F auid!=4294967295 -k my_mount
--a always,exit -F arch=b32 -F path=/bin/mount -F auid>=500 -F auid!=4294967295 -k my_mount
+-a exit,always -F arch=b64 -S mount -F auid>=500 -F auid!=4294967295 -k my_mount
+-a exit,always -F arch=b64 -F path=/bin/mount -F auid>=500 -F auid!=4294967295 -k my_mount
+-a exit,always -F arch=b32 -S mount -F auid>=500 -F auid!=4294967295 -k my_mount
+-a exit,always -F arch=b32 -F path=/bin/mount -F auid>=500 -F auid!=4294967295 -k my_mount
 
--a always,exit -F path=/bin/umount -F perm=x -F auid>=500 -F auid!=4294967295 -k my_mount
+-a exit,always -F path=/bin/umount -F perm=x -F auid>=500 -F auid!=4294967295 -k my_mount
 
 ## Audit local accounts
 -w /etc/passwd -p wa -k my_local_account

--- a/spec/classes/config/audit_profiles/expected/stig_el6_base_rules.txt
+++ b/spec/classes/config/audit_profiles/expected/stig_el6_base_rules.txt
@@ -1,185 +1,140 @@
 #### auditd::config::audit_profiles::stig Audit Rules ####
 
 ## Audit unsuccessful file operations
-# RHEL-07-030500
 -a always,exit -F arch=b64 -S creat -F exit=-EPERM -F auid>=500 -F auid!=4294967295 -k access
 -a always,exit -F arch=b64 -S creat -F exit=-EACCES -F auid>=500 -F auid!=4294967295 -k access
 -a always,exit -F arch=b32 -S creat -F exit=-EPERM -F auid>=500 -F auid!=4294967295 -k access
 -a always,exit -F arch=b32 -S creat -F exit=-EACCES -F auid>=500 -F auid!=4294967295 -k access
 
-# RHEL-07-030510
 -a always,exit -F arch=b64 -S open -F exit=-EPERM -F auid>=500 -F auid!=4294967295 -k access
 -a always,exit -F arch=b64 -S open -F exit=-EACCES -F auid>=500 -F auid!=4294967295 -k access
 -a always,exit -F arch=b32 -S open -F exit=-EPERM -F auid>=500 -F auid!=4294967295 -k access
 -a always,exit -F arch=b32 -S open -F exit=-EACCES -F auid>=500 -F auid!=4294967295 -k access
 
-# RHEL-07-030520
 -a always,exit -F arch=b64 -S openat -F exit=-EPERM -F auid>=500 -F auid!=4294967295 -k access
 -a always,exit -F arch=b64 -S openat -F exit=-EACCES -F auid>=500 -F auid!=4294967295 -k access
 -a always,exit -F arch=b32 -S openat -F exit=-EPERM -F auid>=500 -F auid!=4294967295 -k access
 -a always,exit -F arch=b32 -S openat -F exit=-EACCES -F auid>=500 -F auid!=4294967295 -k access
 
-# RHEL-07-030530
 -a always,exit -F arch=b64 -S open_by_handle_at -F exit=-EPERM -F auid>=500 -F auid!=4294967295 -k access
 -a always,exit -F arch=b64 -S open_by_handle_at -F exit=-EACCES -F auid>=500 -F auid!=4294967295 -k access
 -a always,exit -F arch=b32 -S open_by_handle_at -F exit=-EPERM -F auid>=500 -F auid!=4294967295 -k access
 -a always,exit -F arch=b32 -S open_by_handle_at -F exit=-EACCES -F auid>=500 -F auid!=4294967295 -k access
 
-# RHEL-07-030540
 -a always,exit -F arch=b64 -S truncate -F exit=-EPERM -F auid>=500 -F auid!=4294967295 -k access
 -a always,exit -F arch=b64 -S truncate -F exit=-EACCES -F auid>=500 -F auid!=4294967295 -k access
 -a always,exit -F arch=b32 -S truncate -F exit=-EPERM -F auid>=500 -F auid!=4294967295 -k access
 -a always,exit -F arch=b32 -S truncate -F exit=-EACCES -F auid>=500 -F auid!=4294967295 -k access
 
-# RHEL-07-030550
 -a always,exit -F arch=b64 -S ftruncate -F exit=-EPERM -F auid>=500 -F auid!=4294967295 -k access
 -a always,exit -F arch=b64 -S ftruncate -F exit=-EACCES -F auid>=500 -F auid!=4294967295 -k access
 -a always,exit -F arch=b32 -S ftruncate -F exit=-EPERM -F auid>=500 -F auid!=4294967295 -k access
 -a always,exit -F arch=b32 -S ftruncate -F exit=-EACCES -F auid>=500 -F auid!=4294967295 -k access
 
 ## Audit the execution of password commands
-# RHEL-07-030630
 -a always,exit -F path=/usr/bin/passwd -F perm=x -F auid>=500 -F auid!=4294967295 -k privileged-passwd
 
-# RHEL-07-030640
 -a always,exit -F path=/sbin/unix_chkpwd -F perm=x -F auid>=500 -F auid!=4294967295 -k privileged-passwd
 
-# RHEL-07-030650
 -a always,exit -F path=/usr/bin/gpasswd -F perm=x -F auid>=500 -F auid!=4294967295 -k privileged-passwd
 
-# RHEL-07-030660
 -a always,exit -F path=/usr/bin/chage -F perm=x -F auid>=500 -F auid!=4294967295 -k privileged-passwd
 
-# RHEL-07-030670
 -a always,exit -F path=/usr/sbin/userhelper -F perm=x -F auid>=500 -F auid!=4294967295 -k privileged-passwd
 
 ## Audit the execution of privilege-related commands
-# RHEL-07-030680
 -a always,exit -F path=/bin/su -F perm=x -F auid>=500 -F auid!=4294967295 -k privileged-priv_change
 
-# RHEL-07-030690
 -a always,exit -F path=/usr/bin/sudo -F perm=x -F auid>=500 -F auid!=4294967295 -k privileged-priv_change
 
-# RHEL-07-030710
 -a always,exit -F path=/usr/bin/newgrp -F perm=x -F auid>=500 -F auid!=4294967295 -k privileged-priv_change
 
-# RHEL-07-030720
 -a always,exit -F path=/usr/bin/chsh -F perm=x -F auid>=500 -F auid!=4294967295 -k privileged-priv_change
 
-# RHEL-07-030730
 -a always,exit -F path=/usr/bin/sudoedit -F perm=x -F auid>=500 -F auid!=4294967295 -k privileged-priv_change
 
 ## Audit the execution of postfix-related commands
-# RHEL-07-030760
 -a always,exit -F path=/usr/sbin/postdrop -F perm=x -F auid>=500 -F auid!=4294967295 -k privileged-postfix
 
-# RHEL-07-030770
 -a always,exit -F path=/usr/sbin/postqueue -F perm=x -F auid>=500 -F auid!=4294967295 -k privileged-postfix
 
 ## Audit the execution of the ssh-keysign command
-# RHEL-07-030780
 -a always,exit -F path=/usr/libexec/openssh/ssh-keysign -F perm=x -F auid>=500 -F auid!=4294967295 -k privileged-ssh
 
 ## Audit the execution of the crontab command
-# RHEL-07-030800
 -a always,exit -F path=/usr/bin/crontab -F perm=x -F auid>=500 -F auid!=4294967295 -k privileged-cron
 
 ## Audit the execution of the pam_timestamp_check command
-# RHEL-07-030810
 -a always,exit -F path=/sbin/pam_timestamp_check -F perm=x -F auid>=500 -F auid!=4294967295 -k privileged-pam
 
 ## Audit selinux commands
-# RHEL-07-030560
 -a always,exit -F path=/usr/sbin/semanage -F perm=x -F auid>=500 -F auid!=4294967295 -k privileged-priv_change
 
-# RHEL-07-030570
 -a always,exit -F path=/usr/sbin/setsebool -F perm=x -F auid>=500 -F auid!=4294967295 -k privileged-priv_change
 
-# RHEL-07-030580
 -a always,exit -F path=/usr/bin/chcon -F perm=x -F auid>=500 -F auid!=4294967295 -k privileged-priv_change
 
-# RHEL-07-030590
 -a always,exit -F path=/sbin/setfiles -F perm=x -F auid>=500 -F auid!=4294967295 -k privileged-priv_change
 
-# RHEL-07-030590
 -a always,exit -F path=/sbin/restorecon -F perm=x -F auid>=500 -F auid!=4294967295 -k privileged-priv_change
 
 ## Permissions auditing separated by chown, chmod, and attr
-# RHEL-07-030370
 -a always,exit -F arch=b64 -S chown -F auid>=500 -F auid!=4294967295 -k perm_mod
 -a always,exit -F arch=b32 -S chown -F auid>=500 -F auid!=4294967295 -k perm_mod
 
-# RHEL-07-030380
 -a always,exit -F arch=b64 -S fchown -F auid>=500 -F auid!=4294967295 -k perm_mod
 -a always,exit -F arch=b32 -S fchown -F auid>=500 -F auid!=4294967295 -k perm_mod
 
-# RHEL-07-030390
 -a always,exit -F arch=b64 -S lchown -F auid>=500 -F auid!=4294967295 -k perm_mod
 -a always,exit -F arch=b32 -S lchown -F auid>=500 -F auid!=4294967295 -k perm_mod
 
-# RHEL-07-030400
 -a always,exit -F arch=b64 -S fchownat -F auid>=500 -F auid!=4294967295 -k perm_mod
 -a always,exit -F arch=b32 -S fchownat -F auid>=500 -F auid!=4294967295 -k perm_mod
 
-# RHEL-07-030410
 -a always,exit -F arch=b64 -S chmod -F auid>=500 -F auid!=4294967295 -k perm_mod
 -a always,exit -F arch=b32 -S chmod -F auid>=500 -F auid!=4294967295 -k perm_mod
 
-# RHEL-07-030420
 -a always,exit -F arch=b64 -S fchmod -F auid>=500 -F auid!=4294967295 -k perm_mod
 -a always,exit -F arch=b32 -S fchmod -F auid>=500 -F auid!=4294967295 -k perm_mod
 
-# RHEL-07-030430
 -a always,exit -F arch=b64 -S fchmodat -F auid>=500 -F auid!=4294967295 -k perm_mod
 -a always,exit -F arch=b32 -S fchmodat -F auid>=500 -F auid!=4294967295 -k perm_mod
 
-# RHEL-07-030440
 -a always,exit -F arch=b64 -S setxattr -F auid>=500 -F auid!=4294967295 -k perm_mod
 -a always,exit -F arch=b32 -S setxattr -F auid>=500 -F auid!=4294967295 -k perm_mod
 
-# RHEL-07-030450
 -a always,exit -F arch=b64 -S fsetxattr -F auid>=500 -F auid!=4294967295 -k perm_mod
 -a always,exit -F arch=b32 -S fsetxattr -F auid>=500 -F auid!=4294967295 -k perm_mod
 
-# RHEL-07-030460
 -a always,exit -F arch=b64 -S lsetxattr -F auid>=500 -F auid!=4294967295 -k perm_mod
 -a always,exit -F arch=b32 -S lsetxattr -F auid>=500 -F auid!=4294967295 -k perm_mod
 
-# RHEL-07-030470
 -a always,exit -F arch=b64 -S removexattr -F auid>=500 -F auid!=4294967295 -k perm_mod
 -a always,exit -F arch=b32 -S removexattr -F auid>=500 -F auid!=4294967295 -k perm_mod
 
-# RHEL-07-030480
 -a always,exit -F arch=b64 -S fremovexattr -F auid>=500 -F auid!=4294967295 -k perm_mod
 -a always,exit -F arch=b32 -S fremovexattr -F auid>=500 -F auid!=4294967295 -k perm_mod
 
-# RHEL-07-030490
 -a always,exit -F arch=b64 -S lremovexattr -F auid>=500 -F auid!=4294967295 -k perm_mod
 -a always,exit -F arch=b32 -S lremovexattr -F auid>=500 -F auid!=4294967295 -k perm_mod
 
 ## Audit rename/removal operations
-# RHEL-07-030880
 -a always,exit -F arch=b64 -S rename -F perm=x -F auid>=500 -F auid!=4294967295 -k delete
 -a always,exit -F arch=b32 -S rename -F perm=x -F auid>=500 -F auid!=4294967295 -k delete
 
-# RHEL-07-030890
 -a always,exit -F arch=b64 -S renameat -F perm=x -F auid>=500 -F auid!=4294967295 -k delete
 -a always,exit -F arch=b32 -S renameat -F perm=x -F auid>=500 -F auid!=4294967295 -k delete
 
-# RHEL-07-030900
 -a always,exit -F arch=b64 -S rmdir -F perm=x -F auid>=500 -F auid!=4294967295 -k delete
 -a always,exit -F arch=b32 -S rmdir -F perm=x -F auid>=500 -F auid!=4294967295 -k delete
 
-# RHEL-07-030910
 -a always,exit -F arch=b64 -S unlink -F perm=x -F auid>=500 -F auid!=4294967295 -k delete
 -a always,exit -F arch=b32 -S unlink -F perm=x -F auid>=500 -F auid!=4294967295 -k delete
 
-# RHEL-07-030920
 -a always,exit -F arch=b64 -S unlinkat -F perm=x -F auid>=500 -F auid!=4294967295 -k delete
 -a always,exit -F arch=b32 -S unlinkat -F perm=x -F auid>=500 -F auid!=4294967295 -k delete
 
 ## Audit the execution of suid and sgid binaries.
-# RHEL-07-030360
 -a always,exit -F path=/bin/cgclassify -F perm=x -F auid>=500 -F auid!=4294967295 -k setuid/setgid
 -a always,exit -F path=/bin/cgexec -F perm=x -F auid>=500 -F auid!=4294967295 -k setuid/setgid
 -a always,exit -F path=/bin/ping -F perm=x -F auid>=500 -F auid!=4294967295 -k setuid/setgid
@@ -231,68 +186,50 @@
 -a always,exit -F path=/usr/sbin/usernetctl -F perm=x -F auid>=500 -F auid!=4294967295 -k setuid/setgid
 
 ## Audit the loading and unloading of kernel modules.
-# RHEL-07-030840
 -w /sbin/insmod -p x -F auid!=4294967295 -k module-change
 
-# RHEL-07-030850
 -w /sbin/rmmod -p x -F auid!=4294967295 -k module-change
 
-# RHEL-07-030860
 -w /sbin/modprobe -p x -F auid!=4294967295 -k module-change
 
-# RHEL-07-030819
 -a always,exit -F arch=b64 -S create_module -k module-change
 -a always,exit -F arch=b32 -S create_module -k module-change
 
-# RHEL-07-030820
 -a always,exit -F arch=b64 -S init_module -k module-change
 -a always,exit -F arch=b32 -S init_module -k module-change
 
-# RHEL-07-030821
 -a always,exit -F arch=b64 -S finit_module -k module-change
 -a always,exit -F arch=b32 -S finit_module -k module-change
 
-# RHEL-07-030830
 -a always,exit -F arch=b64 -S delete_module -k module-change
 -a always,exit -F arch=b32 -S delete_module -k module-change
 
 ## Audit mount operations
-# RHEL-07-030740
 -a always,exit -F arch=b64 -S mount -F auid>=500 -F auid!=4294967295 -k privileged-mount
 -a always,exit -F arch=b64 -F path=/bin/mount -F auid>=500 -F auid!=4294967295 -k privileged-mount
 -a always,exit -F arch=b32 -S mount -F auid>=500 -F auid!=4294967295 -k privileged-mount
 -a always,exit -F arch=b32 -F path=/bin/mount -F auid>=500 -F auid!=4294967295 -k privileged-mount
 
-# RHEL-07-030750
 -a always,exit -F path=/bin/umount -F perm=x -F auid>=500 -F auid!=4294967295 -k privileged-mount
 
 ## Audit local accounts
-# RHEL-07-030870
 -w /etc/passwd -p wa -k identity
 
-# RHEL-07-030871
 -w /etc/group -p wa -k identity
 
-# RHEL-07-030872
 -w /etc/gshadow -p wa -k identity
 
-# RHEL-07-030873
 -w /etc/shadow -p wa -k identity
 
-# RHEL-07-030874
 -w /etc/security/opasswd -p wa -k identity
 
 ## Audit login files
-# RHEL-07-030600
 -w /var/log/tallylog -p wa -k logins
 
-# RHEL-07-030610
 -w /var/run/faillock -p wa -k logins
 
-# RHEL-07-030620
 -w /var/log/lastlog -p wa -k logins
 
 ## Audit sudoers configuration files
-# RHEL-07-030700
 -w /etc/sudoers -p wa -k privileged-actions
 -w /etc/sudoers.d/ -p wa -k privileged-actions

--- a/spec/classes/config/audit_profiles/expected/stig_el6_base_rules.txt
+++ b/spec/classes/config/audit_profiles/expected/stig_el6_base_rules.txt
@@ -1,189 +1,189 @@
 #### auditd::config::audit_profiles::stig Audit Rules ####
 
 ## Audit unsuccessful file operations
--a always,exit -F arch=b64 -S creat -F exit=-EPERM -F auid>=500 -F auid!=4294967295 -k access
--a always,exit -F arch=b64 -S creat -F exit=-EACCES -F auid>=500 -F auid!=4294967295 -k access
--a always,exit -F arch=b32 -S creat -F exit=-EPERM -F auid>=500 -F auid!=4294967295 -k access
--a always,exit -F arch=b32 -S creat -F exit=-EACCES -F auid>=500 -F auid!=4294967295 -k access
+-a exit,always -F arch=b64 -S creat -F exit=-EPERM -F auid>=500 -F auid!=4294967295 -k access
+-a exit,always -F arch=b64 -S creat -F exit=-EACCES -F auid>=500 -F auid!=4294967295 -k access
+-a exit,always -F arch=b32 -S creat -F exit=-EPERM -F auid>=500 -F auid!=4294967295 -k access
+-a exit,always -F arch=b32 -S creat -F exit=-EACCES -F auid>=500 -F auid!=4294967295 -k access
 
--a always,exit -F arch=b64 -S open -F exit=-EPERM -F auid>=500 -F auid!=4294967295 -k access
--a always,exit -F arch=b64 -S open -F exit=-EACCES -F auid>=500 -F auid!=4294967295 -k access
--a always,exit -F arch=b32 -S open -F exit=-EPERM -F auid>=500 -F auid!=4294967295 -k access
--a always,exit -F arch=b32 -S open -F exit=-EACCES -F auid>=500 -F auid!=4294967295 -k access
+-a exit,always -F arch=b64 -S open -F exit=-EPERM -F auid>=500 -F auid!=4294967295 -k access
+-a exit,always -F arch=b64 -S open -F exit=-EACCES -F auid>=500 -F auid!=4294967295 -k access
+-a exit,always -F arch=b32 -S open -F exit=-EPERM -F auid>=500 -F auid!=4294967295 -k access
+-a exit,always -F arch=b32 -S open -F exit=-EACCES -F auid>=500 -F auid!=4294967295 -k access
 
--a always,exit -F arch=b64 -S openat -F exit=-EPERM -F auid>=500 -F auid!=4294967295 -k access
--a always,exit -F arch=b64 -S openat -F exit=-EACCES -F auid>=500 -F auid!=4294967295 -k access
--a always,exit -F arch=b32 -S openat -F exit=-EPERM -F auid>=500 -F auid!=4294967295 -k access
--a always,exit -F arch=b32 -S openat -F exit=-EACCES -F auid>=500 -F auid!=4294967295 -k access
+-a exit,always -F arch=b64 -S openat -F exit=-EPERM -F auid>=500 -F auid!=4294967295 -k access
+-a exit,always -F arch=b64 -S openat -F exit=-EACCES -F auid>=500 -F auid!=4294967295 -k access
+-a exit,always -F arch=b32 -S openat -F exit=-EPERM -F auid>=500 -F auid!=4294967295 -k access
+-a exit,always -F arch=b32 -S openat -F exit=-EACCES -F auid>=500 -F auid!=4294967295 -k access
 
--a always,exit -F arch=b64 -S open_by_handle_at -F exit=-EPERM -F auid>=500 -F auid!=4294967295 -k access
--a always,exit -F arch=b64 -S open_by_handle_at -F exit=-EACCES -F auid>=500 -F auid!=4294967295 -k access
--a always,exit -F arch=b32 -S open_by_handle_at -F exit=-EPERM -F auid>=500 -F auid!=4294967295 -k access
--a always,exit -F arch=b32 -S open_by_handle_at -F exit=-EACCES -F auid>=500 -F auid!=4294967295 -k access
+-a exit,always -F arch=b64 -S open_by_handle_at -F exit=-EPERM -F auid>=500 -F auid!=4294967295 -k access
+-a exit,always -F arch=b64 -S open_by_handle_at -F exit=-EACCES -F auid>=500 -F auid!=4294967295 -k access
+-a exit,always -F arch=b32 -S open_by_handle_at -F exit=-EPERM -F auid>=500 -F auid!=4294967295 -k access
+-a exit,always -F arch=b32 -S open_by_handle_at -F exit=-EACCES -F auid>=500 -F auid!=4294967295 -k access
 
--a always,exit -F arch=b64 -S truncate -F exit=-EPERM -F auid>=500 -F auid!=4294967295 -k access
--a always,exit -F arch=b64 -S truncate -F exit=-EACCES -F auid>=500 -F auid!=4294967295 -k access
--a always,exit -F arch=b32 -S truncate -F exit=-EPERM -F auid>=500 -F auid!=4294967295 -k access
--a always,exit -F arch=b32 -S truncate -F exit=-EACCES -F auid>=500 -F auid!=4294967295 -k access
+-a exit,always -F arch=b64 -S truncate -F exit=-EPERM -F auid>=500 -F auid!=4294967295 -k access
+-a exit,always -F arch=b64 -S truncate -F exit=-EACCES -F auid>=500 -F auid!=4294967295 -k access
+-a exit,always -F arch=b32 -S truncate -F exit=-EPERM -F auid>=500 -F auid!=4294967295 -k access
+-a exit,always -F arch=b32 -S truncate -F exit=-EACCES -F auid>=500 -F auid!=4294967295 -k access
 
--a always,exit -F arch=b64 -S ftruncate -F exit=-EPERM -F auid>=500 -F auid!=4294967295 -k access
--a always,exit -F arch=b64 -S ftruncate -F exit=-EACCES -F auid>=500 -F auid!=4294967295 -k access
--a always,exit -F arch=b32 -S ftruncate -F exit=-EPERM -F auid>=500 -F auid!=4294967295 -k access
--a always,exit -F arch=b32 -S ftruncate -F exit=-EACCES -F auid>=500 -F auid!=4294967295 -k access
+-a exit,always -F arch=b64 -S ftruncate -F exit=-EPERM -F auid>=500 -F auid!=4294967295 -k access
+-a exit,always -F arch=b64 -S ftruncate -F exit=-EACCES -F auid>=500 -F auid!=4294967295 -k access
+-a exit,always -F arch=b32 -S ftruncate -F exit=-EPERM -F auid>=500 -F auid!=4294967295 -k access
+-a exit,always -F arch=b32 -S ftruncate -F exit=-EACCES -F auid>=500 -F auid!=4294967295 -k access
 
 ## Audit the execution of password commands
--a always,exit -F path=/usr/bin/passwd -F perm=x -F auid>=500 -F auid!=4294967295 -k privileged-passwd
+-a exit,always -F path=/usr/bin/passwd -F perm=x -F auid>=500 -F auid!=4294967295 -k privileged-passwd
 
--a always,exit -F path=/sbin/unix_chkpwd -F perm=x -F auid>=500 -F auid!=4294967295 -k privileged-passwd
+-a exit,always -F path=/sbin/unix_chkpwd -F perm=x -F auid>=500 -F auid!=4294967295 -k privileged-passwd
 
--a always,exit -F path=/usr/bin/gpasswd -F perm=x -F auid>=500 -F auid!=4294967295 -k privileged-passwd
+-a exit,always -F path=/usr/bin/gpasswd -F perm=x -F auid>=500 -F auid!=4294967295 -k privileged-passwd
 
--a always,exit -F path=/usr/bin/chage -F perm=x -F auid>=500 -F auid!=4294967295 -k privileged-passwd
+-a exit,always -F path=/usr/bin/chage -F perm=x -F auid>=500 -F auid!=4294967295 -k privileged-passwd
 
--a always,exit -F path=/usr/sbin/userhelper -F perm=x -F auid>=500 -F auid!=4294967295 -k privileged-passwd
+-a exit,always -F path=/usr/sbin/userhelper -F perm=x -F auid>=500 -F auid!=4294967295 -k privileged-passwd
 
 ## Audit the execution of privilege-related commands
--a always,exit -F path=/bin/su -F perm=x -F auid>=500 -F auid!=4294967295 -k privileged-priv_change
+-a exit,always -F path=/bin/su -F perm=x -F auid>=500 -F auid!=4294967295 -k privileged-priv_change
 
--a always,exit -F path=/usr/bin/sudo -F perm=x -F auid>=500 -F auid!=4294967295 -k privileged-priv_change
+-a exit,always -F path=/usr/bin/sudo -F perm=x -F auid>=500 -F auid!=4294967295 -k privileged-priv_change
 
--a always,exit -F path=/usr/bin/newgrp -F perm=x -F auid>=500 -F auid!=4294967295 -k privileged-priv_change
+-a exit,always -F path=/usr/bin/newgrp -F perm=x -F auid>=500 -F auid!=4294967295 -k privileged-priv_change
 
--a always,exit -F path=/usr/bin/chsh -F perm=x -F auid>=500 -F auid!=4294967295 -k privileged-priv_change
+-a exit,always -F path=/usr/bin/chsh -F perm=x -F auid>=500 -F auid!=4294967295 -k privileged-priv_change
 
--a always,exit -F path=/usr/bin/sudoedit -F perm=x -F auid>=500 -F auid!=4294967295 -k privileged-priv_change
+-a exit,always -F path=/usr/bin/sudoedit -F perm=x -F auid>=500 -F auid!=4294967295 -k privileged-priv_change
 
 ## Audit the execution of postfix-related commands
--a always,exit -F path=/usr/sbin/postdrop -F perm=x -F auid>=500 -F auid!=4294967295 -k privileged-postfix
+-a exit,always -F path=/usr/sbin/postdrop -F perm=x -F auid>=500 -F auid!=4294967295 -k privileged-postfix
 
--a always,exit -F path=/usr/sbin/postqueue -F perm=x -F auid>=500 -F auid!=4294967295 -k privileged-postfix
+-a exit,always -F path=/usr/sbin/postqueue -F perm=x -F auid>=500 -F auid!=4294967295 -k privileged-postfix
 
 ## Audit the execution of the ssh-keysign command
--a always,exit -F path=/usr/libexec/openssh/ssh-keysign -F perm=x -F auid>=500 -F auid!=4294967295 -k privileged-ssh
+-a exit,always -F path=/usr/libexec/openssh/ssh-keysign -F perm=x -F auid>=500 -F auid!=4294967295 -k privileged-ssh
 
 ## Audit the execution of the crontab command
--a always,exit -F path=/usr/bin/crontab -F perm=x -F auid>=500 -F auid!=4294967295 -k privileged-cron
+-a exit,always -F path=/usr/bin/crontab -F perm=x -F auid>=500 -F auid!=4294967295 -k privileged-cron
 
 ## Audit the execution of the pam_timestamp_check command
--a always,exit -F path=/sbin/pam_timestamp_check -F perm=x -F auid>=500 -F auid!=4294967295 -k privileged-pam
+-a exit,always -F path=/sbin/pam_timestamp_check -F perm=x -F auid>=500 -F auid!=4294967295 -k privileged-pam
 
 ## Audit selinux commands
--a always,exit -F path=/usr/sbin/semanage -F perm=x -F auid>=500 -F auid!=4294967295 -k privileged-priv_change
+-a exit,always -F path=/usr/sbin/semanage -F perm=x -F auid>=500 -F auid!=4294967295 -k privileged-priv_change
 
--a always,exit -F path=/usr/sbin/setsebool -F perm=x -F auid>=500 -F auid!=4294967295 -k privileged-priv_change
+-a exit,always -F path=/usr/sbin/setsebool -F perm=x -F auid>=500 -F auid!=4294967295 -k privileged-priv_change
 
--a always,exit -F path=/usr/bin/chcon -F perm=x -F auid>=500 -F auid!=4294967295 -k privileged-priv_change
+-a exit,always -F path=/usr/bin/chcon -F perm=x -F auid>=500 -F auid!=4294967295 -k privileged-priv_change
 
--a always,exit -F path=/sbin/setfiles -F perm=x -F auid>=500 -F auid!=4294967295 -k privileged-priv_change
+-a exit,always -F path=/sbin/setfiles -F perm=x -F auid>=500 -F auid!=4294967295 -k privileged-priv_change
 
--a always,exit -F path=/sbin/restorecon -F perm=x -F auid>=500 -F auid!=4294967295 -k privileged-priv_change
+-a exit,always -F path=/sbin/restorecon -F perm=x -F auid>=500 -F auid!=4294967295 -k privileged-priv_change
 
 ## Permissions auditing separated by chown, chmod, and attr
--a always,exit -F arch=b64 -S chown -F auid>=500 -F auid!=4294967295 -k perm_mod
--a always,exit -F arch=b32 -S chown -F auid>=500 -F auid!=4294967295 -k perm_mod
+-a exit,always -F arch=b64 -S chown -F auid>=500 -F auid!=4294967295 -k perm_mod
+-a exit,always -F arch=b32 -S chown -F auid>=500 -F auid!=4294967295 -k perm_mod
 
--a always,exit -F arch=b64 -S fchown -F auid>=500 -F auid!=4294967295 -k perm_mod
--a always,exit -F arch=b32 -S fchown -F auid>=500 -F auid!=4294967295 -k perm_mod
+-a exit,always -F arch=b64 -S fchown -F auid>=500 -F auid!=4294967295 -k perm_mod
+-a exit,always -F arch=b32 -S fchown -F auid>=500 -F auid!=4294967295 -k perm_mod
 
--a always,exit -F arch=b64 -S lchown -F auid>=500 -F auid!=4294967295 -k perm_mod
--a always,exit -F arch=b32 -S lchown -F auid>=500 -F auid!=4294967295 -k perm_mod
+-a exit,always -F arch=b64 -S lchown -F auid>=500 -F auid!=4294967295 -k perm_mod
+-a exit,always -F arch=b32 -S lchown -F auid>=500 -F auid!=4294967295 -k perm_mod
 
--a always,exit -F arch=b64 -S fchownat -F auid>=500 -F auid!=4294967295 -k perm_mod
--a always,exit -F arch=b32 -S fchownat -F auid>=500 -F auid!=4294967295 -k perm_mod
+-a exit,always -F arch=b64 -S fchownat -F auid>=500 -F auid!=4294967295 -k perm_mod
+-a exit,always -F arch=b32 -S fchownat -F auid>=500 -F auid!=4294967295 -k perm_mod
 
--a always,exit -F arch=b64 -S chmod -F auid>=500 -F auid!=4294967295 -k perm_mod
--a always,exit -F arch=b32 -S chmod -F auid>=500 -F auid!=4294967295 -k perm_mod
+-a exit,always -F arch=b64 -S chmod -F auid>=500 -F auid!=4294967295 -k perm_mod
+-a exit,always -F arch=b32 -S chmod -F auid>=500 -F auid!=4294967295 -k perm_mod
 
--a always,exit -F arch=b64 -S fchmod -F auid>=500 -F auid!=4294967295 -k perm_mod
--a always,exit -F arch=b32 -S fchmod -F auid>=500 -F auid!=4294967295 -k perm_mod
+-a exit,always -F arch=b64 -S fchmod -F auid>=500 -F auid!=4294967295 -k perm_mod
+-a exit,always -F arch=b32 -S fchmod -F auid>=500 -F auid!=4294967295 -k perm_mod
 
--a always,exit -F arch=b64 -S fchmodat -F auid>=500 -F auid!=4294967295 -k perm_mod
--a always,exit -F arch=b32 -S fchmodat -F auid>=500 -F auid!=4294967295 -k perm_mod
+-a exit,always -F arch=b64 -S fchmodat -F auid>=500 -F auid!=4294967295 -k perm_mod
+-a exit,always -F arch=b32 -S fchmodat -F auid>=500 -F auid!=4294967295 -k perm_mod
 
--a always,exit -F arch=b64 -S setxattr -F auid>=500 -F auid!=4294967295 -k perm_mod
--a always,exit -F arch=b32 -S setxattr -F auid>=500 -F auid!=4294967295 -k perm_mod
+-a exit,always -F arch=b64 -S setxattr -F auid>=500 -F auid!=4294967295 -k perm_mod
+-a exit,always -F arch=b32 -S setxattr -F auid>=500 -F auid!=4294967295 -k perm_mod
 
--a always,exit -F arch=b64 -S fsetxattr -F auid>=500 -F auid!=4294967295 -k perm_mod
--a always,exit -F arch=b32 -S fsetxattr -F auid>=500 -F auid!=4294967295 -k perm_mod
+-a exit,always -F arch=b64 -S fsetxattr -F auid>=500 -F auid!=4294967295 -k perm_mod
+-a exit,always -F arch=b32 -S fsetxattr -F auid>=500 -F auid!=4294967295 -k perm_mod
 
--a always,exit -F arch=b64 -S lsetxattr -F auid>=500 -F auid!=4294967295 -k perm_mod
--a always,exit -F arch=b32 -S lsetxattr -F auid>=500 -F auid!=4294967295 -k perm_mod
+-a exit,always -F arch=b64 -S lsetxattr -F auid>=500 -F auid!=4294967295 -k perm_mod
+-a exit,always -F arch=b32 -S lsetxattr -F auid>=500 -F auid!=4294967295 -k perm_mod
 
--a always,exit -F arch=b64 -S removexattr -F auid>=500 -F auid!=4294967295 -k perm_mod
--a always,exit -F arch=b32 -S removexattr -F auid>=500 -F auid!=4294967295 -k perm_mod
+-a exit,always -F arch=b64 -S removexattr -F auid>=500 -F auid!=4294967295 -k perm_mod
+-a exit,always -F arch=b32 -S removexattr -F auid>=500 -F auid!=4294967295 -k perm_mod
 
--a always,exit -F arch=b64 -S fremovexattr -F auid>=500 -F auid!=4294967295 -k perm_mod
--a always,exit -F arch=b32 -S fremovexattr -F auid>=500 -F auid!=4294967295 -k perm_mod
+-a exit,always -F arch=b64 -S fremovexattr -F auid>=500 -F auid!=4294967295 -k perm_mod
+-a exit,always -F arch=b32 -S fremovexattr -F auid>=500 -F auid!=4294967295 -k perm_mod
 
--a always,exit -F arch=b64 -S lremovexattr -F auid>=500 -F auid!=4294967295 -k perm_mod
--a always,exit -F arch=b32 -S lremovexattr -F auid>=500 -F auid!=4294967295 -k perm_mod
+-a exit,always -F arch=b64 -S lremovexattr -F auid>=500 -F auid!=4294967295 -k perm_mod
+-a exit,always -F arch=b32 -S lremovexattr -F auid>=500 -F auid!=4294967295 -k perm_mod
 
 ## Audit rename/removal operations
--a always,exit -F arch=b64 -S rename -F perm=x -F auid>=500 -F auid!=4294967295 -k delete
--a always,exit -F arch=b32 -S rename -F perm=x -F auid>=500 -F auid!=4294967295 -k delete
+-a exit,always -F arch=b64 -S rename -F perm=x -F auid>=500 -F auid!=4294967295 -k delete
+-a exit,always -F arch=b32 -S rename -F perm=x -F auid>=500 -F auid!=4294967295 -k delete
 
--a always,exit -F arch=b64 -S renameat -F perm=x -F auid>=500 -F auid!=4294967295 -k delete
--a always,exit -F arch=b32 -S renameat -F perm=x -F auid>=500 -F auid!=4294967295 -k delete
+-a exit,always -F arch=b64 -S renameat -F perm=x -F auid>=500 -F auid!=4294967295 -k delete
+-a exit,always -F arch=b32 -S renameat -F perm=x -F auid>=500 -F auid!=4294967295 -k delete
 
--a always,exit -F arch=b64 -S rmdir -F perm=x -F auid>=500 -F auid!=4294967295 -k delete
--a always,exit -F arch=b32 -S rmdir -F perm=x -F auid>=500 -F auid!=4294967295 -k delete
+-a exit,always -F arch=b64 -S rmdir -F perm=x -F auid>=500 -F auid!=4294967295 -k delete
+-a exit,always -F arch=b32 -S rmdir -F perm=x -F auid>=500 -F auid!=4294967295 -k delete
 
--a always,exit -F arch=b64 -S unlink -F perm=x -F auid>=500 -F auid!=4294967295 -k delete
--a always,exit -F arch=b32 -S unlink -F perm=x -F auid>=500 -F auid!=4294967295 -k delete
+-a exit,always -F arch=b64 -S unlink -F perm=x -F auid>=500 -F auid!=4294967295 -k delete
+-a exit,always -F arch=b32 -S unlink -F perm=x -F auid>=500 -F auid!=4294967295 -k delete
 
--a always,exit -F arch=b64 -S unlinkat -F perm=x -F auid>=500 -F auid!=4294967295 -k delete
--a always,exit -F arch=b32 -S unlinkat -F perm=x -F auid>=500 -F auid!=4294967295 -k delete
+-a exit,always -F arch=b64 -S unlinkat -F perm=x -F auid>=500 -F auid!=4294967295 -k delete
+-a exit,always -F arch=b32 -S unlinkat -F perm=x -F auid>=500 -F auid!=4294967295 -k delete
 
 ## Audit the execution of suid and sgid binaries.
--a always,exit -F path=/bin/cgclassify -F perm=x -F auid>=500 -F auid!=4294967295 -k setuid/setgid
--a always,exit -F path=/bin/cgexec -F perm=x -F auid>=500 -F auid!=4294967295 -k setuid/setgid
--a always,exit -F path=/bin/ping -F perm=x -F auid>=500 -F auid!=4294967295 -k setuid/setgid
--a always,exit -F path=/bin/ping6 -F perm=x -F auid>=500 -F auid!=4294967295 -k setuid/setgid
--a always,exit -F path=/sbin/mount.nfs -F perm=x -F auid>=500 -F auid!=4294967295 -k setuid/setgid
--a always,exit -F path=/sbin/netreport -F perm=x -F auid>=500 -F auid!=4294967295 -k setuid/setgid
--a always,exit -F path=/usr/bin/at -F perm=x -F auid>=500 -F auid!=4294967295 -k setuid/setgid
--a always,exit -F path=/usr/bin/chage -F perm=x -F auid>=500 -F auid!=4294967295 -k setuid/setgid
--a always,exit -F path=/usr/bin/chcon -F perm=x -F auid>=500 -F auid!=4294967295 -k setuid/setgid
--a always,exit -F path=/usr/bin/chfn -F perm=x -F auid>=500 -F auid!=4294967295 -k setuid/setgid
--a always,exit -F path=/usr/bin/chsh -F perm=x -F auid>=500 -F auid!=4294967295 -k setuid/setgid
--a always,exit -F path=/usr/bin/crontab -F perm=x -F auid>=500 -F auid!=4294967295 -k setuid/setgid
--a always,exit -F path=/usr/bin/fusermount -F perm=x -F auid>=500 -F auid!=4294967295 -k setuid/setgid
--a always,exit -F path=/usr/bin/gpasswd -F perm=x -F auid>=500 -F auid!=4294967295 -k setuid/setgid
--a always,exit -F path=/usr/bin/incrontab -F perm=x -F auid>=500 -F auid!=4294967295 -k setuid/setgid
--a always,exit -F path=/usr/bin/ksu -F perm=x -F auid>=500 -F auid!=4294967295 -k setuid/setgid
--a always,exit -F path=/usr/bin/locate -F perm=x -F auid>=500 -F auid!=4294967295 -k setuid/setgid
--a always,exit -F path=/usr/bin/mount -F perm=x -F auid>=500 -F auid!=4294967295 -k setuid/setgid
--a always,exit -F path=/usr/bin/newgidmap -F perm=x -F auid>=500 -F auid!=4294967295 -k setuid/setgid
--a always,exit -F path=/usr/bin/newgrp -F perm=x -F auid>=500 -F auid!=4294967295 -k setuid/setgid
--a always,exit -F path=/usr/bin/newuidmap -F perm=x -F auid>=500 -F auid!=4294967295 -k setuid/setgid
--a always,exit -F path=/usr/bin/passwd -F perm=x -F auid>=500 -F auid!=4294967295 -k setuid/setgid
--a always,exit -F path=/usr/bin/pkexec -F perm=x -F auid>=500 -F auid!=4294967295 -k setuid/setgid
--a always,exit -F path=/usr/bin/screen -F perm=x -F auid>=500 -F auid!=4294967295 -k setuid/setgid
--a always,exit -F path=/usr/bin/ssh-agent -F perm=x -F auid>=500 -F auid!=4294967295 -k setuid/setgid
--a always,exit -F path=/usr/bin/su -F perm=x -F auid>=500 -F auid!=4294967295 -k setuid/setgid
--a always,exit -F path=/usr/bin/sudo -F perm=x -F auid>=500 -F auid!=4294967295 -k setuid/setgid
--a always,exit -F path=/usr/bin/sudoedit -F perm=x -F auid>=500 -F auid!=4294967295 -k setuid/setgid
--a always,exit -F path=/usr/bin/umount -F perm=x -F auid>=500 -F auid!=4294967295 -k setuid/setgid
--a always,exit -F path=/usr/bin/wall -F perm=x -F auid>=500 -F auid!=4294967295 -k setuid/setgid
--a always,exit -F path=/usr/bin/write -F perm=x -F auid>=500 -F auid!=4294967295 -k setuid/setgid
--a always,exit -F path=/usr/bin/Xorg -F perm=x -F auid>=500 -F auid!=4294967295 -k setuid/setgid
--a always,exit -F path=/usr/libexec/dbus-1/dbus-daemon-launch-helper -F perm=x -F auid>=500 -F auid!=4294967295 -k setuid/setgid
--a always,exit -F path=/usr/libexec/openssh/ssh-keysign -F perm=x -F auid>=500 -F auid!=4294967295 -k setuid/setgid
--a always,exit -F path=/usr/libexec/polkit-1/polkit-agent-helper-1 -F perm=x -F auid>=500 -F auid!=4294967295 -k setuid/setgid
--a always,exit -F path=/usr/libexec/pt_chown -F perm=x -F auid>=500 -F auid!=4294967295 -k setuid/setgid
--a always,exit -F path=/usr/libexec/utempter/utempter -F perm=x -F auid>=500 -F auid!=4294967295 -k setuid/setgid
--a always,exit -F path=/usr/sbin/pam_timestamp_check -F perm=x -F auid>=500 -F auid!=4294967295 -k setuid/setgid
--a always,exit -F path=/usr/sbin/postdrop -F perm=x -F auid>=500 -F auid!=4294967295 -k setuid/setgid
--a always,exit -F path=/usr/sbin/postqueue -F perm=x -F auid>=500 -F auid!=4294967295 -k setuid/setgid
--a always,exit -F path=/usr/sbin/restorecon -F perm=x -F auid>=500 -F auid!=4294967295 -k setuid/setgid
--a always,exit -F path=/usr/sbin/semanage -F perm=x -F auid>=500 -F auid!=4294967295 -k setuid/setgid
--a always,exit -F path=/usr/sbin/setfiles -F perm=x -F auid>=500 -F auid!=4294967295 -k setuid/setgid
--a always,exit -F path=/usr/sbin/setsebool -F perm=x -F auid>=500 -F auid!=4294967295 -k setuid/setgid
--a always,exit -F path=/usr/sbin/seunshare -F perm=x -F auid>=500 -F auid!=4294967295 -k setuid/setgid
--a always,exit -F path=/usr/sbin/suexec -F perm=x -F auid>=500 -F auid!=4294967295 -k setuid/setgid
--a always,exit -F path=/usr/sbin/unix_chkpwd -F perm=x -F auid>=500 -F auid!=4294967295 -k setuid/setgid
--a always,exit -F path=/usr/sbin/userhelper -F perm=x -F auid>=500 -F auid!=4294967295 -k setuid/setgid
--a always,exit -F path=/usr/sbin/usernetctl -F perm=x -F auid>=500 -F auid!=4294967295 -k setuid/setgid
+-a exit,always -F path=/bin/cgclassify -F perm=x -F auid>=500 -F auid!=4294967295 -k setuid/setgid
+-a exit,always -F path=/bin/cgexec -F perm=x -F auid>=500 -F auid!=4294967295 -k setuid/setgid
+-a exit,always -F path=/bin/ping -F perm=x -F auid>=500 -F auid!=4294967295 -k setuid/setgid
+-a exit,always -F path=/bin/ping6 -F perm=x -F auid>=500 -F auid!=4294967295 -k setuid/setgid
+-a exit,always -F path=/sbin/mount.nfs -F perm=x -F auid>=500 -F auid!=4294967295 -k setuid/setgid
+-a exit,always -F path=/sbin/netreport -F perm=x -F auid>=500 -F auid!=4294967295 -k setuid/setgid
+-a exit,always -F path=/usr/bin/at -F perm=x -F auid>=500 -F auid!=4294967295 -k setuid/setgid
+-a exit,always -F path=/usr/bin/chage -F perm=x -F auid>=500 -F auid!=4294967295 -k setuid/setgid
+-a exit,always -F path=/usr/bin/chcon -F perm=x -F auid>=500 -F auid!=4294967295 -k setuid/setgid
+-a exit,always -F path=/usr/bin/chfn -F perm=x -F auid>=500 -F auid!=4294967295 -k setuid/setgid
+-a exit,always -F path=/usr/bin/chsh -F perm=x -F auid>=500 -F auid!=4294967295 -k setuid/setgid
+-a exit,always -F path=/usr/bin/crontab -F perm=x -F auid>=500 -F auid!=4294967295 -k setuid/setgid
+-a exit,always -F path=/usr/bin/fusermount -F perm=x -F auid>=500 -F auid!=4294967295 -k setuid/setgid
+-a exit,always -F path=/usr/bin/gpasswd -F perm=x -F auid>=500 -F auid!=4294967295 -k setuid/setgid
+-a exit,always -F path=/usr/bin/incrontab -F perm=x -F auid>=500 -F auid!=4294967295 -k setuid/setgid
+-a exit,always -F path=/usr/bin/ksu -F perm=x -F auid>=500 -F auid!=4294967295 -k setuid/setgid
+-a exit,always -F path=/usr/bin/locate -F perm=x -F auid>=500 -F auid!=4294967295 -k setuid/setgid
+-a exit,always -F path=/usr/bin/mount -F perm=x -F auid>=500 -F auid!=4294967295 -k setuid/setgid
+-a exit,always -F path=/usr/bin/newgidmap -F perm=x -F auid>=500 -F auid!=4294967295 -k setuid/setgid
+-a exit,always -F path=/usr/bin/newgrp -F perm=x -F auid>=500 -F auid!=4294967295 -k setuid/setgid
+-a exit,always -F path=/usr/bin/newuidmap -F perm=x -F auid>=500 -F auid!=4294967295 -k setuid/setgid
+-a exit,always -F path=/usr/bin/passwd -F perm=x -F auid>=500 -F auid!=4294967295 -k setuid/setgid
+-a exit,always -F path=/usr/bin/pkexec -F perm=x -F auid>=500 -F auid!=4294967295 -k setuid/setgid
+-a exit,always -F path=/usr/bin/screen -F perm=x -F auid>=500 -F auid!=4294967295 -k setuid/setgid
+-a exit,always -F path=/usr/bin/ssh-agent -F perm=x -F auid>=500 -F auid!=4294967295 -k setuid/setgid
+-a exit,always -F path=/usr/bin/su -F perm=x -F auid>=500 -F auid!=4294967295 -k setuid/setgid
+-a exit,always -F path=/usr/bin/sudo -F perm=x -F auid>=500 -F auid!=4294967295 -k setuid/setgid
+-a exit,always -F path=/usr/bin/sudoedit -F perm=x -F auid>=500 -F auid!=4294967295 -k setuid/setgid
+-a exit,always -F path=/usr/bin/umount -F perm=x -F auid>=500 -F auid!=4294967295 -k setuid/setgid
+-a exit,always -F path=/usr/bin/wall -F perm=x -F auid>=500 -F auid!=4294967295 -k setuid/setgid
+-a exit,always -F path=/usr/bin/write -F perm=x -F auid>=500 -F auid!=4294967295 -k setuid/setgid
+-a exit,always -F path=/usr/bin/Xorg -F perm=x -F auid>=500 -F auid!=4294967295 -k setuid/setgid
+-a exit,always -F path=/usr/libexec/dbus-1/dbus-daemon-launch-helper -F perm=x -F auid>=500 -F auid!=4294967295 -k setuid/setgid
+-a exit,always -F path=/usr/libexec/openssh/ssh-keysign -F perm=x -F auid>=500 -F auid!=4294967295 -k setuid/setgid
+-a exit,always -F path=/usr/libexec/polkit-1/polkit-agent-helper-1 -F perm=x -F auid>=500 -F auid!=4294967295 -k setuid/setgid
+-a exit,always -F path=/usr/libexec/pt_chown -F perm=x -F auid>=500 -F auid!=4294967295 -k setuid/setgid
+-a exit,always -F path=/usr/libexec/utempter/utempter -F perm=x -F auid>=500 -F auid!=4294967295 -k setuid/setgid
+-a exit,always -F path=/usr/sbin/pam_timestamp_check -F perm=x -F auid>=500 -F auid!=4294967295 -k setuid/setgid
+-a exit,always -F path=/usr/sbin/postdrop -F perm=x -F auid>=500 -F auid!=4294967295 -k setuid/setgid
+-a exit,always -F path=/usr/sbin/postqueue -F perm=x -F auid>=500 -F auid!=4294967295 -k setuid/setgid
+-a exit,always -F path=/usr/sbin/restorecon -F perm=x -F auid>=500 -F auid!=4294967295 -k setuid/setgid
+-a exit,always -F path=/usr/sbin/semanage -F perm=x -F auid>=500 -F auid!=4294967295 -k setuid/setgid
+-a exit,always -F path=/usr/sbin/setfiles -F perm=x -F auid>=500 -F auid!=4294967295 -k setuid/setgid
+-a exit,always -F path=/usr/sbin/setsebool -F perm=x -F auid>=500 -F auid!=4294967295 -k setuid/setgid
+-a exit,always -F path=/usr/sbin/seunshare -F perm=x -F auid>=500 -F auid!=4294967295 -k setuid/setgid
+-a exit,always -F path=/usr/sbin/suexec -F perm=x -F auid>=500 -F auid!=4294967295 -k setuid/setgid
+-a exit,always -F path=/usr/sbin/unix_chkpwd -F perm=x -F auid>=500 -F auid!=4294967295 -k setuid/setgid
+-a exit,always -F path=/usr/sbin/userhelper -F perm=x -F auid>=500 -F auid!=4294967295 -k setuid/setgid
+-a exit,always -F path=/usr/sbin/usernetctl -F perm=x -F auid>=500 -F auid!=4294967295 -k setuid/setgid
 
 ## Audit the loading and unloading of kernel modules.
 -w /sbin/insmod -p x -F auid!=4294967295 -k module-change
@@ -192,25 +192,25 @@
 
 -w /sbin/modprobe -p x -F auid!=4294967295 -k module-change
 
--a always,exit -F arch=b64 -S create_module -k module-change
--a always,exit -F arch=b32 -S create_module -k module-change
+-a exit,always -F arch=b64 -S create_module -k module-change
+-a exit,always -F arch=b32 -S create_module -k module-change
 
--a always,exit -F arch=b64 -S init_module -k module-change
--a always,exit -F arch=b32 -S init_module -k module-change
+-a exit,always -F arch=b64 -S init_module -k module-change
+-a exit,always -F arch=b32 -S init_module -k module-change
 
--a always,exit -F arch=b64 -S finit_module -k module-change
--a always,exit -F arch=b32 -S finit_module -k module-change
+-a exit,always -F arch=b64 -S finit_module -k module-change
+-a exit,always -F arch=b32 -S finit_module -k module-change
 
--a always,exit -F arch=b64 -S delete_module -k module-change
--a always,exit -F arch=b32 -S delete_module -k module-change
+-a exit,always -F arch=b64 -S delete_module -k module-change
+-a exit,always -F arch=b32 -S delete_module -k module-change
 
 ## Audit mount operations
--a always,exit -F arch=b64 -S mount -F auid>=500 -F auid!=4294967295 -k privileged-mount
--a always,exit -F arch=b64 -F path=/bin/mount -F auid>=500 -F auid!=4294967295 -k privileged-mount
--a always,exit -F arch=b32 -S mount -F auid>=500 -F auid!=4294967295 -k privileged-mount
--a always,exit -F arch=b32 -F path=/bin/mount -F auid>=500 -F auid!=4294967295 -k privileged-mount
+-a exit,always -F arch=b64 -S mount -F auid>=500 -F auid!=4294967295 -k privileged-mount
+-a exit,always -F arch=b64 -F path=/bin/mount -F auid>=500 -F auid!=4294967295 -k privileged-mount
+-a exit,always -F arch=b32 -S mount -F auid>=500 -F auid!=4294967295 -k privileged-mount
+-a exit,always -F arch=b32 -F path=/bin/mount -F auid>=500 -F auid!=4294967295 -k privileged-mount
 
--a always,exit -F path=/bin/umount -F perm=x -F auid>=500 -F auid!=4294967295 -k privileged-mount
+-a exit,always -F path=/bin/umount -F perm=x -F auid>=500 -F auid!=4294967295 -k privileged-mount
 
 ## Audit local accounts
 -w /etc/passwd -p wa -k identity

--- a/spec/classes/config/audit_profiles/expected/stig_el7_all_custom_tags.txt
+++ b/spec/classes/config/audit_profiles/expected/stig_el7_all_custom_tags.txt
@@ -1,204 +1,159 @@
 #### auditd::config::audit_profiles::stig Audit Rules ####
 
 ## Audit unsuccessful file operations
-# RHEL-07-030500
 -a always,exit -F arch=b64 -S creat -F exit=-EPERM -F auid>=1000 -F auid!=4294967295 -k my_unsuccessful_file_operations
 -a always,exit -F arch=b64 -S creat -F exit=-EACCES -F auid>=1000 -F auid!=4294967295 -k my_unsuccessful_file_operations
 -a always,exit -F arch=b32 -S creat -F exit=-EPERM -F auid>=1000 -F auid!=4294967295 -k my_unsuccessful_file_operations
 -a always,exit -F arch=b32 -S creat -F exit=-EACCES -F auid>=1000 -F auid!=4294967295 -k my_unsuccessful_file_operations
 
-# RHEL-07-030510
 -a always,exit -F arch=b64 -S open -F exit=-EPERM -F auid>=1000 -F auid!=4294967295 -k my_unsuccessful_file_operations
 -a always,exit -F arch=b64 -S open -F exit=-EACCES -F auid>=1000 -F auid!=4294967295 -k my_unsuccessful_file_operations
 -a always,exit -F arch=b32 -S open -F exit=-EPERM -F auid>=1000 -F auid!=4294967295 -k my_unsuccessful_file_operations
 -a always,exit -F arch=b32 -S open -F exit=-EACCES -F auid>=1000 -F auid!=4294967295 -k my_unsuccessful_file_operations
 
-# RHEL-07-030520
 -a always,exit -F arch=b64 -S openat -F exit=-EPERM -F auid>=1000 -F auid!=4294967295 -k my_unsuccessful_file_operations
 -a always,exit -F arch=b64 -S openat -F exit=-EACCES -F auid>=1000 -F auid!=4294967295 -k my_unsuccessful_file_operations
 -a always,exit -F arch=b32 -S openat -F exit=-EPERM -F auid>=1000 -F auid!=4294967295 -k my_unsuccessful_file_operations
 -a always,exit -F arch=b32 -S openat -F exit=-EACCES -F auid>=1000 -F auid!=4294967295 -k my_unsuccessful_file_operations
 
-# RHEL-07-030530
 -a always,exit -F arch=b64 -S open_by_handle_at -F exit=-EPERM -F auid>=1000 -F auid!=4294967295 -k my_unsuccessful_file_operations
 -a always,exit -F arch=b64 -S open_by_handle_at -F exit=-EACCES -F auid>=1000 -F auid!=4294967295 -k my_unsuccessful_file_operations
 -a always,exit -F arch=b32 -S open_by_handle_at -F exit=-EPERM -F auid>=1000 -F auid!=4294967295 -k my_unsuccessful_file_operations
 -a always,exit -F arch=b32 -S open_by_handle_at -F exit=-EACCES -F auid>=1000 -F auid!=4294967295 -k my_unsuccessful_file_operations
 
-# RHEL-07-030540
 -a always,exit -F arch=b64 -S truncate -F exit=-EPERM -F auid>=1000 -F auid!=4294967295 -k my_unsuccessful_file_operations
 -a always,exit -F arch=b64 -S truncate -F exit=-EACCES -F auid>=1000 -F auid!=4294967295 -k my_unsuccessful_file_operations
 -a always,exit -F arch=b32 -S truncate -F exit=-EPERM -F auid>=1000 -F auid!=4294967295 -k my_unsuccessful_file_operations
 -a always,exit -F arch=b32 -S truncate -F exit=-EACCES -F auid>=1000 -F auid!=4294967295 -k my_unsuccessful_file_operations
 
-# RHEL-07-030550
 -a always,exit -F arch=b64 -S ftruncate -F exit=-EPERM -F auid>=1000 -F auid!=4294967295 -k my_unsuccessful_file_operations
 -a always,exit -F arch=b64 -S ftruncate -F exit=-EACCES -F auid>=1000 -F auid!=4294967295 -k my_unsuccessful_file_operations
 -a always,exit -F arch=b32 -S ftruncate -F exit=-EPERM -F auid>=1000 -F auid!=4294967295 -k my_unsuccessful_file_operations
 -a always,exit -F arch=b32 -S ftruncate -F exit=-EACCES -F auid>=1000 -F auid!=4294967295 -k my_unsuccessful_file_operations
 
 ## Audit the execution of password commands
-# RHEL-07-030630
 -a always,exit -F path=/usr/bin/passwd -F perm=x -F auid>=1000 -F auid!=4294967295 -k my_passwd_cmds
 -a always,exit -F path=/bin/passwd -F perm=x -F auid>=1000 -F auid!=4294967295 -k my_passwd_cmds
 
-# RHEL-07-030640
 -a always,exit -F path=/usr/sbin/unix_chkpwd -F perm=x -F auid>=1000 -F auid!=4294967295 -k my_passwd_cmds
 -a always,exit -F path=/sbin/unix_chkpwd -F perm=x -F auid>=1000 -F auid!=4294967295 -k my_passwd_cmds
 
-# RHEL-07-030650
 -a always,exit -F path=/usr/bin/gpasswd -F perm=x -F auid>=1000 -F auid!=4294967295 -k my_passwd_cmds
 -a always,exit -F path=/bin/gpasswd -F perm=x -F auid>=1000 -F auid!=4294967295 -k my_passwd_cmds
 
-# RHEL-07-030660
 -a always,exit -F path=/usr/bin/chage -F perm=x -F auid>=1000 -F auid!=4294967295 -k my_passwd_cmds
 -a always,exit -F path=/bin/chage -F perm=x -F auid>=1000 -F auid!=4294967295 -k my_passwd_cmds
 
-# RHEL-07-030670
 -a always,exit -F path=/usr/sbin/userhelper -F perm=x -F auid>=1000 -F auid!=4294967295 -k my_passwd_cmds
 -a always,exit -F path=/sbin/userhelper -F perm=x -F auid>=1000 -F auid!=4294967295 -k my_passwd_cmds
 
 ## Audit the execution of privilege-related commands
-# RHEL-07-030680
 -a always,exit -F path=/usr/bin/su -F perm=x -F auid>=1000 -F auid!=4294967295 -k my_priv_cmds
 -a always,exit -F path=/bin/su -F perm=x -F auid>=1000 -F auid!=4294967295 -k my_priv_cmds
 
-# RHEL-07-030690
 -a always,exit -F path=/usr/bin/sudo -F perm=x -F auid>=1000 -F auid!=4294967295 -k my_priv_cmds
 -a always,exit -F path=/bin/sudo -F perm=x -F auid>=1000 -F auid!=4294967295 -k my_priv_cmds
 
-# RHEL-07-030710
 -a always,exit -F path=/usr/bin/newgrp -F perm=x -F auid>=1000 -F auid!=4294967295 -k my_priv_cmds
 -a always,exit -F path=/bin/newgrp -F perm=x -F auid>=1000 -F auid!=4294967295 -k my_priv_cmds
 
-# RHEL-07-030720
 -a always,exit -F path=/usr/bin/chsh -F perm=x -F auid>=1000 -F auid!=4294967295 -k my_priv_cmds
 -a always,exit -F path=/bin/chsh -F perm=x -F auid>=1000 -F auid!=4294967295 -k my_priv_cmds
 
-# RHEL-07-030730
 -a always,exit -F path=/usr/bin/sudoedit -F perm=x -F auid>=1000 -F auid!=4294967295 -k my_priv_cmds
 -a always,exit -F path=/bin/sudoedit -F perm=x -F auid>=1000 -F auid!=4294967295 -k my_priv_cmds
 
 ## Audit the execution of postfix-related commands
-# RHEL-07-030760
 -a always,exit -F path=/usr/sbin/postdrop -F perm=x -F auid>=1000 -F auid!=4294967295 -k my_postfix_cmds
 -a always,exit -F path=/sbin/postdrop -F perm=x -F auid>=1000 -F auid!=4294967295 -k my_postfix_cmds
 
-# RHEL-07-030770
 -a always,exit -F path=/usr/sbin/postqueue -F perm=x -F auid>=1000 -F auid!=4294967295 -k my_postfix_cmds
 -a always,exit -F path=/sbin/postqueue -F perm=x -F auid>=1000 -F auid!=4294967295 -k my_postfix_cmds
 
 ## Audit the execution of the ssh-keysign command
-# RHEL-07-030780
 -a always,exit -F path=/usr/libexec/openssh/ssh-keysign -F perm=x -F auid>=1000 -F auid!=4294967295 -k my_ssh_keysign_cmd
 
 ## Audit the execution of the crontab command
-# RHEL-07-030800
 -a always,exit -F path=/usr/bin/crontab -F perm=x -F auid>=1000 -F auid!=4294967295 -k my_crontab
 -a always,exit -F path=/bin/crontab -F perm=x -F auid>=1000 -F auid!=4294967295 -k my_crontab
 
 ## Audit the execution of the pam_timestamp_check command
-# RHEL-07-030810
 -a always,exit -F path=/usr/sbin/pam_timestamp_check -F perm=x -F auid>=1000 -F auid!=4294967295 -k my_pam_timestamp_check_cmd
 -a always,exit -F path=/sbin/pam_timestamp_check -F perm=x -F auid>=1000 -F auid!=4294967295 -k my_pam_timestamp_check_cmd
 
 ## Audit selinux commands
-# RHEL-07-030560
 -a always,exit -F path=/usr/sbin/semanage -F perm=x -F auid>=1000 -F auid!=4294967295 -k my_selinux_cmds
 -a always,exit -F path=/sbin/semanage -F perm=x -F auid>=1000 -F auid!=4294967295 -k my_selinux_cmds
 
-# RHEL-07-030570
 -a always,exit -F path=/usr/sbin/setsebool -F perm=x -F auid>=1000 -F auid!=4294967295 -k my_selinux_cmds
 -a always,exit -F path=/sbin/setsebool -F perm=x -F auid>=1000 -F auid!=4294967295 -k my_selinux_cmds
 
-# RHEL-07-030580
 -a always,exit -F path=/usr/bin/chcon -F perm=x -F auid>=1000 -F auid!=4294967295 -k my_selinux_cmds
 -a always,exit -F path=/bin/chcon -F perm=x -F auid>=1000 -F auid!=4294967295 -k my_selinux_cmds
 
-# RHEL-07-030590
 -a always,exit -F path=/usr/sbin/setfiles -F perm=x -F auid>=1000 -F auid!=4294967295 -k my_selinux_cmds
 -a always,exit -F path=/sbin/setfiles -F perm=x -F auid>=1000 -F auid!=4294967295 -k my_selinux_cmds
 
-# RHEL-07-030590
 -a always,exit -F path=/sbin/restorecon -F perm=x -F auid>=1000 -F auid!=4294967295 -k my_selinux_cmds
 -a always,exit -F path=/usr/sbin/restorecon -F perm=x -F auid>=1000 -F auid!=4294967295 -k my_selinux_cmds
 
 ## Permissions auditing separated by chown, chmod, and attr
-# RHEL-07-030370
 -a always,exit -F arch=b64 -S chown -F auid>=1000 -F auid!=4294967295 -k my_chown
 -a always,exit -F arch=b32 -S chown -F auid>=1000 -F auid!=4294967295 -k my_chown
 
-# RHEL-07-030380
 -a always,exit -F arch=b64 -S fchown -F auid>=1000 -F auid!=4294967295 -k my_chown
 -a always,exit -F arch=b32 -S fchown -F auid>=1000 -F auid!=4294967295 -k my_chown
 
-# RHEL-07-030390
 -a always,exit -F arch=b64 -S lchown -F auid>=1000 -F auid!=4294967295 -k my_chown
 -a always,exit -F arch=b32 -S lchown -F auid>=1000 -F auid!=4294967295 -k my_chown
 
-# RHEL-07-030400
 -a always,exit -F arch=b64 -S fchownat -F auid>=1000 -F auid!=4294967295 -k my_chown
 -a always,exit -F arch=b32 -S fchownat -F auid>=1000 -F auid!=4294967295 -k my_chown
 
-# RHEL-07-030410
 -a always,exit -F arch=b64 -S chmod -F auid>=1000 -F auid!=4294967295 -k my_chmod
 -a always,exit -F arch=b32 -S chmod -F auid>=1000 -F auid!=4294967295 -k my_chmod
 
-# RHEL-07-030420
 -a always,exit -F arch=b64 -S fchmod -F auid>=1000 -F auid!=4294967295 -k my_chmod
 -a always,exit -F arch=b32 -S fchmod -F auid>=1000 -F auid!=4294967295 -k my_chmod
 
-# RHEL-07-030430
 -a always,exit -F arch=b64 -S fchmodat -F auid>=1000 -F auid!=4294967295 -k my_chmod
 -a always,exit -F arch=b32 -S fchmodat -F auid>=1000 -F auid!=4294967295 -k my_chmod
 
-# RHEL-07-030440
 -a always,exit -F arch=b64 -S setxattr -F auid>=1000 -F auid!=4294967295 -k my_attr
 -a always,exit -F arch=b32 -S setxattr -F auid>=1000 -F auid!=4294967295 -k my_attr
 
-# RHEL-07-030450
 -a always,exit -F arch=b64 -S fsetxattr -F auid>=1000 -F auid!=4294967295 -k my_attr
 -a always,exit -F arch=b32 -S fsetxattr -F auid>=1000 -F auid!=4294967295 -k my_attr
 
-# RHEL-07-030460
 -a always,exit -F arch=b64 -S lsetxattr -F auid>=1000 -F auid!=4294967295 -k my_attr
 -a always,exit -F arch=b32 -S lsetxattr -F auid>=1000 -F auid!=4294967295 -k my_attr
 
-# RHEL-07-030470
 -a always,exit -F arch=b64 -S removexattr -F auid>=1000 -F auid!=4294967295 -k my_attr
 -a always,exit -F arch=b32 -S removexattr -F auid>=1000 -F auid!=4294967295 -k my_attr
 
-# RHEL-07-030480
 -a always,exit -F arch=b64 -S fremovexattr -F auid>=1000 -F auid!=4294967295 -k my_attr
 -a always,exit -F arch=b32 -S fremovexattr -F auid>=1000 -F auid!=4294967295 -k my_attr
 
-# RHEL-07-030490
 -a always,exit -F arch=b64 -S lremovexattr -F auid>=1000 -F auid!=4294967295 -k my_attr
 -a always,exit -F arch=b32 -S lremovexattr -F auid>=1000 -F auid!=4294967295 -k my_attr
 
 ## Audit rename/removal operations
-# RHEL-07-030880
 -a always,exit -F arch=b64 -S rename -F perm=x -F auid>=1000 -F auid!=4294967295 -k my_rename_remove
 -a always,exit -F arch=b32 -S rename -F perm=x -F auid>=1000 -F auid!=4294967295 -k my_rename_remove
 
-# RHEL-07-030890
 -a always,exit -F arch=b64 -S renameat -F perm=x -F auid>=1000 -F auid!=4294967295 -k my_rename_remove
 -a always,exit -F arch=b32 -S renameat -F perm=x -F auid>=1000 -F auid!=4294967295 -k my_rename_remove
 
-# RHEL-07-030900
 -a always,exit -F arch=b64 -S rmdir -F perm=x -F auid>=1000 -F auid!=4294967295 -k my_rename_remove
 -a always,exit -F arch=b32 -S rmdir -F perm=x -F auid>=1000 -F auid!=4294967295 -k my_rename_remove
 
-# RHEL-07-030910
 -a always,exit -F arch=b64 -S unlink -F perm=x -F auid>=1000 -F auid!=4294967295 -k my_rename_remove
 -a always,exit -F arch=b32 -S unlink -F perm=x -F auid>=1000 -F auid!=4294967295 -k my_rename_remove
 
-# RHEL-07-030920
 -a always,exit -F arch=b64 -S unlinkat -F perm=x -F auid>=1000 -F auid!=4294967295 -k my_rename_remove
 -a always,exit -F arch=b32 -S unlinkat -F perm=x -F auid>=1000 -F auid!=4294967295 -k my_rename_remove
 
 ## Audit the execution of suid and sgid binaries.
-# RHEL-07-030360
 -a always,exit -F path=/usr/bin/at -F perm=x -F auid>=1000 -F auid!=4294967295 -k my_suid_sgid
 -a always,exit -F path=/usr/bin/chage -F perm=x -F auid>=1000 -F auid!=4294967295 -k my_suid_sgid
 -a always,exit -F path=/usr/bin/chcon -F perm=x -F auid>=1000 -F auid!=4294967295 -k my_suid_sgid
@@ -250,36 +205,28 @@
 -a always,exit -F path=/usr/sbin/usernetctl -F perm=x -F auid>=1000 -F auid!=4294967295 -k my_suid_sgid
 
 ## Audit the loading and unloading of kernel modules.
-# RHEL-07-030840
 -w /usr/sbin/insmod -p x -F auid!=4294967295 -k my_kernel_modules
 -w /sbin/insmod -p x -F auid!=4294967295 -k my_kernel_modules
 
-# RHEL-07-030850
 -w /usr/sbin/rmmod -p x -F auid!=4294967295 -k my_kernel_modules
 -w /sbin/rmmod -p x -F auid!=4294967295 -k my_kernel_modules
 
-# RHEL-07-030860
 -w /usr/sbin/modprobe -p x -F auid!=4294967295 -k my_kernel_modules
 -w /sbin/modprobe -p x -F auid!=4294967295 -k my_kernel_modules
 
-# RHEL-07-030819
 -a always,exit -F arch=b64 -S create_module -k my_kernel_modules
 -a always,exit -F arch=b32 -S create_module -k my_kernel_modules
 
-# RHEL-07-030820
 -a always,exit -F arch=b64 -S init_module -k my_kernel_modules
 -a always,exit -F arch=b32 -S init_module -k my_kernel_modules
 
-# RHEL-07-030821
 -a always,exit -F arch=b64 -S finit_module -k my_kernel_modules
 -a always,exit -F arch=b32 -S finit_module -k my_kernel_modules
 
-# RHEL-07-030830
 -a always,exit -F arch=b64 -S delete_module -k my_kernel_modules
 -a always,exit -F arch=b32 -S delete_module -k my_kernel_modules
 
 ## Audit mount operations
-# RHEL-07-030740
 -a always,exit -F arch=b64 -S mount -F auid>=1000 -F auid!=4294967295 -k my_mount
 -a always,exit -F arch=b64 -F path=/usr/bin/mount -F auid>=1000 -F auid!=4294967295 -k my_mount
 -a always,exit -F arch=b64 -F path=/bin/mount -F auid>=1000 -F auid!=4294967295 -k my_mount
@@ -287,37 +234,27 @@
 -a always,exit -F arch=b32 -F path=/usr/bin/mount -F auid>=1000 -F auid!=4294967295 -k my_mount
 -a always,exit -F arch=b32 -F path=/bin/mount -F auid>=1000 -F auid!=4294967295 -k my_mount
 
-# RHEL-07-030750
 -a always,exit -F path=/usr/bin/umount -F perm=x -F auid>=1000 -F auid!=4294967295 -k my_mount
 -a always,exit -F path=/bin/umount -F perm=x -F auid>=1000 -F auid!=4294967295 -k my_mount
 
 ## Audit local accounts
-# RHEL-07-030870
 -w /etc/passwd -p wa -k my_local_account
 
-# RHEL-07-030871
 -w /etc/group -p wa -k my_local_account
 
-# RHEL-07-030872
 -w /etc/gshadow -p wa -k my_local_account
 
-# RHEL-07-030873
 -w /etc/shadow -p wa -k my_local_account
 
-# RHEL-07-030874
 -w /etc/security/opasswd -p wa -k my_local_account
 
 ## Audit login files
-# RHEL-07-030600
 -w /var/log/tallylog -p wa -k my_login_files
 
-# RHEL-07-030610
 -w /var/run/faillock -p wa -k my_login_files
 
-# RHEL-07-030620
 -w /var/log/lastlog -p wa -k my_login_files
 
 ## Audit sudoers configuration files
-# RHEL-07-030700
 -w /etc/sudoers -p wa -k my_cfg_sudoers
 -w /etc/sudoers.d/ -p wa -k my_cfg_sudoers

--- a/spec/classes/config/audit_profiles/expected/stig_el7_all_custom_tags.txt
+++ b/spec/classes/config/audit_profiles/expected/stig_el7_all_custom_tags.txt
@@ -1,208 +1,208 @@
 #### auditd::config::audit_profiles::stig Audit Rules ####
 
 ## Audit unsuccessful file operations
--a always,exit -F arch=b64 -S creat -F exit=-EPERM -F auid>=1000 -F auid!=4294967295 -k my_unsuccessful_file_operations
--a always,exit -F arch=b64 -S creat -F exit=-EACCES -F auid>=1000 -F auid!=4294967295 -k my_unsuccessful_file_operations
--a always,exit -F arch=b32 -S creat -F exit=-EPERM -F auid>=1000 -F auid!=4294967295 -k my_unsuccessful_file_operations
--a always,exit -F arch=b32 -S creat -F exit=-EACCES -F auid>=1000 -F auid!=4294967295 -k my_unsuccessful_file_operations
+-a exit,always -F arch=b64 -S creat -F exit=-EPERM -F auid>=1000 -F auid!=4294967295 -k my_unsuccessful_file_operations
+-a exit,always -F arch=b64 -S creat -F exit=-EACCES -F auid>=1000 -F auid!=4294967295 -k my_unsuccessful_file_operations
+-a exit,always -F arch=b32 -S creat -F exit=-EPERM -F auid>=1000 -F auid!=4294967295 -k my_unsuccessful_file_operations
+-a exit,always -F arch=b32 -S creat -F exit=-EACCES -F auid>=1000 -F auid!=4294967295 -k my_unsuccessful_file_operations
 
--a always,exit -F arch=b64 -S open -F exit=-EPERM -F auid>=1000 -F auid!=4294967295 -k my_unsuccessful_file_operations
--a always,exit -F arch=b64 -S open -F exit=-EACCES -F auid>=1000 -F auid!=4294967295 -k my_unsuccessful_file_operations
--a always,exit -F arch=b32 -S open -F exit=-EPERM -F auid>=1000 -F auid!=4294967295 -k my_unsuccessful_file_operations
--a always,exit -F arch=b32 -S open -F exit=-EACCES -F auid>=1000 -F auid!=4294967295 -k my_unsuccessful_file_operations
+-a exit,always -F arch=b64 -S open -F exit=-EPERM -F auid>=1000 -F auid!=4294967295 -k my_unsuccessful_file_operations
+-a exit,always -F arch=b64 -S open -F exit=-EACCES -F auid>=1000 -F auid!=4294967295 -k my_unsuccessful_file_operations
+-a exit,always -F arch=b32 -S open -F exit=-EPERM -F auid>=1000 -F auid!=4294967295 -k my_unsuccessful_file_operations
+-a exit,always -F arch=b32 -S open -F exit=-EACCES -F auid>=1000 -F auid!=4294967295 -k my_unsuccessful_file_operations
 
--a always,exit -F arch=b64 -S openat -F exit=-EPERM -F auid>=1000 -F auid!=4294967295 -k my_unsuccessful_file_operations
--a always,exit -F arch=b64 -S openat -F exit=-EACCES -F auid>=1000 -F auid!=4294967295 -k my_unsuccessful_file_operations
--a always,exit -F arch=b32 -S openat -F exit=-EPERM -F auid>=1000 -F auid!=4294967295 -k my_unsuccessful_file_operations
--a always,exit -F arch=b32 -S openat -F exit=-EACCES -F auid>=1000 -F auid!=4294967295 -k my_unsuccessful_file_operations
+-a exit,always -F arch=b64 -S openat -F exit=-EPERM -F auid>=1000 -F auid!=4294967295 -k my_unsuccessful_file_operations
+-a exit,always -F arch=b64 -S openat -F exit=-EACCES -F auid>=1000 -F auid!=4294967295 -k my_unsuccessful_file_operations
+-a exit,always -F arch=b32 -S openat -F exit=-EPERM -F auid>=1000 -F auid!=4294967295 -k my_unsuccessful_file_operations
+-a exit,always -F arch=b32 -S openat -F exit=-EACCES -F auid>=1000 -F auid!=4294967295 -k my_unsuccessful_file_operations
 
--a always,exit -F arch=b64 -S open_by_handle_at -F exit=-EPERM -F auid>=1000 -F auid!=4294967295 -k my_unsuccessful_file_operations
--a always,exit -F arch=b64 -S open_by_handle_at -F exit=-EACCES -F auid>=1000 -F auid!=4294967295 -k my_unsuccessful_file_operations
--a always,exit -F arch=b32 -S open_by_handle_at -F exit=-EPERM -F auid>=1000 -F auid!=4294967295 -k my_unsuccessful_file_operations
--a always,exit -F arch=b32 -S open_by_handle_at -F exit=-EACCES -F auid>=1000 -F auid!=4294967295 -k my_unsuccessful_file_operations
+-a exit,always -F arch=b64 -S open_by_handle_at -F exit=-EPERM -F auid>=1000 -F auid!=4294967295 -k my_unsuccessful_file_operations
+-a exit,always -F arch=b64 -S open_by_handle_at -F exit=-EACCES -F auid>=1000 -F auid!=4294967295 -k my_unsuccessful_file_operations
+-a exit,always -F arch=b32 -S open_by_handle_at -F exit=-EPERM -F auid>=1000 -F auid!=4294967295 -k my_unsuccessful_file_operations
+-a exit,always -F arch=b32 -S open_by_handle_at -F exit=-EACCES -F auid>=1000 -F auid!=4294967295 -k my_unsuccessful_file_operations
 
--a always,exit -F arch=b64 -S truncate -F exit=-EPERM -F auid>=1000 -F auid!=4294967295 -k my_unsuccessful_file_operations
--a always,exit -F arch=b64 -S truncate -F exit=-EACCES -F auid>=1000 -F auid!=4294967295 -k my_unsuccessful_file_operations
--a always,exit -F arch=b32 -S truncate -F exit=-EPERM -F auid>=1000 -F auid!=4294967295 -k my_unsuccessful_file_operations
--a always,exit -F arch=b32 -S truncate -F exit=-EACCES -F auid>=1000 -F auid!=4294967295 -k my_unsuccessful_file_operations
+-a exit,always -F arch=b64 -S truncate -F exit=-EPERM -F auid>=1000 -F auid!=4294967295 -k my_unsuccessful_file_operations
+-a exit,always -F arch=b64 -S truncate -F exit=-EACCES -F auid>=1000 -F auid!=4294967295 -k my_unsuccessful_file_operations
+-a exit,always -F arch=b32 -S truncate -F exit=-EPERM -F auid>=1000 -F auid!=4294967295 -k my_unsuccessful_file_operations
+-a exit,always -F arch=b32 -S truncate -F exit=-EACCES -F auid>=1000 -F auid!=4294967295 -k my_unsuccessful_file_operations
 
--a always,exit -F arch=b64 -S ftruncate -F exit=-EPERM -F auid>=1000 -F auid!=4294967295 -k my_unsuccessful_file_operations
--a always,exit -F arch=b64 -S ftruncate -F exit=-EACCES -F auid>=1000 -F auid!=4294967295 -k my_unsuccessful_file_operations
--a always,exit -F arch=b32 -S ftruncate -F exit=-EPERM -F auid>=1000 -F auid!=4294967295 -k my_unsuccessful_file_operations
--a always,exit -F arch=b32 -S ftruncate -F exit=-EACCES -F auid>=1000 -F auid!=4294967295 -k my_unsuccessful_file_operations
+-a exit,always -F arch=b64 -S ftruncate -F exit=-EPERM -F auid>=1000 -F auid!=4294967295 -k my_unsuccessful_file_operations
+-a exit,always -F arch=b64 -S ftruncate -F exit=-EACCES -F auid>=1000 -F auid!=4294967295 -k my_unsuccessful_file_operations
+-a exit,always -F arch=b32 -S ftruncate -F exit=-EPERM -F auid>=1000 -F auid!=4294967295 -k my_unsuccessful_file_operations
+-a exit,always -F arch=b32 -S ftruncate -F exit=-EACCES -F auid>=1000 -F auid!=4294967295 -k my_unsuccessful_file_operations
 
 ## Audit the execution of password commands
--a always,exit -F path=/usr/bin/passwd -F perm=x -F auid>=1000 -F auid!=4294967295 -k my_passwd_cmds
--a always,exit -F path=/bin/passwd -F perm=x -F auid>=1000 -F auid!=4294967295 -k my_passwd_cmds
+-a exit,always -F path=/usr/bin/passwd -F perm=x -F auid>=1000 -F auid!=4294967295 -k my_passwd_cmds
+-a exit,always -F path=/bin/passwd -F perm=x -F auid>=1000 -F auid!=4294967295 -k my_passwd_cmds
 
--a always,exit -F path=/usr/sbin/unix_chkpwd -F perm=x -F auid>=1000 -F auid!=4294967295 -k my_passwd_cmds
--a always,exit -F path=/sbin/unix_chkpwd -F perm=x -F auid>=1000 -F auid!=4294967295 -k my_passwd_cmds
+-a exit,always -F path=/usr/sbin/unix_chkpwd -F perm=x -F auid>=1000 -F auid!=4294967295 -k my_passwd_cmds
+-a exit,always -F path=/sbin/unix_chkpwd -F perm=x -F auid>=1000 -F auid!=4294967295 -k my_passwd_cmds
 
--a always,exit -F path=/usr/bin/gpasswd -F perm=x -F auid>=1000 -F auid!=4294967295 -k my_passwd_cmds
--a always,exit -F path=/bin/gpasswd -F perm=x -F auid>=1000 -F auid!=4294967295 -k my_passwd_cmds
+-a exit,always -F path=/usr/bin/gpasswd -F perm=x -F auid>=1000 -F auid!=4294967295 -k my_passwd_cmds
+-a exit,always -F path=/bin/gpasswd -F perm=x -F auid>=1000 -F auid!=4294967295 -k my_passwd_cmds
 
--a always,exit -F path=/usr/bin/chage -F perm=x -F auid>=1000 -F auid!=4294967295 -k my_passwd_cmds
--a always,exit -F path=/bin/chage -F perm=x -F auid>=1000 -F auid!=4294967295 -k my_passwd_cmds
+-a exit,always -F path=/usr/bin/chage -F perm=x -F auid>=1000 -F auid!=4294967295 -k my_passwd_cmds
+-a exit,always -F path=/bin/chage -F perm=x -F auid>=1000 -F auid!=4294967295 -k my_passwd_cmds
 
--a always,exit -F path=/usr/sbin/userhelper -F perm=x -F auid>=1000 -F auid!=4294967295 -k my_passwd_cmds
--a always,exit -F path=/sbin/userhelper -F perm=x -F auid>=1000 -F auid!=4294967295 -k my_passwd_cmds
+-a exit,always -F path=/usr/sbin/userhelper -F perm=x -F auid>=1000 -F auid!=4294967295 -k my_passwd_cmds
+-a exit,always -F path=/sbin/userhelper -F perm=x -F auid>=1000 -F auid!=4294967295 -k my_passwd_cmds
 
 ## Audit the execution of privilege-related commands
--a always,exit -F path=/usr/bin/su -F perm=x -F auid>=1000 -F auid!=4294967295 -k my_priv_cmds
--a always,exit -F path=/bin/su -F perm=x -F auid>=1000 -F auid!=4294967295 -k my_priv_cmds
+-a exit,always -F path=/usr/bin/su -F perm=x -F auid>=1000 -F auid!=4294967295 -k my_priv_cmds
+-a exit,always -F path=/bin/su -F perm=x -F auid>=1000 -F auid!=4294967295 -k my_priv_cmds
 
--a always,exit -F path=/usr/bin/sudo -F perm=x -F auid>=1000 -F auid!=4294967295 -k my_priv_cmds
--a always,exit -F path=/bin/sudo -F perm=x -F auid>=1000 -F auid!=4294967295 -k my_priv_cmds
+-a exit,always -F path=/usr/bin/sudo -F perm=x -F auid>=1000 -F auid!=4294967295 -k my_priv_cmds
+-a exit,always -F path=/bin/sudo -F perm=x -F auid>=1000 -F auid!=4294967295 -k my_priv_cmds
 
--a always,exit -F path=/usr/bin/newgrp -F perm=x -F auid>=1000 -F auid!=4294967295 -k my_priv_cmds
--a always,exit -F path=/bin/newgrp -F perm=x -F auid>=1000 -F auid!=4294967295 -k my_priv_cmds
+-a exit,always -F path=/usr/bin/newgrp -F perm=x -F auid>=1000 -F auid!=4294967295 -k my_priv_cmds
+-a exit,always -F path=/bin/newgrp -F perm=x -F auid>=1000 -F auid!=4294967295 -k my_priv_cmds
 
--a always,exit -F path=/usr/bin/chsh -F perm=x -F auid>=1000 -F auid!=4294967295 -k my_priv_cmds
--a always,exit -F path=/bin/chsh -F perm=x -F auid>=1000 -F auid!=4294967295 -k my_priv_cmds
+-a exit,always -F path=/usr/bin/chsh -F perm=x -F auid>=1000 -F auid!=4294967295 -k my_priv_cmds
+-a exit,always -F path=/bin/chsh -F perm=x -F auid>=1000 -F auid!=4294967295 -k my_priv_cmds
 
--a always,exit -F path=/usr/bin/sudoedit -F perm=x -F auid>=1000 -F auid!=4294967295 -k my_priv_cmds
--a always,exit -F path=/bin/sudoedit -F perm=x -F auid>=1000 -F auid!=4294967295 -k my_priv_cmds
+-a exit,always -F path=/usr/bin/sudoedit -F perm=x -F auid>=1000 -F auid!=4294967295 -k my_priv_cmds
+-a exit,always -F path=/bin/sudoedit -F perm=x -F auid>=1000 -F auid!=4294967295 -k my_priv_cmds
 
 ## Audit the execution of postfix-related commands
--a always,exit -F path=/usr/sbin/postdrop -F perm=x -F auid>=1000 -F auid!=4294967295 -k my_postfix_cmds
--a always,exit -F path=/sbin/postdrop -F perm=x -F auid>=1000 -F auid!=4294967295 -k my_postfix_cmds
+-a exit,always -F path=/usr/sbin/postdrop -F perm=x -F auid>=1000 -F auid!=4294967295 -k my_postfix_cmds
+-a exit,always -F path=/sbin/postdrop -F perm=x -F auid>=1000 -F auid!=4294967295 -k my_postfix_cmds
 
--a always,exit -F path=/usr/sbin/postqueue -F perm=x -F auid>=1000 -F auid!=4294967295 -k my_postfix_cmds
--a always,exit -F path=/sbin/postqueue -F perm=x -F auid>=1000 -F auid!=4294967295 -k my_postfix_cmds
+-a exit,always -F path=/usr/sbin/postqueue -F perm=x -F auid>=1000 -F auid!=4294967295 -k my_postfix_cmds
+-a exit,always -F path=/sbin/postqueue -F perm=x -F auid>=1000 -F auid!=4294967295 -k my_postfix_cmds
 
 ## Audit the execution of the ssh-keysign command
--a always,exit -F path=/usr/libexec/openssh/ssh-keysign -F perm=x -F auid>=1000 -F auid!=4294967295 -k my_ssh_keysign_cmd
+-a exit,always -F path=/usr/libexec/openssh/ssh-keysign -F perm=x -F auid>=1000 -F auid!=4294967295 -k my_ssh_keysign_cmd
 
 ## Audit the execution of the crontab command
--a always,exit -F path=/usr/bin/crontab -F perm=x -F auid>=1000 -F auid!=4294967295 -k my_crontab
--a always,exit -F path=/bin/crontab -F perm=x -F auid>=1000 -F auid!=4294967295 -k my_crontab
+-a exit,always -F path=/usr/bin/crontab -F perm=x -F auid>=1000 -F auid!=4294967295 -k my_crontab
+-a exit,always -F path=/bin/crontab -F perm=x -F auid>=1000 -F auid!=4294967295 -k my_crontab
 
 ## Audit the execution of the pam_timestamp_check command
--a always,exit -F path=/usr/sbin/pam_timestamp_check -F perm=x -F auid>=1000 -F auid!=4294967295 -k my_pam_timestamp_check_cmd
--a always,exit -F path=/sbin/pam_timestamp_check -F perm=x -F auid>=1000 -F auid!=4294967295 -k my_pam_timestamp_check_cmd
+-a exit,always -F path=/usr/sbin/pam_timestamp_check -F perm=x -F auid>=1000 -F auid!=4294967295 -k my_pam_timestamp_check_cmd
+-a exit,always -F path=/sbin/pam_timestamp_check -F perm=x -F auid>=1000 -F auid!=4294967295 -k my_pam_timestamp_check_cmd
 
 ## Audit selinux commands
--a always,exit -F path=/usr/sbin/semanage -F perm=x -F auid>=1000 -F auid!=4294967295 -k my_selinux_cmds
--a always,exit -F path=/sbin/semanage -F perm=x -F auid>=1000 -F auid!=4294967295 -k my_selinux_cmds
+-a exit,always -F path=/usr/sbin/semanage -F perm=x -F auid>=1000 -F auid!=4294967295 -k my_selinux_cmds
+-a exit,always -F path=/sbin/semanage -F perm=x -F auid>=1000 -F auid!=4294967295 -k my_selinux_cmds
 
--a always,exit -F path=/usr/sbin/setsebool -F perm=x -F auid>=1000 -F auid!=4294967295 -k my_selinux_cmds
--a always,exit -F path=/sbin/setsebool -F perm=x -F auid>=1000 -F auid!=4294967295 -k my_selinux_cmds
+-a exit,always -F path=/usr/sbin/setsebool -F perm=x -F auid>=1000 -F auid!=4294967295 -k my_selinux_cmds
+-a exit,always -F path=/sbin/setsebool -F perm=x -F auid>=1000 -F auid!=4294967295 -k my_selinux_cmds
 
--a always,exit -F path=/usr/bin/chcon -F perm=x -F auid>=1000 -F auid!=4294967295 -k my_selinux_cmds
--a always,exit -F path=/bin/chcon -F perm=x -F auid>=1000 -F auid!=4294967295 -k my_selinux_cmds
+-a exit,always -F path=/usr/bin/chcon -F perm=x -F auid>=1000 -F auid!=4294967295 -k my_selinux_cmds
+-a exit,always -F path=/bin/chcon -F perm=x -F auid>=1000 -F auid!=4294967295 -k my_selinux_cmds
 
--a always,exit -F path=/usr/sbin/setfiles -F perm=x -F auid>=1000 -F auid!=4294967295 -k my_selinux_cmds
--a always,exit -F path=/sbin/setfiles -F perm=x -F auid>=1000 -F auid!=4294967295 -k my_selinux_cmds
+-a exit,always -F path=/usr/sbin/setfiles -F perm=x -F auid>=1000 -F auid!=4294967295 -k my_selinux_cmds
+-a exit,always -F path=/sbin/setfiles -F perm=x -F auid>=1000 -F auid!=4294967295 -k my_selinux_cmds
 
--a always,exit -F path=/sbin/restorecon -F perm=x -F auid>=1000 -F auid!=4294967295 -k my_selinux_cmds
--a always,exit -F path=/usr/sbin/restorecon -F perm=x -F auid>=1000 -F auid!=4294967295 -k my_selinux_cmds
+-a exit,always -F path=/sbin/restorecon -F perm=x -F auid>=1000 -F auid!=4294967295 -k my_selinux_cmds
+-a exit,always -F path=/usr/sbin/restorecon -F perm=x -F auid>=1000 -F auid!=4294967295 -k my_selinux_cmds
 
 ## Permissions auditing separated by chown, chmod, and attr
--a always,exit -F arch=b64 -S chown -F auid>=1000 -F auid!=4294967295 -k my_chown
--a always,exit -F arch=b32 -S chown -F auid>=1000 -F auid!=4294967295 -k my_chown
+-a exit,always -F arch=b64 -S chown -F auid>=1000 -F auid!=4294967295 -k my_chown
+-a exit,always -F arch=b32 -S chown -F auid>=1000 -F auid!=4294967295 -k my_chown
 
--a always,exit -F arch=b64 -S fchown -F auid>=1000 -F auid!=4294967295 -k my_chown
--a always,exit -F arch=b32 -S fchown -F auid>=1000 -F auid!=4294967295 -k my_chown
+-a exit,always -F arch=b64 -S fchown -F auid>=1000 -F auid!=4294967295 -k my_chown
+-a exit,always -F arch=b32 -S fchown -F auid>=1000 -F auid!=4294967295 -k my_chown
 
--a always,exit -F arch=b64 -S lchown -F auid>=1000 -F auid!=4294967295 -k my_chown
--a always,exit -F arch=b32 -S lchown -F auid>=1000 -F auid!=4294967295 -k my_chown
+-a exit,always -F arch=b64 -S lchown -F auid>=1000 -F auid!=4294967295 -k my_chown
+-a exit,always -F arch=b32 -S lchown -F auid>=1000 -F auid!=4294967295 -k my_chown
 
--a always,exit -F arch=b64 -S fchownat -F auid>=1000 -F auid!=4294967295 -k my_chown
--a always,exit -F arch=b32 -S fchownat -F auid>=1000 -F auid!=4294967295 -k my_chown
+-a exit,always -F arch=b64 -S fchownat -F auid>=1000 -F auid!=4294967295 -k my_chown
+-a exit,always -F arch=b32 -S fchownat -F auid>=1000 -F auid!=4294967295 -k my_chown
 
--a always,exit -F arch=b64 -S chmod -F auid>=1000 -F auid!=4294967295 -k my_chmod
--a always,exit -F arch=b32 -S chmod -F auid>=1000 -F auid!=4294967295 -k my_chmod
+-a exit,always -F arch=b64 -S chmod -F auid>=1000 -F auid!=4294967295 -k my_chmod
+-a exit,always -F arch=b32 -S chmod -F auid>=1000 -F auid!=4294967295 -k my_chmod
 
--a always,exit -F arch=b64 -S fchmod -F auid>=1000 -F auid!=4294967295 -k my_chmod
--a always,exit -F arch=b32 -S fchmod -F auid>=1000 -F auid!=4294967295 -k my_chmod
+-a exit,always -F arch=b64 -S fchmod -F auid>=1000 -F auid!=4294967295 -k my_chmod
+-a exit,always -F arch=b32 -S fchmod -F auid>=1000 -F auid!=4294967295 -k my_chmod
 
--a always,exit -F arch=b64 -S fchmodat -F auid>=1000 -F auid!=4294967295 -k my_chmod
--a always,exit -F arch=b32 -S fchmodat -F auid>=1000 -F auid!=4294967295 -k my_chmod
+-a exit,always -F arch=b64 -S fchmodat -F auid>=1000 -F auid!=4294967295 -k my_chmod
+-a exit,always -F arch=b32 -S fchmodat -F auid>=1000 -F auid!=4294967295 -k my_chmod
 
--a always,exit -F arch=b64 -S setxattr -F auid>=1000 -F auid!=4294967295 -k my_attr
--a always,exit -F arch=b32 -S setxattr -F auid>=1000 -F auid!=4294967295 -k my_attr
+-a exit,always -F arch=b64 -S setxattr -F auid>=1000 -F auid!=4294967295 -k my_attr
+-a exit,always -F arch=b32 -S setxattr -F auid>=1000 -F auid!=4294967295 -k my_attr
 
--a always,exit -F arch=b64 -S fsetxattr -F auid>=1000 -F auid!=4294967295 -k my_attr
--a always,exit -F arch=b32 -S fsetxattr -F auid>=1000 -F auid!=4294967295 -k my_attr
+-a exit,always -F arch=b64 -S fsetxattr -F auid>=1000 -F auid!=4294967295 -k my_attr
+-a exit,always -F arch=b32 -S fsetxattr -F auid>=1000 -F auid!=4294967295 -k my_attr
 
--a always,exit -F arch=b64 -S lsetxattr -F auid>=1000 -F auid!=4294967295 -k my_attr
--a always,exit -F arch=b32 -S lsetxattr -F auid>=1000 -F auid!=4294967295 -k my_attr
+-a exit,always -F arch=b64 -S lsetxattr -F auid>=1000 -F auid!=4294967295 -k my_attr
+-a exit,always -F arch=b32 -S lsetxattr -F auid>=1000 -F auid!=4294967295 -k my_attr
 
--a always,exit -F arch=b64 -S removexattr -F auid>=1000 -F auid!=4294967295 -k my_attr
--a always,exit -F arch=b32 -S removexattr -F auid>=1000 -F auid!=4294967295 -k my_attr
+-a exit,always -F arch=b64 -S removexattr -F auid>=1000 -F auid!=4294967295 -k my_attr
+-a exit,always -F arch=b32 -S removexattr -F auid>=1000 -F auid!=4294967295 -k my_attr
 
--a always,exit -F arch=b64 -S fremovexattr -F auid>=1000 -F auid!=4294967295 -k my_attr
--a always,exit -F arch=b32 -S fremovexattr -F auid>=1000 -F auid!=4294967295 -k my_attr
+-a exit,always -F arch=b64 -S fremovexattr -F auid>=1000 -F auid!=4294967295 -k my_attr
+-a exit,always -F arch=b32 -S fremovexattr -F auid>=1000 -F auid!=4294967295 -k my_attr
 
--a always,exit -F arch=b64 -S lremovexattr -F auid>=1000 -F auid!=4294967295 -k my_attr
--a always,exit -F arch=b32 -S lremovexattr -F auid>=1000 -F auid!=4294967295 -k my_attr
+-a exit,always -F arch=b64 -S lremovexattr -F auid>=1000 -F auid!=4294967295 -k my_attr
+-a exit,always -F arch=b32 -S lremovexattr -F auid>=1000 -F auid!=4294967295 -k my_attr
 
 ## Audit rename/removal operations
--a always,exit -F arch=b64 -S rename -F perm=x -F auid>=1000 -F auid!=4294967295 -k my_rename_remove
--a always,exit -F arch=b32 -S rename -F perm=x -F auid>=1000 -F auid!=4294967295 -k my_rename_remove
+-a exit,always -F arch=b64 -S rename -F perm=x -F auid>=1000 -F auid!=4294967295 -k my_rename_remove
+-a exit,always -F arch=b32 -S rename -F perm=x -F auid>=1000 -F auid!=4294967295 -k my_rename_remove
 
--a always,exit -F arch=b64 -S renameat -F perm=x -F auid>=1000 -F auid!=4294967295 -k my_rename_remove
--a always,exit -F arch=b32 -S renameat -F perm=x -F auid>=1000 -F auid!=4294967295 -k my_rename_remove
+-a exit,always -F arch=b64 -S renameat -F perm=x -F auid>=1000 -F auid!=4294967295 -k my_rename_remove
+-a exit,always -F arch=b32 -S renameat -F perm=x -F auid>=1000 -F auid!=4294967295 -k my_rename_remove
 
--a always,exit -F arch=b64 -S rmdir -F perm=x -F auid>=1000 -F auid!=4294967295 -k my_rename_remove
--a always,exit -F arch=b32 -S rmdir -F perm=x -F auid>=1000 -F auid!=4294967295 -k my_rename_remove
+-a exit,always -F arch=b64 -S rmdir -F perm=x -F auid>=1000 -F auid!=4294967295 -k my_rename_remove
+-a exit,always -F arch=b32 -S rmdir -F perm=x -F auid>=1000 -F auid!=4294967295 -k my_rename_remove
 
--a always,exit -F arch=b64 -S unlink -F perm=x -F auid>=1000 -F auid!=4294967295 -k my_rename_remove
--a always,exit -F arch=b32 -S unlink -F perm=x -F auid>=1000 -F auid!=4294967295 -k my_rename_remove
+-a exit,always -F arch=b64 -S unlink -F perm=x -F auid>=1000 -F auid!=4294967295 -k my_rename_remove
+-a exit,always -F arch=b32 -S unlink -F perm=x -F auid>=1000 -F auid!=4294967295 -k my_rename_remove
 
--a always,exit -F arch=b64 -S unlinkat -F perm=x -F auid>=1000 -F auid!=4294967295 -k my_rename_remove
--a always,exit -F arch=b32 -S unlinkat -F perm=x -F auid>=1000 -F auid!=4294967295 -k my_rename_remove
+-a exit,always -F arch=b64 -S unlinkat -F perm=x -F auid>=1000 -F auid!=4294967295 -k my_rename_remove
+-a exit,always -F arch=b32 -S unlinkat -F perm=x -F auid>=1000 -F auid!=4294967295 -k my_rename_remove
 
 ## Audit the execution of suid and sgid binaries.
--a always,exit -F path=/usr/bin/at -F perm=x -F auid>=1000 -F auid!=4294967295 -k my_suid_sgid
--a always,exit -F path=/usr/bin/chage -F perm=x -F auid>=1000 -F auid!=4294967295 -k my_suid_sgid
--a always,exit -F path=/usr/bin/chcon -F perm=x -F auid>=1000 -F auid!=4294967295 -k my_suid_sgid
--a always,exit -F path=/usr/bin/chfn -F perm=x -F auid>=1000 -F auid!=4294967295 -k my_suid_sgid
--a always,exit -F path=/usr/bin/chsh -F perm=x -F auid>=1000 -F auid!=4294967295 -k my_suid_sgid
--a always,exit -F path=/usr/bin/crontab -F perm=x -F auid>=1000 -F auid!=4294967295 -k my_suid_sgid
--a always,exit -F path=/usr/bin/fusermount -F perm=x -F auid>=1000 -F auid!=4294967295 -k my_suid_sgid
--a always,exit -F path=/usr/bin/gpasswd -F perm=x -F auid>=1000 -F auid!=4294967295 -k my_suid_sgid
--a always,exit -F path=/usr/bin/incrontab -F perm=x -F auid>=1000 -F auid!=4294967295 -k my_suid_sgid
--a always,exit -F path=/usr/bin/ksu -F perm=x -F auid>=1000 -F auid!=4294967295 -k my_suid_sgid
--a always,exit -F path=/usr/bin/locate -F perm=x -F auid>=1000 -F auid!=4294967295 -k my_suid_sgid
--a always,exit -F path=/usr/bin/mount -F perm=x -F auid>=1000 -F auid!=4294967295 -k my_suid_sgid
--a always,exit -F path=/usr/bin/newgidmap -F perm=x -F auid>=1000 -F auid!=4294967295 -k my_suid_sgid
--a always,exit -F path=/usr/bin/newgrp -F perm=x -F auid>=1000 -F auid!=4294967295 -k my_suid_sgid
--a always,exit -F path=/usr/bin/newuidmap -F perm=x -F auid>=1000 -F auid!=4294967295 -k my_suid_sgid
--a always,exit -F path=/usr/bin/passwd -F perm=x -F auid>=1000 -F auid!=4294967295 -k my_suid_sgid
--a always,exit -F path=/usr/bin/pkexec -F perm=x -F auid>=1000 -F auid!=4294967295 -k my_suid_sgid
--a always,exit -F path=/usr/bin/screen -F perm=x -F auid>=1000 -F auid!=4294967295 -k my_suid_sgid
--a always,exit -F path=/usr/bin/ssh-agent -F perm=x -F auid>=1000 -F auid!=4294967295 -k my_suid_sgid
--a always,exit -F path=/usr/bin/su -F perm=x -F auid>=1000 -F auid!=4294967295 -k my_suid_sgid
--a always,exit -F path=/usr/bin/sudo -F perm=x -F auid>=1000 -F auid!=4294967295 -k my_suid_sgid
--a always,exit -F path=/usr/bin/sudoedit -F perm=x -F auid>=1000 -F auid!=4294967295 -k my_suid_sgid
--a always,exit -F path=/usr/bin/umount -F perm=x -F auid>=1000 -F auid!=4294967295 -k my_suid_sgid
--a always,exit -F path=/usr/bin/wall -F perm=x -F auid>=1000 -F auid!=4294967295 -k my_suid_sgid
--a always,exit -F path=/usr/bin/write -F perm=x -F auid>=1000 -F auid!=4294967295 -k my_suid_sgid
--a always,exit -F path=/usr/bin/Xorg -F perm=x -F auid>=1000 -F auid!=4294967295 -k my_suid_sgid
--a always,exit -F path=/usr/lib64/dbus-1/dbus-daemon-launch-helper -F perm=x -F auid>=1000 -F auid!=4294967295 -k my_suid_sgid
--a always,exit -F path=/usr/libexec/dbus-1/dbus-daemon-launch-helper -F perm=x -F auid>=1000 -F auid!=4294967295 -k my_suid_sgid
--a always,exit -F path=/usr/libexec/openssh/ssh-keysign -F perm=x -F auid>=1000 -F auid!=4294967295 -k my_suid_sgid
--a always,exit -F path=/usr/libexec/pt_chown -F perm=x -F auid>=1000 -F auid!=4294967295 -k my_suid_sgid
--a always,exit -F path=/usr/libexec/sssd/krb5_child -F perm=x -F auid>=1000 -F auid!=4294967295 -k my_suid_sgid
--a always,exit -F path=/usr/libexec/sssd/ldap_child -F perm=x -F auid>=1000 -F auid!=4294967295 -k my_suid_sgid
--a always,exit -F path=/usr/libexec/sssd/proxy_child -F perm=x -F auid>=1000 -F auid!=4294967295 -k my_suid_sgid
--a always,exit -F path=/usr/libexec/sssd/selinux_child -F perm=x -F auid>=1000 -F auid!=4294967295 -k my_suid_sgid
--a always,exit -F path=/usr/libexec/utempter/utempter -F perm=x -F auid>=1000 -F auid!=4294967295 -k my_suid_sgid
--a always,exit -F path=/usr/lib/polkit-1/polkit-agent-helper-1 -F perm=x -F auid>=1000 -F auid!=4294967295 -k my_suid_sgid
--a always,exit -F path=/usr/sbin/mount.nfs -F perm=x -F auid>=1000 -F auid!=4294967295 -k my_suid_sgid
--a always,exit -F path=/usr/sbin/netreport -F perm=x -F auid>=1000 -F auid!=4294967295 -k my_suid_sgid
--a always,exit -F path=/usr/sbin/pam_timestamp_check -F perm=x -F auid>=1000 -F auid!=4294967295 -k my_suid_sgid
--a always,exit -F path=/usr/sbin/postdrop -F perm=x -F auid>=1000 -F auid!=4294967295 -k my_suid_sgid
--a always,exit -F path=/usr/sbin/postqueue -F perm=x -F auid>=1000 -F auid!=4294967295 -k my_suid_sgid
--a always,exit -F path=/usr/sbin/restorecon -F perm=x -F auid>=1000 -F auid!=4294967295 -k my_suid_sgid
--a always,exit -F path=/usr/sbin/semanage -F perm=x -F auid>=1000 -F auid!=4294967295 -k my_suid_sgid
--a always,exit -F path=/usr/sbin/setfiles -F perm=x -F auid>=1000 -F auid!=4294967295 -k my_suid_sgid
--a always,exit -F path=/usr/sbin/setsebool -F perm=x -F auid>=1000 -F auid!=4294967295 -k my_suid_sgid
--a always,exit -F path=/usr/sbin/seunshare -F perm=x -F auid>=1000 -F auid!=4294967295 -k my_suid_sgid
--a always,exit -F path=/usr/sbin/unix_chkpwd -F perm=x -F auid>=1000 -F auid!=4294967295 -k my_suid_sgid
--a always,exit -F path=/usr/sbin/userhelper -F perm=x -F auid>=1000 -F auid!=4294967295 -k my_suid_sgid
--a always,exit -F path=/usr/sbin/usernetctl -F perm=x -F auid>=1000 -F auid!=4294967295 -k my_suid_sgid
+-a exit,always -F path=/usr/bin/at -F perm=x -F auid>=1000 -F auid!=4294967295 -k my_suid_sgid
+-a exit,always -F path=/usr/bin/chage -F perm=x -F auid>=1000 -F auid!=4294967295 -k my_suid_sgid
+-a exit,always -F path=/usr/bin/chcon -F perm=x -F auid>=1000 -F auid!=4294967295 -k my_suid_sgid
+-a exit,always -F path=/usr/bin/chfn -F perm=x -F auid>=1000 -F auid!=4294967295 -k my_suid_sgid
+-a exit,always -F path=/usr/bin/chsh -F perm=x -F auid>=1000 -F auid!=4294967295 -k my_suid_sgid
+-a exit,always -F path=/usr/bin/crontab -F perm=x -F auid>=1000 -F auid!=4294967295 -k my_suid_sgid
+-a exit,always -F path=/usr/bin/fusermount -F perm=x -F auid>=1000 -F auid!=4294967295 -k my_suid_sgid
+-a exit,always -F path=/usr/bin/gpasswd -F perm=x -F auid>=1000 -F auid!=4294967295 -k my_suid_sgid
+-a exit,always -F path=/usr/bin/incrontab -F perm=x -F auid>=1000 -F auid!=4294967295 -k my_suid_sgid
+-a exit,always -F path=/usr/bin/ksu -F perm=x -F auid>=1000 -F auid!=4294967295 -k my_suid_sgid
+-a exit,always -F path=/usr/bin/locate -F perm=x -F auid>=1000 -F auid!=4294967295 -k my_suid_sgid
+-a exit,always -F path=/usr/bin/mount -F perm=x -F auid>=1000 -F auid!=4294967295 -k my_suid_sgid
+-a exit,always -F path=/usr/bin/newgidmap -F perm=x -F auid>=1000 -F auid!=4294967295 -k my_suid_sgid
+-a exit,always -F path=/usr/bin/newgrp -F perm=x -F auid>=1000 -F auid!=4294967295 -k my_suid_sgid
+-a exit,always -F path=/usr/bin/newuidmap -F perm=x -F auid>=1000 -F auid!=4294967295 -k my_suid_sgid
+-a exit,always -F path=/usr/bin/passwd -F perm=x -F auid>=1000 -F auid!=4294967295 -k my_suid_sgid
+-a exit,always -F path=/usr/bin/pkexec -F perm=x -F auid>=1000 -F auid!=4294967295 -k my_suid_sgid
+-a exit,always -F path=/usr/bin/screen -F perm=x -F auid>=1000 -F auid!=4294967295 -k my_suid_sgid
+-a exit,always -F path=/usr/bin/ssh-agent -F perm=x -F auid>=1000 -F auid!=4294967295 -k my_suid_sgid
+-a exit,always -F path=/usr/bin/su -F perm=x -F auid>=1000 -F auid!=4294967295 -k my_suid_sgid
+-a exit,always -F path=/usr/bin/sudo -F perm=x -F auid>=1000 -F auid!=4294967295 -k my_suid_sgid
+-a exit,always -F path=/usr/bin/sudoedit -F perm=x -F auid>=1000 -F auid!=4294967295 -k my_suid_sgid
+-a exit,always -F path=/usr/bin/umount -F perm=x -F auid>=1000 -F auid!=4294967295 -k my_suid_sgid
+-a exit,always -F path=/usr/bin/wall -F perm=x -F auid>=1000 -F auid!=4294967295 -k my_suid_sgid
+-a exit,always -F path=/usr/bin/write -F perm=x -F auid>=1000 -F auid!=4294967295 -k my_suid_sgid
+-a exit,always -F path=/usr/bin/Xorg -F perm=x -F auid>=1000 -F auid!=4294967295 -k my_suid_sgid
+-a exit,always -F path=/usr/lib64/dbus-1/dbus-daemon-launch-helper -F perm=x -F auid>=1000 -F auid!=4294967295 -k my_suid_sgid
+-a exit,always -F path=/usr/libexec/dbus-1/dbus-daemon-launch-helper -F perm=x -F auid>=1000 -F auid!=4294967295 -k my_suid_sgid
+-a exit,always -F path=/usr/libexec/openssh/ssh-keysign -F perm=x -F auid>=1000 -F auid!=4294967295 -k my_suid_sgid
+-a exit,always -F path=/usr/libexec/pt_chown -F perm=x -F auid>=1000 -F auid!=4294967295 -k my_suid_sgid
+-a exit,always -F path=/usr/libexec/sssd/krb5_child -F perm=x -F auid>=1000 -F auid!=4294967295 -k my_suid_sgid
+-a exit,always -F path=/usr/libexec/sssd/ldap_child -F perm=x -F auid>=1000 -F auid!=4294967295 -k my_suid_sgid
+-a exit,always -F path=/usr/libexec/sssd/proxy_child -F perm=x -F auid>=1000 -F auid!=4294967295 -k my_suid_sgid
+-a exit,always -F path=/usr/libexec/sssd/selinux_child -F perm=x -F auid>=1000 -F auid!=4294967295 -k my_suid_sgid
+-a exit,always -F path=/usr/libexec/utempter/utempter -F perm=x -F auid>=1000 -F auid!=4294967295 -k my_suid_sgid
+-a exit,always -F path=/usr/lib/polkit-1/polkit-agent-helper-1 -F perm=x -F auid>=1000 -F auid!=4294967295 -k my_suid_sgid
+-a exit,always -F path=/usr/sbin/mount.nfs -F perm=x -F auid>=1000 -F auid!=4294967295 -k my_suid_sgid
+-a exit,always -F path=/usr/sbin/netreport -F perm=x -F auid>=1000 -F auid!=4294967295 -k my_suid_sgid
+-a exit,always -F path=/usr/sbin/pam_timestamp_check -F perm=x -F auid>=1000 -F auid!=4294967295 -k my_suid_sgid
+-a exit,always -F path=/usr/sbin/postdrop -F perm=x -F auid>=1000 -F auid!=4294967295 -k my_suid_sgid
+-a exit,always -F path=/usr/sbin/postqueue -F perm=x -F auid>=1000 -F auid!=4294967295 -k my_suid_sgid
+-a exit,always -F path=/usr/sbin/restorecon -F perm=x -F auid>=1000 -F auid!=4294967295 -k my_suid_sgid
+-a exit,always -F path=/usr/sbin/semanage -F perm=x -F auid>=1000 -F auid!=4294967295 -k my_suid_sgid
+-a exit,always -F path=/usr/sbin/setfiles -F perm=x -F auid>=1000 -F auid!=4294967295 -k my_suid_sgid
+-a exit,always -F path=/usr/sbin/setsebool -F perm=x -F auid>=1000 -F auid!=4294967295 -k my_suid_sgid
+-a exit,always -F path=/usr/sbin/seunshare -F perm=x -F auid>=1000 -F auid!=4294967295 -k my_suid_sgid
+-a exit,always -F path=/usr/sbin/unix_chkpwd -F perm=x -F auid>=1000 -F auid!=4294967295 -k my_suid_sgid
+-a exit,always -F path=/usr/sbin/userhelper -F perm=x -F auid>=1000 -F auid!=4294967295 -k my_suid_sgid
+-a exit,always -F path=/usr/sbin/usernetctl -F perm=x -F auid>=1000 -F auid!=4294967295 -k my_suid_sgid
 
 ## Audit the loading and unloading of kernel modules.
 -w /usr/sbin/insmod -p x -F auid!=4294967295 -k my_kernel_modules
@@ -214,28 +214,28 @@
 -w /usr/sbin/modprobe -p x -F auid!=4294967295 -k my_kernel_modules
 -w /sbin/modprobe -p x -F auid!=4294967295 -k my_kernel_modules
 
--a always,exit -F arch=b64 -S create_module -k my_kernel_modules
--a always,exit -F arch=b32 -S create_module -k my_kernel_modules
+-a exit,always -F arch=b64 -S create_module -k my_kernel_modules
+-a exit,always -F arch=b32 -S create_module -k my_kernel_modules
 
--a always,exit -F arch=b64 -S init_module -k my_kernel_modules
--a always,exit -F arch=b32 -S init_module -k my_kernel_modules
+-a exit,always -F arch=b64 -S init_module -k my_kernel_modules
+-a exit,always -F arch=b32 -S init_module -k my_kernel_modules
 
--a always,exit -F arch=b64 -S finit_module -k my_kernel_modules
--a always,exit -F arch=b32 -S finit_module -k my_kernel_modules
+-a exit,always -F arch=b64 -S finit_module -k my_kernel_modules
+-a exit,always -F arch=b32 -S finit_module -k my_kernel_modules
 
--a always,exit -F arch=b64 -S delete_module -k my_kernel_modules
--a always,exit -F arch=b32 -S delete_module -k my_kernel_modules
+-a exit,always -F arch=b64 -S delete_module -k my_kernel_modules
+-a exit,always -F arch=b32 -S delete_module -k my_kernel_modules
 
 ## Audit mount operations
--a always,exit -F arch=b64 -S mount -F auid>=1000 -F auid!=4294967295 -k my_mount
--a always,exit -F arch=b64 -F path=/usr/bin/mount -F auid>=1000 -F auid!=4294967295 -k my_mount
--a always,exit -F arch=b64 -F path=/bin/mount -F auid>=1000 -F auid!=4294967295 -k my_mount
--a always,exit -F arch=b32 -S mount -F auid>=1000 -F auid!=4294967295 -k my_mount
--a always,exit -F arch=b32 -F path=/usr/bin/mount -F auid>=1000 -F auid!=4294967295 -k my_mount
--a always,exit -F arch=b32 -F path=/bin/mount -F auid>=1000 -F auid!=4294967295 -k my_mount
+-a exit,always -F arch=b64 -S mount -F auid>=1000 -F auid!=4294967295 -k my_mount
+-a exit,always -F arch=b64 -F path=/usr/bin/mount -F auid>=1000 -F auid!=4294967295 -k my_mount
+-a exit,always -F arch=b64 -F path=/bin/mount -F auid>=1000 -F auid!=4294967295 -k my_mount
+-a exit,always -F arch=b32 -S mount -F auid>=1000 -F auid!=4294967295 -k my_mount
+-a exit,always -F arch=b32 -F path=/usr/bin/mount -F auid>=1000 -F auid!=4294967295 -k my_mount
+-a exit,always -F arch=b32 -F path=/bin/mount -F auid>=1000 -F auid!=4294967295 -k my_mount
 
--a always,exit -F path=/usr/bin/umount -F perm=x -F auid>=1000 -F auid!=4294967295 -k my_mount
--a always,exit -F path=/bin/umount -F perm=x -F auid>=1000 -F auid!=4294967295 -k my_mount
+-a exit,always -F path=/usr/bin/umount -F perm=x -F auid>=1000 -F auid!=4294967295 -k my_mount
+-a exit,always -F path=/bin/umount -F perm=x -F auid>=1000 -F auid!=4294967295 -k my_mount
 
 ## Audit local accounts
 -w /etc/passwd -p wa -k my_local_account

--- a/spec/classes/config/audit_profiles/expected/stig_el7_base_rules.txt
+++ b/spec/classes/config/audit_profiles/expected/stig_el7_base_rules.txt
@@ -1,208 +1,208 @@
 #### auditd::config::audit_profiles::stig Audit Rules ####
 
 ## Audit unsuccessful file operations
--a always,exit -F arch=b64 -S creat -F exit=-EPERM -F auid>=1000 -F auid!=4294967295 -k access
--a always,exit -F arch=b64 -S creat -F exit=-EACCES -F auid>=1000 -F auid!=4294967295 -k access
--a always,exit -F arch=b32 -S creat -F exit=-EPERM -F auid>=1000 -F auid!=4294967295 -k access
--a always,exit -F arch=b32 -S creat -F exit=-EACCES -F auid>=1000 -F auid!=4294967295 -k access
+-a exit,always -F arch=b64 -S creat -F exit=-EPERM -F auid>=1000 -F auid!=4294967295 -k access
+-a exit,always -F arch=b64 -S creat -F exit=-EACCES -F auid>=1000 -F auid!=4294967295 -k access
+-a exit,always -F arch=b32 -S creat -F exit=-EPERM -F auid>=1000 -F auid!=4294967295 -k access
+-a exit,always -F arch=b32 -S creat -F exit=-EACCES -F auid>=1000 -F auid!=4294967295 -k access
 
--a always,exit -F arch=b64 -S open -F exit=-EPERM -F auid>=1000 -F auid!=4294967295 -k access
--a always,exit -F arch=b64 -S open -F exit=-EACCES -F auid>=1000 -F auid!=4294967295 -k access
--a always,exit -F arch=b32 -S open -F exit=-EPERM -F auid>=1000 -F auid!=4294967295 -k access
--a always,exit -F arch=b32 -S open -F exit=-EACCES -F auid>=1000 -F auid!=4294967295 -k access
+-a exit,always -F arch=b64 -S open -F exit=-EPERM -F auid>=1000 -F auid!=4294967295 -k access
+-a exit,always -F arch=b64 -S open -F exit=-EACCES -F auid>=1000 -F auid!=4294967295 -k access
+-a exit,always -F arch=b32 -S open -F exit=-EPERM -F auid>=1000 -F auid!=4294967295 -k access
+-a exit,always -F arch=b32 -S open -F exit=-EACCES -F auid>=1000 -F auid!=4294967295 -k access
 
--a always,exit -F arch=b64 -S openat -F exit=-EPERM -F auid>=1000 -F auid!=4294967295 -k access
--a always,exit -F arch=b64 -S openat -F exit=-EACCES -F auid>=1000 -F auid!=4294967295 -k access
--a always,exit -F arch=b32 -S openat -F exit=-EPERM -F auid>=1000 -F auid!=4294967295 -k access
--a always,exit -F arch=b32 -S openat -F exit=-EACCES -F auid>=1000 -F auid!=4294967295 -k access
+-a exit,always -F arch=b64 -S openat -F exit=-EPERM -F auid>=1000 -F auid!=4294967295 -k access
+-a exit,always -F arch=b64 -S openat -F exit=-EACCES -F auid>=1000 -F auid!=4294967295 -k access
+-a exit,always -F arch=b32 -S openat -F exit=-EPERM -F auid>=1000 -F auid!=4294967295 -k access
+-a exit,always -F arch=b32 -S openat -F exit=-EACCES -F auid>=1000 -F auid!=4294967295 -k access
 
--a always,exit -F arch=b64 -S open_by_handle_at -F exit=-EPERM -F auid>=1000 -F auid!=4294967295 -k access
--a always,exit -F arch=b64 -S open_by_handle_at -F exit=-EACCES -F auid>=1000 -F auid!=4294967295 -k access
--a always,exit -F arch=b32 -S open_by_handle_at -F exit=-EPERM -F auid>=1000 -F auid!=4294967295 -k access
--a always,exit -F arch=b32 -S open_by_handle_at -F exit=-EACCES -F auid>=1000 -F auid!=4294967295 -k access
+-a exit,always -F arch=b64 -S open_by_handle_at -F exit=-EPERM -F auid>=1000 -F auid!=4294967295 -k access
+-a exit,always -F arch=b64 -S open_by_handle_at -F exit=-EACCES -F auid>=1000 -F auid!=4294967295 -k access
+-a exit,always -F arch=b32 -S open_by_handle_at -F exit=-EPERM -F auid>=1000 -F auid!=4294967295 -k access
+-a exit,always -F arch=b32 -S open_by_handle_at -F exit=-EACCES -F auid>=1000 -F auid!=4294967295 -k access
 
--a always,exit -F arch=b64 -S truncate -F exit=-EPERM -F auid>=1000 -F auid!=4294967295 -k access
--a always,exit -F arch=b64 -S truncate -F exit=-EACCES -F auid>=1000 -F auid!=4294967295 -k access
--a always,exit -F arch=b32 -S truncate -F exit=-EPERM -F auid>=1000 -F auid!=4294967295 -k access
--a always,exit -F arch=b32 -S truncate -F exit=-EACCES -F auid>=1000 -F auid!=4294967295 -k access
+-a exit,always -F arch=b64 -S truncate -F exit=-EPERM -F auid>=1000 -F auid!=4294967295 -k access
+-a exit,always -F arch=b64 -S truncate -F exit=-EACCES -F auid>=1000 -F auid!=4294967295 -k access
+-a exit,always -F arch=b32 -S truncate -F exit=-EPERM -F auid>=1000 -F auid!=4294967295 -k access
+-a exit,always -F arch=b32 -S truncate -F exit=-EACCES -F auid>=1000 -F auid!=4294967295 -k access
 
--a always,exit -F arch=b64 -S ftruncate -F exit=-EPERM -F auid>=1000 -F auid!=4294967295 -k access
--a always,exit -F arch=b64 -S ftruncate -F exit=-EACCES -F auid>=1000 -F auid!=4294967295 -k access
--a always,exit -F arch=b32 -S ftruncate -F exit=-EPERM -F auid>=1000 -F auid!=4294967295 -k access
--a always,exit -F arch=b32 -S ftruncate -F exit=-EACCES -F auid>=1000 -F auid!=4294967295 -k access
+-a exit,always -F arch=b64 -S ftruncate -F exit=-EPERM -F auid>=1000 -F auid!=4294967295 -k access
+-a exit,always -F arch=b64 -S ftruncate -F exit=-EACCES -F auid>=1000 -F auid!=4294967295 -k access
+-a exit,always -F arch=b32 -S ftruncate -F exit=-EPERM -F auid>=1000 -F auid!=4294967295 -k access
+-a exit,always -F arch=b32 -S ftruncate -F exit=-EACCES -F auid>=1000 -F auid!=4294967295 -k access
 
 ## Audit the execution of password commands
--a always,exit -F path=/usr/bin/passwd -F perm=x -F auid>=1000 -F auid!=4294967295 -k privileged-passwd
--a always,exit -F path=/bin/passwd -F perm=x -F auid>=1000 -F auid!=4294967295 -k privileged-passwd
+-a exit,always -F path=/usr/bin/passwd -F perm=x -F auid>=1000 -F auid!=4294967295 -k privileged-passwd
+-a exit,always -F path=/bin/passwd -F perm=x -F auid>=1000 -F auid!=4294967295 -k privileged-passwd
 
--a always,exit -F path=/usr/sbin/unix_chkpwd -F perm=x -F auid>=1000 -F auid!=4294967295 -k privileged-passwd
--a always,exit -F path=/sbin/unix_chkpwd -F perm=x -F auid>=1000 -F auid!=4294967295 -k privileged-passwd
+-a exit,always -F path=/usr/sbin/unix_chkpwd -F perm=x -F auid>=1000 -F auid!=4294967295 -k privileged-passwd
+-a exit,always -F path=/sbin/unix_chkpwd -F perm=x -F auid>=1000 -F auid!=4294967295 -k privileged-passwd
 
--a always,exit -F path=/usr/bin/gpasswd -F perm=x -F auid>=1000 -F auid!=4294967295 -k privileged-passwd
--a always,exit -F path=/bin/gpasswd -F perm=x -F auid>=1000 -F auid!=4294967295 -k privileged-passwd
+-a exit,always -F path=/usr/bin/gpasswd -F perm=x -F auid>=1000 -F auid!=4294967295 -k privileged-passwd
+-a exit,always -F path=/bin/gpasswd -F perm=x -F auid>=1000 -F auid!=4294967295 -k privileged-passwd
 
--a always,exit -F path=/usr/bin/chage -F perm=x -F auid>=1000 -F auid!=4294967295 -k privileged-passwd
--a always,exit -F path=/bin/chage -F perm=x -F auid>=1000 -F auid!=4294967295 -k privileged-passwd
+-a exit,always -F path=/usr/bin/chage -F perm=x -F auid>=1000 -F auid!=4294967295 -k privileged-passwd
+-a exit,always -F path=/bin/chage -F perm=x -F auid>=1000 -F auid!=4294967295 -k privileged-passwd
 
--a always,exit -F path=/usr/sbin/userhelper -F perm=x -F auid>=1000 -F auid!=4294967295 -k privileged-passwd
--a always,exit -F path=/sbin/userhelper -F perm=x -F auid>=1000 -F auid!=4294967295 -k privileged-passwd
+-a exit,always -F path=/usr/sbin/userhelper -F perm=x -F auid>=1000 -F auid!=4294967295 -k privileged-passwd
+-a exit,always -F path=/sbin/userhelper -F perm=x -F auid>=1000 -F auid!=4294967295 -k privileged-passwd
 
 ## Audit the execution of privilege-related commands
--a always,exit -F path=/usr/bin/su -F perm=x -F auid>=1000 -F auid!=4294967295 -k privileged-priv_change
--a always,exit -F path=/bin/su -F perm=x -F auid>=1000 -F auid!=4294967295 -k privileged-priv_change
+-a exit,always -F path=/usr/bin/su -F perm=x -F auid>=1000 -F auid!=4294967295 -k privileged-priv_change
+-a exit,always -F path=/bin/su -F perm=x -F auid>=1000 -F auid!=4294967295 -k privileged-priv_change
 
--a always,exit -F path=/usr/bin/sudo -F perm=x -F auid>=1000 -F auid!=4294967295 -k privileged-priv_change
--a always,exit -F path=/bin/sudo -F perm=x -F auid>=1000 -F auid!=4294967295 -k privileged-priv_change
+-a exit,always -F path=/usr/bin/sudo -F perm=x -F auid>=1000 -F auid!=4294967295 -k privileged-priv_change
+-a exit,always -F path=/bin/sudo -F perm=x -F auid>=1000 -F auid!=4294967295 -k privileged-priv_change
 
--a always,exit -F path=/usr/bin/newgrp -F perm=x -F auid>=1000 -F auid!=4294967295 -k privileged-priv_change
--a always,exit -F path=/bin/newgrp -F perm=x -F auid>=1000 -F auid!=4294967295 -k privileged-priv_change
+-a exit,always -F path=/usr/bin/newgrp -F perm=x -F auid>=1000 -F auid!=4294967295 -k privileged-priv_change
+-a exit,always -F path=/bin/newgrp -F perm=x -F auid>=1000 -F auid!=4294967295 -k privileged-priv_change
 
--a always,exit -F path=/usr/bin/chsh -F perm=x -F auid>=1000 -F auid!=4294967295 -k privileged-priv_change
--a always,exit -F path=/bin/chsh -F perm=x -F auid>=1000 -F auid!=4294967295 -k privileged-priv_change
+-a exit,always -F path=/usr/bin/chsh -F perm=x -F auid>=1000 -F auid!=4294967295 -k privileged-priv_change
+-a exit,always -F path=/bin/chsh -F perm=x -F auid>=1000 -F auid!=4294967295 -k privileged-priv_change
 
--a always,exit -F path=/usr/bin/sudoedit -F perm=x -F auid>=1000 -F auid!=4294967295 -k privileged-priv_change
--a always,exit -F path=/bin/sudoedit -F perm=x -F auid>=1000 -F auid!=4294967295 -k privileged-priv_change
+-a exit,always -F path=/usr/bin/sudoedit -F perm=x -F auid>=1000 -F auid!=4294967295 -k privileged-priv_change
+-a exit,always -F path=/bin/sudoedit -F perm=x -F auid>=1000 -F auid!=4294967295 -k privileged-priv_change
 
 ## Audit the execution of postfix-related commands
--a always,exit -F path=/usr/sbin/postdrop -F perm=x -F auid>=1000 -F auid!=4294967295 -k privileged-postfix
--a always,exit -F path=/sbin/postdrop -F perm=x -F auid>=1000 -F auid!=4294967295 -k privileged-postfix
+-a exit,always -F path=/usr/sbin/postdrop -F perm=x -F auid>=1000 -F auid!=4294967295 -k privileged-postfix
+-a exit,always -F path=/sbin/postdrop -F perm=x -F auid>=1000 -F auid!=4294967295 -k privileged-postfix
 
--a always,exit -F path=/usr/sbin/postqueue -F perm=x -F auid>=1000 -F auid!=4294967295 -k privileged-postfix
--a always,exit -F path=/sbin/postqueue -F perm=x -F auid>=1000 -F auid!=4294967295 -k privileged-postfix
+-a exit,always -F path=/usr/sbin/postqueue -F perm=x -F auid>=1000 -F auid!=4294967295 -k privileged-postfix
+-a exit,always -F path=/sbin/postqueue -F perm=x -F auid>=1000 -F auid!=4294967295 -k privileged-postfix
 
 ## Audit the execution of the ssh-keysign command
--a always,exit -F path=/usr/libexec/openssh/ssh-keysign -F perm=x -F auid>=1000 -F auid!=4294967295 -k privileged-ssh
+-a exit,always -F path=/usr/libexec/openssh/ssh-keysign -F perm=x -F auid>=1000 -F auid!=4294967295 -k privileged-ssh
 
 ## Audit the execution of the crontab command
--a always,exit -F path=/usr/bin/crontab -F perm=x -F auid>=1000 -F auid!=4294967295 -k privileged-cron
--a always,exit -F path=/bin/crontab -F perm=x -F auid>=1000 -F auid!=4294967295 -k privileged-cron
+-a exit,always -F path=/usr/bin/crontab -F perm=x -F auid>=1000 -F auid!=4294967295 -k privileged-cron
+-a exit,always -F path=/bin/crontab -F perm=x -F auid>=1000 -F auid!=4294967295 -k privileged-cron
 
 ## Audit the execution of the pam_timestamp_check command
--a always,exit -F path=/usr/sbin/pam_timestamp_check -F perm=x -F auid>=1000 -F auid!=4294967295 -k privileged-pam
--a always,exit -F path=/sbin/pam_timestamp_check -F perm=x -F auid>=1000 -F auid!=4294967295 -k privileged-pam
+-a exit,always -F path=/usr/sbin/pam_timestamp_check -F perm=x -F auid>=1000 -F auid!=4294967295 -k privileged-pam
+-a exit,always -F path=/sbin/pam_timestamp_check -F perm=x -F auid>=1000 -F auid!=4294967295 -k privileged-pam
 
 ## Audit selinux commands
--a always,exit -F path=/usr/sbin/semanage -F perm=x -F auid>=1000 -F auid!=4294967295 -k privileged-priv_change
--a always,exit -F path=/sbin/semanage -F perm=x -F auid>=1000 -F auid!=4294967295 -k privileged-priv_change
+-a exit,always -F path=/usr/sbin/semanage -F perm=x -F auid>=1000 -F auid!=4294967295 -k privileged-priv_change
+-a exit,always -F path=/sbin/semanage -F perm=x -F auid>=1000 -F auid!=4294967295 -k privileged-priv_change
 
--a always,exit -F path=/usr/sbin/setsebool -F perm=x -F auid>=1000 -F auid!=4294967295 -k privileged-priv_change
--a always,exit -F path=/sbin/setsebool -F perm=x -F auid>=1000 -F auid!=4294967295 -k privileged-priv_change
+-a exit,always -F path=/usr/sbin/setsebool -F perm=x -F auid>=1000 -F auid!=4294967295 -k privileged-priv_change
+-a exit,always -F path=/sbin/setsebool -F perm=x -F auid>=1000 -F auid!=4294967295 -k privileged-priv_change
 
--a always,exit -F path=/usr/bin/chcon -F perm=x -F auid>=1000 -F auid!=4294967295 -k privileged-priv_change
--a always,exit -F path=/bin/chcon -F perm=x -F auid>=1000 -F auid!=4294967295 -k privileged-priv_change
+-a exit,always -F path=/usr/bin/chcon -F perm=x -F auid>=1000 -F auid!=4294967295 -k privileged-priv_change
+-a exit,always -F path=/bin/chcon -F perm=x -F auid>=1000 -F auid!=4294967295 -k privileged-priv_change
 
--a always,exit -F path=/usr/sbin/setfiles -F perm=x -F auid>=1000 -F auid!=4294967295 -k privileged-priv_change
--a always,exit -F path=/sbin/setfiles -F perm=x -F auid>=1000 -F auid!=4294967295 -k privileged-priv_change
+-a exit,always -F path=/usr/sbin/setfiles -F perm=x -F auid>=1000 -F auid!=4294967295 -k privileged-priv_change
+-a exit,always -F path=/sbin/setfiles -F perm=x -F auid>=1000 -F auid!=4294967295 -k privileged-priv_change
 
--a always,exit -F path=/sbin/restorecon -F perm=x -F auid>=1000 -F auid!=4294967295 -k privileged-priv_change
--a always,exit -F path=/usr/sbin/restorecon -F perm=x -F auid>=1000 -F auid!=4294967295 -k privileged-priv_change
+-a exit,always -F path=/sbin/restorecon -F perm=x -F auid>=1000 -F auid!=4294967295 -k privileged-priv_change
+-a exit,always -F path=/usr/sbin/restorecon -F perm=x -F auid>=1000 -F auid!=4294967295 -k privileged-priv_change
 
 ## Permissions auditing separated by chown, chmod, and attr
--a always,exit -F arch=b64 -S chown -F auid>=1000 -F auid!=4294967295 -k perm_mod
--a always,exit -F arch=b32 -S chown -F auid>=1000 -F auid!=4294967295 -k perm_mod
+-a exit,always -F arch=b64 -S chown -F auid>=1000 -F auid!=4294967295 -k perm_mod
+-a exit,always -F arch=b32 -S chown -F auid>=1000 -F auid!=4294967295 -k perm_mod
 
--a always,exit -F arch=b64 -S fchown -F auid>=1000 -F auid!=4294967295 -k perm_mod
--a always,exit -F arch=b32 -S fchown -F auid>=1000 -F auid!=4294967295 -k perm_mod
+-a exit,always -F arch=b64 -S fchown -F auid>=1000 -F auid!=4294967295 -k perm_mod
+-a exit,always -F arch=b32 -S fchown -F auid>=1000 -F auid!=4294967295 -k perm_mod
 
--a always,exit -F arch=b64 -S lchown -F auid>=1000 -F auid!=4294967295 -k perm_mod
--a always,exit -F arch=b32 -S lchown -F auid>=1000 -F auid!=4294967295 -k perm_mod
+-a exit,always -F arch=b64 -S lchown -F auid>=1000 -F auid!=4294967295 -k perm_mod
+-a exit,always -F arch=b32 -S lchown -F auid>=1000 -F auid!=4294967295 -k perm_mod
 
--a always,exit -F arch=b64 -S fchownat -F auid>=1000 -F auid!=4294967295 -k perm_mod
--a always,exit -F arch=b32 -S fchownat -F auid>=1000 -F auid!=4294967295 -k perm_mod
+-a exit,always -F arch=b64 -S fchownat -F auid>=1000 -F auid!=4294967295 -k perm_mod
+-a exit,always -F arch=b32 -S fchownat -F auid>=1000 -F auid!=4294967295 -k perm_mod
 
--a always,exit -F arch=b64 -S chmod -F auid>=1000 -F auid!=4294967295 -k perm_mod
--a always,exit -F arch=b32 -S chmod -F auid>=1000 -F auid!=4294967295 -k perm_mod
+-a exit,always -F arch=b64 -S chmod -F auid>=1000 -F auid!=4294967295 -k perm_mod
+-a exit,always -F arch=b32 -S chmod -F auid>=1000 -F auid!=4294967295 -k perm_mod
 
--a always,exit -F arch=b64 -S fchmod -F auid>=1000 -F auid!=4294967295 -k perm_mod
--a always,exit -F arch=b32 -S fchmod -F auid>=1000 -F auid!=4294967295 -k perm_mod
+-a exit,always -F arch=b64 -S fchmod -F auid>=1000 -F auid!=4294967295 -k perm_mod
+-a exit,always -F arch=b32 -S fchmod -F auid>=1000 -F auid!=4294967295 -k perm_mod
 
--a always,exit -F arch=b64 -S fchmodat -F auid>=1000 -F auid!=4294967295 -k perm_mod
--a always,exit -F arch=b32 -S fchmodat -F auid>=1000 -F auid!=4294967295 -k perm_mod
+-a exit,always -F arch=b64 -S fchmodat -F auid>=1000 -F auid!=4294967295 -k perm_mod
+-a exit,always -F arch=b32 -S fchmodat -F auid>=1000 -F auid!=4294967295 -k perm_mod
 
--a always,exit -F arch=b64 -S setxattr -F auid>=1000 -F auid!=4294967295 -k perm_mod
--a always,exit -F arch=b32 -S setxattr -F auid>=1000 -F auid!=4294967295 -k perm_mod
+-a exit,always -F arch=b64 -S setxattr -F auid>=1000 -F auid!=4294967295 -k perm_mod
+-a exit,always -F arch=b32 -S setxattr -F auid>=1000 -F auid!=4294967295 -k perm_mod
 
--a always,exit -F arch=b64 -S fsetxattr -F auid>=1000 -F auid!=4294967295 -k perm_mod
--a always,exit -F arch=b32 -S fsetxattr -F auid>=1000 -F auid!=4294967295 -k perm_mod
+-a exit,always -F arch=b64 -S fsetxattr -F auid>=1000 -F auid!=4294967295 -k perm_mod
+-a exit,always -F arch=b32 -S fsetxattr -F auid>=1000 -F auid!=4294967295 -k perm_mod
 
--a always,exit -F arch=b64 -S lsetxattr -F auid>=1000 -F auid!=4294967295 -k perm_mod
--a always,exit -F arch=b32 -S lsetxattr -F auid>=1000 -F auid!=4294967295 -k perm_mod
+-a exit,always -F arch=b64 -S lsetxattr -F auid>=1000 -F auid!=4294967295 -k perm_mod
+-a exit,always -F arch=b32 -S lsetxattr -F auid>=1000 -F auid!=4294967295 -k perm_mod
 
--a always,exit -F arch=b64 -S removexattr -F auid>=1000 -F auid!=4294967295 -k perm_mod
--a always,exit -F arch=b32 -S removexattr -F auid>=1000 -F auid!=4294967295 -k perm_mod
+-a exit,always -F arch=b64 -S removexattr -F auid>=1000 -F auid!=4294967295 -k perm_mod
+-a exit,always -F arch=b32 -S removexattr -F auid>=1000 -F auid!=4294967295 -k perm_mod
 
--a always,exit -F arch=b64 -S fremovexattr -F auid>=1000 -F auid!=4294967295 -k perm_mod
--a always,exit -F arch=b32 -S fremovexattr -F auid>=1000 -F auid!=4294967295 -k perm_mod
+-a exit,always -F arch=b64 -S fremovexattr -F auid>=1000 -F auid!=4294967295 -k perm_mod
+-a exit,always -F arch=b32 -S fremovexattr -F auid>=1000 -F auid!=4294967295 -k perm_mod
 
--a always,exit -F arch=b64 -S lremovexattr -F auid>=1000 -F auid!=4294967295 -k perm_mod
--a always,exit -F arch=b32 -S lremovexattr -F auid>=1000 -F auid!=4294967295 -k perm_mod
+-a exit,always -F arch=b64 -S lremovexattr -F auid>=1000 -F auid!=4294967295 -k perm_mod
+-a exit,always -F arch=b32 -S lremovexattr -F auid>=1000 -F auid!=4294967295 -k perm_mod
 
 ## Audit rename/removal operations
--a always,exit -F arch=b64 -S rename -F perm=x -F auid>=1000 -F auid!=4294967295 -k delete
--a always,exit -F arch=b32 -S rename -F perm=x -F auid>=1000 -F auid!=4294967295 -k delete
+-a exit,always -F arch=b64 -S rename -F perm=x -F auid>=1000 -F auid!=4294967295 -k delete
+-a exit,always -F arch=b32 -S rename -F perm=x -F auid>=1000 -F auid!=4294967295 -k delete
 
--a always,exit -F arch=b64 -S renameat -F perm=x -F auid>=1000 -F auid!=4294967295 -k delete
--a always,exit -F arch=b32 -S renameat -F perm=x -F auid>=1000 -F auid!=4294967295 -k delete
+-a exit,always -F arch=b64 -S renameat -F perm=x -F auid>=1000 -F auid!=4294967295 -k delete
+-a exit,always -F arch=b32 -S renameat -F perm=x -F auid>=1000 -F auid!=4294967295 -k delete
 
--a always,exit -F arch=b64 -S rmdir -F perm=x -F auid>=1000 -F auid!=4294967295 -k delete
--a always,exit -F arch=b32 -S rmdir -F perm=x -F auid>=1000 -F auid!=4294967295 -k delete
+-a exit,always -F arch=b64 -S rmdir -F perm=x -F auid>=1000 -F auid!=4294967295 -k delete
+-a exit,always -F arch=b32 -S rmdir -F perm=x -F auid>=1000 -F auid!=4294967295 -k delete
 
--a always,exit -F arch=b64 -S unlink -F perm=x -F auid>=1000 -F auid!=4294967295 -k delete
--a always,exit -F arch=b32 -S unlink -F perm=x -F auid>=1000 -F auid!=4294967295 -k delete
+-a exit,always -F arch=b64 -S unlink -F perm=x -F auid>=1000 -F auid!=4294967295 -k delete
+-a exit,always -F arch=b32 -S unlink -F perm=x -F auid>=1000 -F auid!=4294967295 -k delete
 
--a always,exit -F arch=b64 -S unlinkat -F perm=x -F auid>=1000 -F auid!=4294967295 -k delete
--a always,exit -F arch=b32 -S unlinkat -F perm=x -F auid>=1000 -F auid!=4294967295 -k delete
+-a exit,always -F arch=b64 -S unlinkat -F perm=x -F auid>=1000 -F auid!=4294967295 -k delete
+-a exit,always -F arch=b32 -S unlinkat -F perm=x -F auid>=1000 -F auid!=4294967295 -k delete
 
 ## Audit the execution of suid and sgid binaries.
--a always,exit -F path=/usr/bin/at -F perm=x -F auid>=1000 -F auid!=4294967295 -k setuid/setgid
--a always,exit -F path=/usr/bin/chage -F perm=x -F auid>=1000 -F auid!=4294967295 -k setuid/setgid
--a always,exit -F path=/usr/bin/chcon -F perm=x -F auid>=1000 -F auid!=4294967295 -k setuid/setgid
--a always,exit -F path=/usr/bin/chfn -F perm=x -F auid>=1000 -F auid!=4294967295 -k setuid/setgid
--a always,exit -F path=/usr/bin/chsh -F perm=x -F auid>=1000 -F auid!=4294967295 -k setuid/setgid
--a always,exit -F path=/usr/bin/crontab -F perm=x -F auid>=1000 -F auid!=4294967295 -k setuid/setgid
--a always,exit -F path=/usr/bin/fusermount -F perm=x -F auid>=1000 -F auid!=4294967295 -k setuid/setgid
--a always,exit -F path=/usr/bin/gpasswd -F perm=x -F auid>=1000 -F auid!=4294967295 -k setuid/setgid
--a always,exit -F path=/usr/bin/incrontab -F perm=x -F auid>=1000 -F auid!=4294967295 -k setuid/setgid
--a always,exit -F path=/usr/bin/ksu -F perm=x -F auid>=1000 -F auid!=4294967295 -k setuid/setgid
--a always,exit -F path=/usr/bin/locate -F perm=x -F auid>=1000 -F auid!=4294967295 -k setuid/setgid
--a always,exit -F path=/usr/bin/mount -F perm=x -F auid>=1000 -F auid!=4294967295 -k setuid/setgid
--a always,exit -F path=/usr/bin/newgidmap -F perm=x -F auid>=1000 -F auid!=4294967295 -k setuid/setgid
--a always,exit -F path=/usr/bin/newgrp -F perm=x -F auid>=1000 -F auid!=4294967295 -k setuid/setgid
--a always,exit -F path=/usr/bin/newuidmap -F perm=x -F auid>=1000 -F auid!=4294967295 -k setuid/setgid
--a always,exit -F path=/usr/bin/passwd -F perm=x -F auid>=1000 -F auid!=4294967295 -k setuid/setgid
--a always,exit -F path=/usr/bin/pkexec -F perm=x -F auid>=1000 -F auid!=4294967295 -k setuid/setgid
--a always,exit -F path=/usr/bin/screen -F perm=x -F auid>=1000 -F auid!=4294967295 -k setuid/setgid
--a always,exit -F path=/usr/bin/ssh-agent -F perm=x -F auid>=1000 -F auid!=4294967295 -k setuid/setgid
--a always,exit -F path=/usr/bin/su -F perm=x -F auid>=1000 -F auid!=4294967295 -k setuid/setgid
--a always,exit -F path=/usr/bin/sudo -F perm=x -F auid>=1000 -F auid!=4294967295 -k setuid/setgid
--a always,exit -F path=/usr/bin/sudoedit -F perm=x -F auid>=1000 -F auid!=4294967295 -k setuid/setgid
--a always,exit -F path=/usr/bin/umount -F perm=x -F auid>=1000 -F auid!=4294967295 -k setuid/setgid
--a always,exit -F path=/usr/bin/wall -F perm=x -F auid>=1000 -F auid!=4294967295 -k setuid/setgid
--a always,exit -F path=/usr/bin/write -F perm=x -F auid>=1000 -F auid!=4294967295 -k setuid/setgid
--a always,exit -F path=/usr/bin/Xorg -F perm=x -F auid>=1000 -F auid!=4294967295 -k setuid/setgid
--a always,exit -F path=/usr/lib64/dbus-1/dbus-daemon-launch-helper -F perm=x -F auid>=1000 -F auid!=4294967295 -k setuid/setgid
--a always,exit -F path=/usr/libexec/dbus-1/dbus-daemon-launch-helper -F perm=x -F auid>=1000 -F auid!=4294967295 -k setuid/setgid
--a always,exit -F path=/usr/libexec/openssh/ssh-keysign -F perm=x -F auid>=1000 -F auid!=4294967295 -k setuid/setgid
--a always,exit -F path=/usr/libexec/pt_chown -F perm=x -F auid>=1000 -F auid!=4294967295 -k setuid/setgid
--a always,exit -F path=/usr/libexec/sssd/krb5_child -F perm=x -F auid>=1000 -F auid!=4294967295 -k setuid/setgid
--a always,exit -F path=/usr/libexec/sssd/ldap_child -F perm=x -F auid>=1000 -F auid!=4294967295 -k setuid/setgid
--a always,exit -F path=/usr/libexec/sssd/proxy_child -F perm=x -F auid>=1000 -F auid!=4294967295 -k setuid/setgid
--a always,exit -F path=/usr/libexec/sssd/selinux_child -F perm=x -F auid>=1000 -F auid!=4294967295 -k setuid/setgid
--a always,exit -F path=/usr/libexec/utempter/utempter -F perm=x -F auid>=1000 -F auid!=4294967295 -k setuid/setgid
--a always,exit -F path=/usr/lib/polkit-1/polkit-agent-helper-1 -F perm=x -F auid>=1000 -F auid!=4294967295 -k setuid/setgid
--a always,exit -F path=/usr/sbin/mount.nfs -F perm=x -F auid>=1000 -F auid!=4294967295 -k setuid/setgid
--a always,exit -F path=/usr/sbin/netreport -F perm=x -F auid>=1000 -F auid!=4294967295 -k setuid/setgid
--a always,exit -F path=/usr/sbin/pam_timestamp_check -F perm=x -F auid>=1000 -F auid!=4294967295 -k setuid/setgid
--a always,exit -F path=/usr/sbin/postdrop -F perm=x -F auid>=1000 -F auid!=4294967295 -k setuid/setgid
--a always,exit -F path=/usr/sbin/postqueue -F perm=x -F auid>=1000 -F auid!=4294967295 -k setuid/setgid
--a always,exit -F path=/usr/sbin/restorecon -F perm=x -F auid>=1000 -F auid!=4294967295 -k setuid/setgid
--a always,exit -F path=/usr/sbin/semanage -F perm=x -F auid>=1000 -F auid!=4294967295 -k setuid/setgid
--a always,exit -F path=/usr/sbin/setfiles -F perm=x -F auid>=1000 -F auid!=4294967295 -k setuid/setgid
--a always,exit -F path=/usr/sbin/setsebool -F perm=x -F auid>=1000 -F auid!=4294967295 -k setuid/setgid
--a always,exit -F path=/usr/sbin/seunshare -F perm=x -F auid>=1000 -F auid!=4294967295 -k setuid/setgid
--a always,exit -F path=/usr/sbin/unix_chkpwd -F perm=x -F auid>=1000 -F auid!=4294967295 -k setuid/setgid
--a always,exit -F path=/usr/sbin/userhelper -F perm=x -F auid>=1000 -F auid!=4294967295 -k setuid/setgid
--a always,exit -F path=/usr/sbin/usernetctl -F perm=x -F auid>=1000 -F auid!=4294967295 -k setuid/setgid
+-a exit,always -F path=/usr/bin/at -F perm=x -F auid>=1000 -F auid!=4294967295 -k setuid/setgid
+-a exit,always -F path=/usr/bin/chage -F perm=x -F auid>=1000 -F auid!=4294967295 -k setuid/setgid
+-a exit,always -F path=/usr/bin/chcon -F perm=x -F auid>=1000 -F auid!=4294967295 -k setuid/setgid
+-a exit,always -F path=/usr/bin/chfn -F perm=x -F auid>=1000 -F auid!=4294967295 -k setuid/setgid
+-a exit,always -F path=/usr/bin/chsh -F perm=x -F auid>=1000 -F auid!=4294967295 -k setuid/setgid
+-a exit,always -F path=/usr/bin/crontab -F perm=x -F auid>=1000 -F auid!=4294967295 -k setuid/setgid
+-a exit,always -F path=/usr/bin/fusermount -F perm=x -F auid>=1000 -F auid!=4294967295 -k setuid/setgid
+-a exit,always -F path=/usr/bin/gpasswd -F perm=x -F auid>=1000 -F auid!=4294967295 -k setuid/setgid
+-a exit,always -F path=/usr/bin/incrontab -F perm=x -F auid>=1000 -F auid!=4294967295 -k setuid/setgid
+-a exit,always -F path=/usr/bin/ksu -F perm=x -F auid>=1000 -F auid!=4294967295 -k setuid/setgid
+-a exit,always -F path=/usr/bin/locate -F perm=x -F auid>=1000 -F auid!=4294967295 -k setuid/setgid
+-a exit,always -F path=/usr/bin/mount -F perm=x -F auid>=1000 -F auid!=4294967295 -k setuid/setgid
+-a exit,always -F path=/usr/bin/newgidmap -F perm=x -F auid>=1000 -F auid!=4294967295 -k setuid/setgid
+-a exit,always -F path=/usr/bin/newgrp -F perm=x -F auid>=1000 -F auid!=4294967295 -k setuid/setgid
+-a exit,always -F path=/usr/bin/newuidmap -F perm=x -F auid>=1000 -F auid!=4294967295 -k setuid/setgid
+-a exit,always -F path=/usr/bin/passwd -F perm=x -F auid>=1000 -F auid!=4294967295 -k setuid/setgid
+-a exit,always -F path=/usr/bin/pkexec -F perm=x -F auid>=1000 -F auid!=4294967295 -k setuid/setgid
+-a exit,always -F path=/usr/bin/screen -F perm=x -F auid>=1000 -F auid!=4294967295 -k setuid/setgid
+-a exit,always -F path=/usr/bin/ssh-agent -F perm=x -F auid>=1000 -F auid!=4294967295 -k setuid/setgid
+-a exit,always -F path=/usr/bin/su -F perm=x -F auid>=1000 -F auid!=4294967295 -k setuid/setgid
+-a exit,always -F path=/usr/bin/sudo -F perm=x -F auid>=1000 -F auid!=4294967295 -k setuid/setgid
+-a exit,always -F path=/usr/bin/sudoedit -F perm=x -F auid>=1000 -F auid!=4294967295 -k setuid/setgid
+-a exit,always -F path=/usr/bin/umount -F perm=x -F auid>=1000 -F auid!=4294967295 -k setuid/setgid
+-a exit,always -F path=/usr/bin/wall -F perm=x -F auid>=1000 -F auid!=4294967295 -k setuid/setgid
+-a exit,always -F path=/usr/bin/write -F perm=x -F auid>=1000 -F auid!=4294967295 -k setuid/setgid
+-a exit,always -F path=/usr/bin/Xorg -F perm=x -F auid>=1000 -F auid!=4294967295 -k setuid/setgid
+-a exit,always -F path=/usr/lib64/dbus-1/dbus-daemon-launch-helper -F perm=x -F auid>=1000 -F auid!=4294967295 -k setuid/setgid
+-a exit,always -F path=/usr/libexec/dbus-1/dbus-daemon-launch-helper -F perm=x -F auid>=1000 -F auid!=4294967295 -k setuid/setgid
+-a exit,always -F path=/usr/libexec/openssh/ssh-keysign -F perm=x -F auid>=1000 -F auid!=4294967295 -k setuid/setgid
+-a exit,always -F path=/usr/libexec/pt_chown -F perm=x -F auid>=1000 -F auid!=4294967295 -k setuid/setgid
+-a exit,always -F path=/usr/libexec/sssd/krb5_child -F perm=x -F auid>=1000 -F auid!=4294967295 -k setuid/setgid
+-a exit,always -F path=/usr/libexec/sssd/ldap_child -F perm=x -F auid>=1000 -F auid!=4294967295 -k setuid/setgid
+-a exit,always -F path=/usr/libexec/sssd/proxy_child -F perm=x -F auid>=1000 -F auid!=4294967295 -k setuid/setgid
+-a exit,always -F path=/usr/libexec/sssd/selinux_child -F perm=x -F auid>=1000 -F auid!=4294967295 -k setuid/setgid
+-a exit,always -F path=/usr/libexec/utempter/utempter -F perm=x -F auid>=1000 -F auid!=4294967295 -k setuid/setgid
+-a exit,always -F path=/usr/lib/polkit-1/polkit-agent-helper-1 -F perm=x -F auid>=1000 -F auid!=4294967295 -k setuid/setgid
+-a exit,always -F path=/usr/sbin/mount.nfs -F perm=x -F auid>=1000 -F auid!=4294967295 -k setuid/setgid
+-a exit,always -F path=/usr/sbin/netreport -F perm=x -F auid>=1000 -F auid!=4294967295 -k setuid/setgid
+-a exit,always -F path=/usr/sbin/pam_timestamp_check -F perm=x -F auid>=1000 -F auid!=4294967295 -k setuid/setgid
+-a exit,always -F path=/usr/sbin/postdrop -F perm=x -F auid>=1000 -F auid!=4294967295 -k setuid/setgid
+-a exit,always -F path=/usr/sbin/postqueue -F perm=x -F auid>=1000 -F auid!=4294967295 -k setuid/setgid
+-a exit,always -F path=/usr/sbin/restorecon -F perm=x -F auid>=1000 -F auid!=4294967295 -k setuid/setgid
+-a exit,always -F path=/usr/sbin/semanage -F perm=x -F auid>=1000 -F auid!=4294967295 -k setuid/setgid
+-a exit,always -F path=/usr/sbin/setfiles -F perm=x -F auid>=1000 -F auid!=4294967295 -k setuid/setgid
+-a exit,always -F path=/usr/sbin/setsebool -F perm=x -F auid>=1000 -F auid!=4294967295 -k setuid/setgid
+-a exit,always -F path=/usr/sbin/seunshare -F perm=x -F auid>=1000 -F auid!=4294967295 -k setuid/setgid
+-a exit,always -F path=/usr/sbin/unix_chkpwd -F perm=x -F auid>=1000 -F auid!=4294967295 -k setuid/setgid
+-a exit,always -F path=/usr/sbin/userhelper -F perm=x -F auid>=1000 -F auid!=4294967295 -k setuid/setgid
+-a exit,always -F path=/usr/sbin/usernetctl -F perm=x -F auid>=1000 -F auid!=4294967295 -k setuid/setgid
 
 ## Audit the loading and unloading of kernel modules.
 -w /usr/sbin/insmod -p x -F auid!=4294967295 -k module-change
@@ -214,28 +214,28 @@
 -w /usr/sbin/modprobe -p x -F auid!=4294967295 -k module-change
 -w /sbin/modprobe -p x -F auid!=4294967295 -k module-change
 
--a always,exit -F arch=b64 -S create_module -k module-change
--a always,exit -F arch=b32 -S create_module -k module-change
+-a exit,always -F arch=b64 -S create_module -k module-change
+-a exit,always -F arch=b32 -S create_module -k module-change
 
--a always,exit -F arch=b64 -S init_module -k module-change
--a always,exit -F arch=b32 -S init_module -k module-change
+-a exit,always -F arch=b64 -S init_module -k module-change
+-a exit,always -F arch=b32 -S init_module -k module-change
 
--a always,exit -F arch=b64 -S finit_module -k module-change
--a always,exit -F arch=b32 -S finit_module -k module-change
+-a exit,always -F arch=b64 -S finit_module -k module-change
+-a exit,always -F arch=b32 -S finit_module -k module-change
 
--a always,exit -F arch=b64 -S delete_module -k module-change
--a always,exit -F arch=b32 -S delete_module -k module-change
+-a exit,always -F arch=b64 -S delete_module -k module-change
+-a exit,always -F arch=b32 -S delete_module -k module-change
 
 ## Audit mount operations
--a always,exit -F arch=b64 -S mount -F auid>=1000 -F auid!=4294967295 -k privileged-mount
--a always,exit -F arch=b64 -F path=/usr/bin/mount -F auid>=1000 -F auid!=4294967295 -k privileged-mount
--a always,exit -F arch=b64 -F path=/bin/mount -F auid>=1000 -F auid!=4294967295 -k privileged-mount
--a always,exit -F arch=b32 -S mount -F auid>=1000 -F auid!=4294967295 -k privileged-mount
--a always,exit -F arch=b32 -F path=/usr/bin/mount -F auid>=1000 -F auid!=4294967295 -k privileged-mount
--a always,exit -F arch=b32 -F path=/bin/mount -F auid>=1000 -F auid!=4294967295 -k privileged-mount
+-a exit,always -F arch=b64 -S mount -F auid>=1000 -F auid!=4294967295 -k privileged-mount
+-a exit,always -F arch=b64 -F path=/usr/bin/mount -F auid>=1000 -F auid!=4294967295 -k privileged-mount
+-a exit,always -F arch=b64 -F path=/bin/mount -F auid>=1000 -F auid!=4294967295 -k privileged-mount
+-a exit,always -F arch=b32 -S mount -F auid>=1000 -F auid!=4294967295 -k privileged-mount
+-a exit,always -F arch=b32 -F path=/usr/bin/mount -F auid>=1000 -F auid!=4294967295 -k privileged-mount
+-a exit,always -F arch=b32 -F path=/bin/mount -F auid>=1000 -F auid!=4294967295 -k privileged-mount
 
--a always,exit -F path=/usr/bin/umount -F perm=x -F auid>=1000 -F auid!=4294967295 -k privileged-mount
--a always,exit -F path=/bin/umount -F perm=x -F auid>=1000 -F auid!=4294967295 -k privileged-mount
+-a exit,always -F path=/usr/bin/umount -F perm=x -F auid>=1000 -F auid!=4294967295 -k privileged-mount
+-a exit,always -F path=/bin/umount -F perm=x -F auid>=1000 -F auid!=4294967295 -k privileged-mount
 
 ## Audit local accounts
 -w /etc/passwd -p wa -k identity

--- a/spec/classes/config/audit_profiles/expected/stig_el7_base_rules.txt
+++ b/spec/classes/config/audit_profiles/expected/stig_el7_base_rules.txt
@@ -1,204 +1,159 @@
 #### auditd::config::audit_profiles::stig Audit Rules ####
 
 ## Audit unsuccessful file operations
-# RHEL-07-030500
 -a always,exit -F arch=b64 -S creat -F exit=-EPERM -F auid>=1000 -F auid!=4294967295 -k access
 -a always,exit -F arch=b64 -S creat -F exit=-EACCES -F auid>=1000 -F auid!=4294967295 -k access
 -a always,exit -F arch=b32 -S creat -F exit=-EPERM -F auid>=1000 -F auid!=4294967295 -k access
 -a always,exit -F arch=b32 -S creat -F exit=-EACCES -F auid>=1000 -F auid!=4294967295 -k access
 
-# RHEL-07-030510
 -a always,exit -F arch=b64 -S open -F exit=-EPERM -F auid>=1000 -F auid!=4294967295 -k access
 -a always,exit -F arch=b64 -S open -F exit=-EACCES -F auid>=1000 -F auid!=4294967295 -k access
 -a always,exit -F arch=b32 -S open -F exit=-EPERM -F auid>=1000 -F auid!=4294967295 -k access
 -a always,exit -F arch=b32 -S open -F exit=-EACCES -F auid>=1000 -F auid!=4294967295 -k access
 
-# RHEL-07-030520
 -a always,exit -F arch=b64 -S openat -F exit=-EPERM -F auid>=1000 -F auid!=4294967295 -k access
 -a always,exit -F arch=b64 -S openat -F exit=-EACCES -F auid>=1000 -F auid!=4294967295 -k access
 -a always,exit -F arch=b32 -S openat -F exit=-EPERM -F auid>=1000 -F auid!=4294967295 -k access
 -a always,exit -F arch=b32 -S openat -F exit=-EACCES -F auid>=1000 -F auid!=4294967295 -k access
 
-# RHEL-07-030530
 -a always,exit -F arch=b64 -S open_by_handle_at -F exit=-EPERM -F auid>=1000 -F auid!=4294967295 -k access
 -a always,exit -F arch=b64 -S open_by_handle_at -F exit=-EACCES -F auid>=1000 -F auid!=4294967295 -k access
 -a always,exit -F arch=b32 -S open_by_handle_at -F exit=-EPERM -F auid>=1000 -F auid!=4294967295 -k access
 -a always,exit -F arch=b32 -S open_by_handle_at -F exit=-EACCES -F auid>=1000 -F auid!=4294967295 -k access
 
-# RHEL-07-030540
 -a always,exit -F arch=b64 -S truncate -F exit=-EPERM -F auid>=1000 -F auid!=4294967295 -k access
 -a always,exit -F arch=b64 -S truncate -F exit=-EACCES -F auid>=1000 -F auid!=4294967295 -k access
 -a always,exit -F arch=b32 -S truncate -F exit=-EPERM -F auid>=1000 -F auid!=4294967295 -k access
 -a always,exit -F arch=b32 -S truncate -F exit=-EACCES -F auid>=1000 -F auid!=4294967295 -k access
 
-# RHEL-07-030550
 -a always,exit -F arch=b64 -S ftruncate -F exit=-EPERM -F auid>=1000 -F auid!=4294967295 -k access
 -a always,exit -F arch=b64 -S ftruncate -F exit=-EACCES -F auid>=1000 -F auid!=4294967295 -k access
 -a always,exit -F arch=b32 -S ftruncate -F exit=-EPERM -F auid>=1000 -F auid!=4294967295 -k access
 -a always,exit -F arch=b32 -S ftruncate -F exit=-EACCES -F auid>=1000 -F auid!=4294967295 -k access
 
 ## Audit the execution of password commands
-# RHEL-07-030630
 -a always,exit -F path=/usr/bin/passwd -F perm=x -F auid>=1000 -F auid!=4294967295 -k privileged-passwd
 -a always,exit -F path=/bin/passwd -F perm=x -F auid>=1000 -F auid!=4294967295 -k privileged-passwd
 
-# RHEL-07-030640
 -a always,exit -F path=/usr/sbin/unix_chkpwd -F perm=x -F auid>=1000 -F auid!=4294967295 -k privileged-passwd
 -a always,exit -F path=/sbin/unix_chkpwd -F perm=x -F auid>=1000 -F auid!=4294967295 -k privileged-passwd
 
-# RHEL-07-030650
 -a always,exit -F path=/usr/bin/gpasswd -F perm=x -F auid>=1000 -F auid!=4294967295 -k privileged-passwd
 -a always,exit -F path=/bin/gpasswd -F perm=x -F auid>=1000 -F auid!=4294967295 -k privileged-passwd
 
-# RHEL-07-030660
 -a always,exit -F path=/usr/bin/chage -F perm=x -F auid>=1000 -F auid!=4294967295 -k privileged-passwd
 -a always,exit -F path=/bin/chage -F perm=x -F auid>=1000 -F auid!=4294967295 -k privileged-passwd
 
-# RHEL-07-030670
 -a always,exit -F path=/usr/sbin/userhelper -F perm=x -F auid>=1000 -F auid!=4294967295 -k privileged-passwd
 -a always,exit -F path=/sbin/userhelper -F perm=x -F auid>=1000 -F auid!=4294967295 -k privileged-passwd
 
 ## Audit the execution of privilege-related commands
-# RHEL-07-030680
 -a always,exit -F path=/usr/bin/su -F perm=x -F auid>=1000 -F auid!=4294967295 -k privileged-priv_change
 -a always,exit -F path=/bin/su -F perm=x -F auid>=1000 -F auid!=4294967295 -k privileged-priv_change
 
-# RHEL-07-030690
 -a always,exit -F path=/usr/bin/sudo -F perm=x -F auid>=1000 -F auid!=4294967295 -k privileged-priv_change
 -a always,exit -F path=/bin/sudo -F perm=x -F auid>=1000 -F auid!=4294967295 -k privileged-priv_change
 
-# RHEL-07-030710
 -a always,exit -F path=/usr/bin/newgrp -F perm=x -F auid>=1000 -F auid!=4294967295 -k privileged-priv_change
 -a always,exit -F path=/bin/newgrp -F perm=x -F auid>=1000 -F auid!=4294967295 -k privileged-priv_change
 
-# RHEL-07-030720
 -a always,exit -F path=/usr/bin/chsh -F perm=x -F auid>=1000 -F auid!=4294967295 -k privileged-priv_change
 -a always,exit -F path=/bin/chsh -F perm=x -F auid>=1000 -F auid!=4294967295 -k privileged-priv_change
 
-# RHEL-07-030730
 -a always,exit -F path=/usr/bin/sudoedit -F perm=x -F auid>=1000 -F auid!=4294967295 -k privileged-priv_change
 -a always,exit -F path=/bin/sudoedit -F perm=x -F auid>=1000 -F auid!=4294967295 -k privileged-priv_change
 
 ## Audit the execution of postfix-related commands
-# RHEL-07-030760
 -a always,exit -F path=/usr/sbin/postdrop -F perm=x -F auid>=1000 -F auid!=4294967295 -k privileged-postfix
 -a always,exit -F path=/sbin/postdrop -F perm=x -F auid>=1000 -F auid!=4294967295 -k privileged-postfix
 
-# RHEL-07-030770
 -a always,exit -F path=/usr/sbin/postqueue -F perm=x -F auid>=1000 -F auid!=4294967295 -k privileged-postfix
 -a always,exit -F path=/sbin/postqueue -F perm=x -F auid>=1000 -F auid!=4294967295 -k privileged-postfix
 
 ## Audit the execution of the ssh-keysign command
-# RHEL-07-030780
 -a always,exit -F path=/usr/libexec/openssh/ssh-keysign -F perm=x -F auid>=1000 -F auid!=4294967295 -k privileged-ssh
 
 ## Audit the execution of the crontab command
-# RHEL-07-030800
 -a always,exit -F path=/usr/bin/crontab -F perm=x -F auid>=1000 -F auid!=4294967295 -k privileged-cron
 -a always,exit -F path=/bin/crontab -F perm=x -F auid>=1000 -F auid!=4294967295 -k privileged-cron
 
 ## Audit the execution of the pam_timestamp_check command
-# RHEL-07-030810
 -a always,exit -F path=/usr/sbin/pam_timestamp_check -F perm=x -F auid>=1000 -F auid!=4294967295 -k privileged-pam
 -a always,exit -F path=/sbin/pam_timestamp_check -F perm=x -F auid>=1000 -F auid!=4294967295 -k privileged-pam
 
 ## Audit selinux commands
-# RHEL-07-030560
 -a always,exit -F path=/usr/sbin/semanage -F perm=x -F auid>=1000 -F auid!=4294967295 -k privileged-priv_change
 -a always,exit -F path=/sbin/semanage -F perm=x -F auid>=1000 -F auid!=4294967295 -k privileged-priv_change
 
-# RHEL-07-030570
 -a always,exit -F path=/usr/sbin/setsebool -F perm=x -F auid>=1000 -F auid!=4294967295 -k privileged-priv_change
 -a always,exit -F path=/sbin/setsebool -F perm=x -F auid>=1000 -F auid!=4294967295 -k privileged-priv_change
 
-# RHEL-07-030580
 -a always,exit -F path=/usr/bin/chcon -F perm=x -F auid>=1000 -F auid!=4294967295 -k privileged-priv_change
 -a always,exit -F path=/bin/chcon -F perm=x -F auid>=1000 -F auid!=4294967295 -k privileged-priv_change
 
-# RHEL-07-030590
 -a always,exit -F path=/usr/sbin/setfiles -F perm=x -F auid>=1000 -F auid!=4294967295 -k privileged-priv_change
 -a always,exit -F path=/sbin/setfiles -F perm=x -F auid>=1000 -F auid!=4294967295 -k privileged-priv_change
 
-# RHEL-07-030590
 -a always,exit -F path=/sbin/restorecon -F perm=x -F auid>=1000 -F auid!=4294967295 -k privileged-priv_change
 -a always,exit -F path=/usr/sbin/restorecon -F perm=x -F auid>=1000 -F auid!=4294967295 -k privileged-priv_change
 
 ## Permissions auditing separated by chown, chmod, and attr
-# RHEL-07-030370
 -a always,exit -F arch=b64 -S chown -F auid>=1000 -F auid!=4294967295 -k perm_mod
 -a always,exit -F arch=b32 -S chown -F auid>=1000 -F auid!=4294967295 -k perm_mod
 
-# RHEL-07-030380
 -a always,exit -F arch=b64 -S fchown -F auid>=1000 -F auid!=4294967295 -k perm_mod
 -a always,exit -F arch=b32 -S fchown -F auid>=1000 -F auid!=4294967295 -k perm_mod
 
-# RHEL-07-030390
 -a always,exit -F arch=b64 -S lchown -F auid>=1000 -F auid!=4294967295 -k perm_mod
 -a always,exit -F arch=b32 -S lchown -F auid>=1000 -F auid!=4294967295 -k perm_mod
 
-# RHEL-07-030400
 -a always,exit -F arch=b64 -S fchownat -F auid>=1000 -F auid!=4294967295 -k perm_mod
 -a always,exit -F arch=b32 -S fchownat -F auid>=1000 -F auid!=4294967295 -k perm_mod
 
-# RHEL-07-030410
 -a always,exit -F arch=b64 -S chmod -F auid>=1000 -F auid!=4294967295 -k perm_mod
 -a always,exit -F arch=b32 -S chmod -F auid>=1000 -F auid!=4294967295 -k perm_mod
 
-# RHEL-07-030420
 -a always,exit -F arch=b64 -S fchmod -F auid>=1000 -F auid!=4294967295 -k perm_mod
 -a always,exit -F arch=b32 -S fchmod -F auid>=1000 -F auid!=4294967295 -k perm_mod
 
-# RHEL-07-030430
 -a always,exit -F arch=b64 -S fchmodat -F auid>=1000 -F auid!=4294967295 -k perm_mod
 -a always,exit -F arch=b32 -S fchmodat -F auid>=1000 -F auid!=4294967295 -k perm_mod
 
-# RHEL-07-030440
 -a always,exit -F arch=b64 -S setxattr -F auid>=1000 -F auid!=4294967295 -k perm_mod
 -a always,exit -F arch=b32 -S setxattr -F auid>=1000 -F auid!=4294967295 -k perm_mod
 
-# RHEL-07-030450
 -a always,exit -F arch=b64 -S fsetxattr -F auid>=1000 -F auid!=4294967295 -k perm_mod
 -a always,exit -F arch=b32 -S fsetxattr -F auid>=1000 -F auid!=4294967295 -k perm_mod
 
-# RHEL-07-030460
 -a always,exit -F arch=b64 -S lsetxattr -F auid>=1000 -F auid!=4294967295 -k perm_mod
 -a always,exit -F arch=b32 -S lsetxattr -F auid>=1000 -F auid!=4294967295 -k perm_mod
 
-# RHEL-07-030470
 -a always,exit -F arch=b64 -S removexattr -F auid>=1000 -F auid!=4294967295 -k perm_mod
 -a always,exit -F arch=b32 -S removexattr -F auid>=1000 -F auid!=4294967295 -k perm_mod
 
-# RHEL-07-030480
 -a always,exit -F arch=b64 -S fremovexattr -F auid>=1000 -F auid!=4294967295 -k perm_mod
 -a always,exit -F arch=b32 -S fremovexattr -F auid>=1000 -F auid!=4294967295 -k perm_mod
 
-# RHEL-07-030490
 -a always,exit -F arch=b64 -S lremovexattr -F auid>=1000 -F auid!=4294967295 -k perm_mod
 -a always,exit -F arch=b32 -S lremovexattr -F auid>=1000 -F auid!=4294967295 -k perm_mod
 
 ## Audit rename/removal operations
-# RHEL-07-030880
 -a always,exit -F arch=b64 -S rename -F perm=x -F auid>=1000 -F auid!=4294967295 -k delete
 -a always,exit -F arch=b32 -S rename -F perm=x -F auid>=1000 -F auid!=4294967295 -k delete
 
-# RHEL-07-030890
 -a always,exit -F arch=b64 -S renameat -F perm=x -F auid>=1000 -F auid!=4294967295 -k delete
 -a always,exit -F arch=b32 -S renameat -F perm=x -F auid>=1000 -F auid!=4294967295 -k delete
 
-# RHEL-07-030900
 -a always,exit -F arch=b64 -S rmdir -F perm=x -F auid>=1000 -F auid!=4294967295 -k delete
 -a always,exit -F arch=b32 -S rmdir -F perm=x -F auid>=1000 -F auid!=4294967295 -k delete
 
-# RHEL-07-030910
 -a always,exit -F arch=b64 -S unlink -F perm=x -F auid>=1000 -F auid!=4294967295 -k delete
 -a always,exit -F arch=b32 -S unlink -F perm=x -F auid>=1000 -F auid!=4294967295 -k delete
 
-# RHEL-07-030920
 -a always,exit -F arch=b64 -S unlinkat -F perm=x -F auid>=1000 -F auid!=4294967295 -k delete
 -a always,exit -F arch=b32 -S unlinkat -F perm=x -F auid>=1000 -F auid!=4294967295 -k delete
 
 ## Audit the execution of suid and sgid binaries.
-# RHEL-07-030360
 -a always,exit -F path=/usr/bin/at -F perm=x -F auid>=1000 -F auid!=4294967295 -k setuid/setgid
 -a always,exit -F path=/usr/bin/chage -F perm=x -F auid>=1000 -F auid!=4294967295 -k setuid/setgid
 -a always,exit -F path=/usr/bin/chcon -F perm=x -F auid>=1000 -F auid!=4294967295 -k setuid/setgid
@@ -250,36 +205,28 @@
 -a always,exit -F path=/usr/sbin/usernetctl -F perm=x -F auid>=1000 -F auid!=4294967295 -k setuid/setgid
 
 ## Audit the loading and unloading of kernel modules.
-# RHEL-07-030840
 -w /usr/sbin/insmod -p x -F auid!=4294967295 -k module-change
 -w /sbin/insmod -p x -F auid!=4294967295 -k module-change
 
-# RHEL-07-030850
 -w /usr/sbin/rmmod -p x -F auid!=4294967295 -k module-change
 -w /sbin/rmmod -p x -F auid!=4294967295 -k module-change
 
-# RHEL-07-030860
 -w /usr/sbin/modprobe -p x -F auid!=4294967295 -k module-change
 -w /sbin/modprobe -p x -F auid!=4294967295 -k module-change
 
-# RHEL-07-030819
 -a always,exit -F arch=b64 -S create_module -k module-change
 -a always,exit -F arch=b32 -S create_module -k module-change
 
-# RHEL-07-030820
 -a always,exit -F arch=b64 -S init_module -k module-change
 -a always,exit -F arch=b32 -S init_module -k module-change
 
-# RHEL-07-030821
 -a always,exit -F arch=b64 -S finit_module -k module-change
 -a always,exit -F arch=b32 -S finit_module -k module-change
 
-# RHEL-07-030830
 -a always,exit -F arch=b64 -S delete_module -k module-change
 -a always,exit -F arch=b32 -S delete_module -k module-change
 
 ## Audit mount operations
-# RHEL-07-030740
 -a always,exit -F arch=b64 -S mount -F auid>=1000 -F auid!=4294967295 -k privileged-mount
 -a always,exit -F arch=b64 -F path=/usr/bin/mount -F auid>=1000 -F auid!=4294967295 -k privileged-mount
 -a always,exit -F arch=b64 -F path=/bin/mount -F auid>=1000 -F auid!=4294967295 -k privileged-mount
@@ -287,37 +234,27 @@
 -a always,exit -F arch=b32 -F path=/usr/bin/mount -F auid>=1000 -F auid!=4294967295 -k privileged-mount
 -a always,exit -F arch=b32 -F path=/bin/mount -F auid>=1000 -F auid!=4294967295 -k privileged-mount
 
-# RHEL-07-030750
 -a always,exit -F path=/usr/bin/umount -F perm=x -F auid>=1000 -F auid!=4294967295 -k privileged-mount
 -a always,exit -F path=/bin/umount -F perm=x -F auid>=1000 -F auid!=4294967295 -k privileged-mount
 
 ## Audit local accounts
-# RHEL-07-030870
 -w /etc/passwd -p wa -k identity
 
-# RHEL-07-030871
 -w /etc/group -p wa -k identity
 
-# RHEL-07-030872
 -w /etc/gshadow -p wa -k identity
 
-# RHEL-07-030873
 -w /etc/shadow -p wa -k identity
 
-# RHEL-07-030874
 -w /etc/security/opasswd -p wa -k identity
 
 ## Audit login files
-# RHEL-07-030600
 -w /var/log/tallylog -p wa -k logins
 
-# RHEL-07-030610
 -w /var/run/faillock -p wa -k logins
 
-# RHEL-07-030620
 -w /var/log/lastlog -p wa -k logins
 
 ## Audit sudoers configuration files
-# RHEL-07-030700
 -w /etc/sudoers -p wa -k privileged-actions
 -w /etc/sudoers.d/ -p wa -k privileged-actions

--- a/spec/classes/config/audit_profiles/simp_spec.rb
+++ b/spec/classes/config/audit_profiles/simp_spec.rb
@@ -38,19 +38,19 @@ describe 'auditd' do
         it 'disables chmod auditing by default' do
           # chmod is disabled by default (SIMP-2250)
           is_expected.not_to contain_file('/etc/audit/rules.d/50_00_simp_base.rules').with_content(
-            %r(^-a always,exit -F arch=b\d\d -S chmod,fchmod,fchmodat -k chmod$)
+            %r(^-a exit,always -F arch=b\d\d -S chmod,fchmod,fchmodat -k chmod$)
           )
         end
 
         it 'disables rename/remove auditing by default' do
           is_expected.not_to contain_file('/etc/audit/rules.d/50_00_simp_base.rules').with_content(
-            %r(^-a always,exit -F arch=b\d\d -S rename,renameat,rmdir,unlink,unlinkat -F perm=x -k delete)
+            %r(^-a exit,always -F arch=b\d\d -S rename,renameat,rmdir,unlink,unlinkat -F perm=x -k delete)
           )
         end
 
         it 'disables umask auditing by default' do
           is_expected.not_to contain_file('/etc/audit/rules.d/50_00_simp_base.rules').with_content(
-            %r(^-a always,exit -F arch=b\d\d -S umask -k umask)
+            %r(^-a exit,always -F arch=b\d\d -S umask -k umask)
           )
         end
 
@@ -63,11 +63,11 @@ describe 'auditd' do
 
         it 'disables selinux commands auditing by default' do
           is_expected.not_to contain_file('/etc/audit/rules.d/50_00_simp_base.rules').with_content(
-            %r{^-a always,exit -F path=/usr/bin/(chcon|semanage|setsebool) -F perm=x -k privileged-priv_change}
+            %r{^-a exit,always -F path=/usr/bin/(chcon|semanage|setsebool) -F perm=x -k privileged-priv_change}
           )
 
           is_expected.not_to contain_file('/etc/audit/rules.d/50_00_simp_base.rules').with_content(
-            %r(^-a always,exit -F path=/(usr/)?sbin/setfiles -F perm=x -k privileged-priv_change)
+            %r(^-a exit,always -F path=/(usr/)?sbin/setfiles -F perm=x -k privileged-priv_change)
           )
         end
       end
@@ -140,11 +140,11 @@ describe 'auditd' do
       context 'with privilege-related command auditing disabled' do
         let(:hieradata) { 'simp_audit_profile/disable__audit_priv_cmds' }
         [
-          %r{^-a always,exit -F path=/(usr/)?bin/su -F perm=x -k privileged-priv_change$},
-          %r{^-a always,exit -F path=/usr/bin/sudo -F perm=x -k privileged-priv_change$},
-          %r{^-a always,exit -F path=/usr/bin/newgrp -F perm=x -k privileged-priv_change$},
-          %r{^-a always,exit -F path=/usr/bin/chsh -F perm=x -k privileged-priv_change$},
-          %r{^-a always,exit -F path=/(usr/)?bin/sudoedit -F perm=x -k privileged-priv_change$}
+          %r{^-a exit,always -F path=/(usr/)?bin/su -F perm=x -k privileged-priv_change$},
+          %r{^-a exit,always -F path=/usr/bin/sudo -F perm=x -k privileged-priv_change$},
+          %r{^-a exit,always -F path=/usr/bin/newgrp -F perm=x -k privileged-priv_change$},
+          %r{^-a exit,always -F path=/usr/bin/chsh -F perm=x -k privileged-priv_change$},
+          %r{^-a exit,always -F path=/(usr/)?bin/sudoedit -F perm=x -k privileged-priv_change$}
         ].each do |command_regex|
           it {
             is_expected.not_to contain_file('/etc/audit/rules.d/50_00_simp_base.rules').
@@ -213,7 +213,7 @@ describe 'auditd' do
 
         it {
           is_expected.not_to contain_file('/etc/audit/rules.d/50_00_simp_base.rules'). with_content(
-            %r{^-a always,exit -F arch=b\d\d -S ptrace -k paranoid$}
+            %r{^-a exit,always -F arch=b\d\d -S ptrace -k paranoid$}
           )
         }
       end
@@ -223,7 +223,7 @@ describe 'auditd' do
 
         it {
           is_expected.not_to contain_file('/etc/audit/rules.d/50_00_simp_base.rules').with_content(
-            %r{^-a always,exit -F arch=b\d\d -S personality -k paranoid$}
+            %r{^-a exit,always -F arch=b\d\d -S personality -k paranoid$}
           )
         }
       end
@@ -233,7 +233,7 @@ describe 'auditd' do
 
         it {
           is_expected.to contain_file('/etc/audit/rules.d/50_00_simp_base.rules').with_content(
-            %r(^-a always,exit -F arch=b\d\d -S chmod,fchmod,fchmodat -k chmod$)
+            %r(^-a exit,always -F arch=b\d\d -S chmod,fchmod,fchmodat -k chmod$)
           )
         }
       end
@@ -243,13 +243,13 @@ describe 'auditd' do
 
         it {
           is_expected.to contain_file('/etc/audit/rules.d/50_00_simp_base.rules').with_content(
-            %r(^-a always,exit -F arch=b64 -S rename,renameat,rmdir,unlink,unlinkat -F perm=x -k delete)
+            %r(^-a exit,always -F arch=b64 -S rename,renameat,rmdir,unlink,unlinkat -F perm=x -k delete)
           )
         }
 
         it {
           is_expected.to contain_file('/etc/audit/rules.d/50_00_simp_base.rules').with_content(
-            %r(^-a always,exit -F arch=b32 -S rename,renameat,rmdir,unlink,unlinkat -F perm=x -k delete)
+            %r(^-a exit,always -F arch=b32 -S rename,renameat,rmdir,unlink,unlinkat -F perm=x -k delete)
           )
         }
       end
@@ -259,7 +259,7 @@ describe 'auditd' do
 
         it {
           is_expected.to contain_file('/etc/audit/rules.d/50_00_simp_base.rules').with_content(
-            %r(^-a always,exit -F arch=b\d\d -S umask -k umask)
+            %r(^-a exit,always -F arch=b\d\d -S umask -k umask)
           )
         }
       end
@@ -269,25 +269,25 @@ describe 'auditd' do
 
         it {
           is_expected.to contain_file('/etc/audit/rules.d/50_00_simp_base.rules').with_content(
-            %r(^-a always,exit -F path=/usr/bin/chcon -F perm=x -k privileged-priv_change)
+            %r(^-a exit,always -F path=/usr/bin/chcon -F perm=x -k privileged-priv_change)
           )
         }
 
         it {
           is_expected.to contain_file('/etc/audit/rules.d/50_00_simp_base.rules').with_content(
-            %r(^-a always,exit -F path=/usr/sbin/semanage -F perm=x -k privileged-priv_change)
+            %r(^-a exit,always -F path=/usr/sbin/semanage -F perm=x -k privileged-priv_change)
           )
         }
 
         it {
           is_expected.to contain_file('/etc/audit/rules.d/50_00_simp_base.rules').with_content(
-            %r(^-a always,exit -F path=/usr/sbin/setsebool -F perm=x -k privileged-priv_change)
+            %r(^-a exit,always -F path=/usr/sbin/setsebool -F perm=x -k privileged-priv_change)
           )
         }
 
         it {
           is_expected.to contain_file('/etc/audit/rules.d/50_00_simp_base.rules').with_content(
-            %r(^-a always,exit -F path=/(usr/)?sbin/setfiles -F perm=x -k privileged-priv_change)
+            %r(^-a exit,always -F path=/(usr/)?sbin/setfiles -F perm=x -k privileged-priv_change)
           )
         }
       end

--- a/spec/classes/config/audit_profiles/stig_spec.rb
+++ b/spec/classes/config/audit_profiles/stig_spec.rb
@@ -59,7 +59,7 @@ describe 'auditd' do
 
         it {
           is_expected.not_to contain_file('/etc/audit/rules.d/50_00_stig_base.rules').with_content(
-            %r(^-a always,exit -F arch=b\d\d -S \w*chown\w* -F auid>=\d+ -F auid!=4294967295 -k perm_mod$)
+            %r(^-a exit,always -F arch=b\d\d -S \w*chown\w* -F auid>=\d+ -F auid!=4294967295 -k perm_mod$)
           )
         }
       end
@@ -70,7 +70,7 @@ describe 'auditd' do
 
         it {
           is_expected.not_to contain_file('/etc/audit/rules.d/50_00_stig_base.rules').with_content(
-            %r(^-a always,exit -F arch=b\d\d -S \w*chmod\w* -F auid>=\d+ -F auid!=4294967295 -k perm_mod$)
+            %r(^-a exit,always -F arch=b\d\d -S \w*chmod\w* -F auid>=\d+ -F auid!=4294967295 -k perm_mod$)
           )
         }
       end
@@ -81,7 +81,7 @@ describe 'auditd' do
 
         it {
           is_expected.not_to contain_file('/etc/audit/rules.d/50_00_stig_base.rules').with_content(
-            %r(^-a always,exit -F arch=b\d\d -S \w*attr -F auid>=\d+ -F auid!=4294967295 -k perm_mod$)
+            %r(^-a exit,always -F arch=b\d\d -S \w*attr -F auid>=\d+ -F auid!=4294967295 -k perm_mod$)
           )
         }
       end
@@ -92,11 +92,11 @@ describe 'auditd' do
 
         it {
           is_expected.not_to contain_file('/etc/audit/rules.d/50_00_stig_base.rules').with_content(
-            %r{^-a always,exit -F path=/usr/bin/(chcon|semanage|setsebool) -F perm=x -F auid>=\d+ -F auid!=4294967295 -k privileged-priv_change}
+            %r{^-a exit,always -F path=/usr/bin/(chcon|semanage|setsebool) -F perm=x -F auid>=\d+ -F auid!=4294967295 -k privileged-priv_change}
           )
 
           is_expected.not_to contain_file('/etc/audit/rules.d/50_00_stig_base.rules').with_content(
-            %r(^-a always,exit -F path=/(usr/)?sbin/setfiles -F perm=x -F auid>=\d+ -F auid!=4294967295 -k privileged-priv_change)
+            %r(^-a exit,always -F path=/(usr/)?sbin/setfiles -F perm=x -F auid>=\d+ -F auid!=4294967295 -k privileged-priv_change)
           )
         }
       end
@@ -105,11 +105,11 @@ describe 'auditd' do
         let(:params) {{ :default_audit_profiles => ['stig'] }}
         let(:hieradata) { 'stig_audit_profile/disable__audit_priv_cmds' }
         [
-          %r{^-a always,exit -F path=/(usr/)?bin/su -F perm=x -F auid>=\d+ -F auid!=4294967295 -k privileged-priv_change$},
-          %r{^-a always,exit -F path=/usr/bin/sudo -F perm=x -F auid>=\d+ -F auid!=4294967295 -k privileged-priv_change$},
-          %r{^-a always,exit -F path=/usr/bin/newgrp -F perm=x -F auid>=\d+ -F auid!=4294967295 -k privileged-priv_change$},
-          %r{^-a always,exit -F path=/usr/bin/chsh -F perm=x -F auid>=\d+ -F auid!=4294967295 -k privileged-priv_change$},
-          %r{^-a always,exit -F path=/(usr/)?bin/sudoedit -F perm=x -F auid>=\d+ -F auid!=4294967295 -k privileged-priv_change$}
+          %r{^-a exit,always -F path=/(usr/)?bin/su -F perm=x -F auid>=\d+ -F auid!=4294967295 -k privileged-priv_change$},
+          %r{^-a exit,always -F path=/usr/bin/sudo -F perm=x -F auid>=\d+ -F auid!=4294967295 -k privileged-priv_change$},
+          %r{^-a exit,always -F path=/usr/bin/newgrp -F perm=x -F auid>=\d+ -F auid!=4294967295 -k privileged-priv_change$},
+          %r{^-a exit,always -F path=/usr/bin/chsh -F perm=x -F auid>=\d+ -F auid!=4294967295 -k privileged-priv_change$},
+          %r{^-a exit,always -F path=/(usr/)?bin/sudoedit -F perm=x -F auid>=\d+ -F auid!=4294967295 -k privileged-priv_change$}
         ].each do |command_regex|
           it {
             is_expected.not_to contain_file('/etc/audit/rules.d/50_00_stig_base.rules').

--- a/spec/classes/config/audit_profiles_spec.rb
+++ b/spec/classes/config/audit_profiles_spec.rb
@@ -22,7 +22,7 @@ describe 'auditd' do
 
       context 'with default parameters' do
         it { is_expected.to compile.with_all_deps }
-        it { is_expected.to contain_auditd__rule('init.d_auditd') }
+        it { is_expected.to contain_auditd__rule('audit_auditd_config').with_content( %r(-w /var/log/audit -p wa -k audit-logs)) }
         it {
           is_expected.to contain_auditd__rule('rotated_audit_logs').with_content(
             %r(-w /var/log/audit/audit.log.5 -p rwa -k audit-logs)
@@ -54,7 +54,7 @@ describe 'auditd' do
 
         it 'adds a drop rule to ignore anonymous and daemon events' do
           is_expected.to contain_file('/etc/audit/rules.d/05_default_drop.rules').with_content(
-            %r(^-a\s+exit,never\s+-F\s+auid=-1$)
+            %r(^-a\s+never,exit\s+-F\s+auid=-1$)
           )
         end
 
@@ -66,7 +66,7 @@ describe 'auditd' do
 
         it 'adds a rule to drop events from system services' do
           is_expected.to contain_file('/etc/audit/rules.d/05_default_drop.rules').with_content(
-            %r(^-a\s+exit,never\s+-F\s+auid!=0\s+-F\s+auid<#{facts[:uid_min]}$)
+            %r(^-a\s+never,exit\s+-F\s+auid!=0\s+-F\s+auid<#{facts[:uid_min]}$)
           )
         end
 

--- a/spec/classes/config/audit_profiles_spec.rb
+++ b/spec/classes/config/audit_profiles_spec.rb
@@ -23,11 +23,6 @@ describe 'auditd' do
       context 'with default parameters' do
         it { is_expected.to compile.with_all_deps }
         it { is_expected.to contain_auditd__rule('audit_auditd_config').with_content( %r(-w /var/log/audit -p wa -k audit-logs)) }
-        it {
-          is_expected.to contain_auditd__rule('rotated_audit_logs').with_content(
-            %r(-w /var/log/audit/audit.log.5 -p rwa -k audit-logs)
-          )
-        }
 
         it 'configures auditd to ignore rule failures' do
           is_expected.to contain_file('/etc/audit/rules.d/00_head.rules').with_content(%r(^-i$))

--- a/spec/defines/rule_spec.rb
+++ b/spec/defines/rule_spec.rb
@@ -31,16 +31,16 @@ describe 'auditd::rule' do
         context 'when :content is an Array' do
           let(:params) {{
             :content => [
-              '-a always,exit -F dir=${confdir} -F uid!=puppet -p wa -k Puppet_Config',
-              '-a always,exit -F dir=${logdir} -F uid!=puppet -p wa -k Puppet_Log',
-              '-a always,exit -F dir=${rundir} -F uid!=puppet -p wa -k Puppet_Run',
-              '-a always,exit -F dir=${ssldir} -F uid!=puppet -p wa -k Puppet_SSL'
+              '-a exit,always -F dir=${confdir} -F uid!=puppet -p wa -k Puppet_Config',
+              '-a exit,always -F dir=${logdir} -F uid!=puppet -p wa -k Puppet_Log',
+              '-a exit,always -F dir=${rundir} -F uid!=puppet -p wa -k Puppet_Run',
+              '-a exit,always -F dir=${ssldir} -F uid!=puppet -p wa -k Puppet_SSL'
             ]
           }}
 
           it {
            is_expected.to compile.with_all_deps
-           is_expected.to create_file("/etc/audit/rules.d/75.#{title}.rules").with_content(%r(^-a always,exit -F dir=))
+           is_expected.to create_file("/etc/audit/rules.d/75.#{title}.rules").with_content(%r(^-a exit,always -F dir=))
            is_expected.to create_file("/etc/audit/rules.d/75.#{title}.rules").without_content(%r(^[^-]))
           }
         end
@@ -49,16 +49,16 @@ describe 'auditd::rule' do
           # :content string mocks a common pattern of declaring readable auditd rules.
           let(:params) {{
             :content => '
-              -a always,exit -F dir=${confdir} -F uid!=puppet -p wa -k Puppet_Config
-              -a always,exit -F dir=${logdir} -F uid!=puppet -p wa -k Puppet_Log
-              -a always,exit -F dir=${rundir} -F uid!=puppet -p wa -k Puppet_Run
-              -a always,exit -F dir=${ssldir} -F uid!=puppet -p wa -k Puppet_SSL
+              -a exit,always -F dir=${confdir} -F uid!=puppet -p wa -k Puppet_Config
+              -a exit,always -F dir=${logdir} -F uid!=puppet -p wa -k Puppet_Log
+              -a exit,always -F dir=${rundir} -F uid!=puppet -p wa -k Puppet_Run
+              -a exit,always -F dir=${ssldir} -F uid!=puppet -p wa -k Puppet_SSL
             '
           }}
 
           it {
            is_expected.to compile.with_all_deps
-           is_expected.to create_file("/etc/audit/rules.d/75.#{title}.rules").with_content(%r(^-a always,exit -F dir=))
+           is_expected.to create_file("/etc/audit/rules.d/75.#{title}.rules").with_content(%r(^-a exit,always -F dir=))
            is_expected.to create_file("/etc/audit/rules.d/75.#{title}.rules").without_content(%r(^[^-]))
           }
         end
@@ -66,7 +66,7 @@ describe 'auditd::rule' do
         context 'with :order specified' do
           let(:params) {{
             :order   => '10',
-            :content => '-a always,exit -F dir=${confdir} -F uid!=puppet -p wa -k Puppet_Config'
+            :content => '-a exit,always -F dir=${confdir} -F uid!=puppet -p wa -k Puppet_Config'
           }}
 
           it {

--- a/spec/fixtures/inspec_profiles/RedHat-7-disa_stig/controls/00_Control_Selector.rb
+++ b/spec/fixtures/inspec_profiles/RedHat-7-disa_stig/controls/00_Control_Selector.rb
@@ -1,7 +1,7 @@
 skips = {
   'V-72209' => 'Cannot guarantee a remote syslog server during test'
 }
-overrides = []
+overrides = [ 'V-72091' ]
 subsystems = [ 'audit' ]
 
 require_controls 'disa_stig-el7-baseline' do
@@ -29,11 +29,13 @@ require_controls 'disa_stig-el7-baseline' do
 
   ## Overrides ##
 
-# # USEFUL DESCRIPTION
-# control 'V-IDENTIFIER' do
-#   # Enhancement, leave this out if you just want to add a different test
-#   overrides << self.to_s
-#
-#   only_if { file('whatever').exist? }
-# end
+  # There's no email server to send anything to by default so syslog is a safer
+  # default for processing.
+  control 'V-72091' do
+    overrides << self.to_s
+
+    describe auditd_conf do
+      its('space_left_action.downcase') { should cmp 'syslog' }
+    end
+  end
 end

--- a/templates/rule_profiles/common/default_drop.epp
+++ b/templates/rule_profiles/common/default_drop.epp
@@ -18,11 +18,11 @@
 <% if $::auditd::ignore_time_daemons { -%>
 # Time daemons can be quite noisy
 <%   if $facts['hardwaremodel'] == 'x86_64' { -%>
--a never,exit -F arch=b64 -S adjtimex -F auid=-1 -F uid=chrony -F subj_typ=chronyd_t
--a never,exit -F arch=b64 -S adjtimex -F auid=-1 -F uid=ntp -F subj_typ=ntpd_t
+-a never,exit -F arch=b64 -S adjtimex -F auid=-1 -F uid=chrony -F subj_type=chronyd_t
+-a never,exit -F arch=b64 -S adjtimex -F auid=-1 -F uid=ntp -F subj_type=ntpd_t
 <%   } -%>
--a never,exit -F arch=b32 -S adjtimex -F auid=-1 -F uid=chrony -F subj_typ=chronyd_t
--a never,exit -F arch=b32 -S adjtimex -F auid=-1 -F uid=ntp -F subj_typ=ntpd_t
+-a never,exit -F arch=b32 -S adjtimex -F auid=-1 -F uid=chrony -F subj_type=chronyd_t
+-a never,exit -F arch=b32 -S adjtimex -F auid=-1 -F uid=ntp -F subj_type=ntpd_t
 <% } -%>
 <% if $::auditd::ignore_crypto_key_user { -%>
 -a always,exclude -F msgtype=CRYPTO_KEY_USER

--- a/templates/rule_profiles/common/default_drop.epp
+++ b/templates/rule_profiles/common/default_drop.epp
@@ -3,17 +3,29 @@
 <% if $::auditd::ignore_anonymous { -%>
 ## Get rid of all anonymous and daemon junk.  It clogs up the logs and doesn't
 # do anyone any good.
--a exit,never -F auid=-1
+-a never,exit -F auid=-1
 <% } -%>
 <% if $::auditd::ignore_system_services { -%>
 # Ignore system services. In most guides this is tagged onto every rule but
 # that just makes for more processing time.
--a exit,never -F auid!=0 -F auid<<%= $::auditd::uid_min %>
+-a never,exit -F auid!=0 -F auid<<%= $::auditd::uid_min %>
 <% } -%>
 <% if $::auditd::ignore_crond { -%>
 # Drop events related to cron jobs.  It creates a lot of logs that are not
 # usually useful
 -a never,user -F subj_type=crond_t
+<% } -%>
+<% if $::auditd::ignore_time_daemons { -%>
+# Time daemons can be quite noisy
+<%   if $facts['hardwaremodel'] == 'x86_64' { -%>
+-a never,exit -F arch=b64 -S adjtimex -F auid=-1 -F uid=chrony -F subj_typ=chronyd_t
+-a never,exit -F arch=b64 -S adjtimex -F auid=-1 -F uid=ntp -F subj_typ=ntpd_t
+<%   } -%>
+-a never,exit -F arch=b32 -S adjtimex -F auid=-1 -F uid=chrony -F subj_typ=chronyd_t
+-a never,exit -F arch=b32 -S adjtimex -F auid=-1 -F uid=ntp -F subj_typ=ntpd_t
+<% } -%>
+<% if $::auditd::ignore_crypto_key_user { -%>
+-a always,exclude -F msgtype=CRYPTO_KEY_USER
 <% } -%>
 <% if $::auditd::target_selinux_types { -%>
 # Drop the following SELinux types to aid performance

--- a/templates/rule_profiles/common/default_drop.epp
+++ b/templates/rule_profiles/common/default_drop.epp
@@ -18,12 +18,20 @@
 <% if $::auditd::ignore_time_daemons { -%>
 # Time daemons can be quite noisy
 <%   if $facts['hardwaremodel'] == 'x86_64' { -%>
+<%     if $facts['os']['release']['major'] > '6' { -%>
 -a never,exit -F arch=b64 -S adjtimex -F auid=-1 -F uid=chrony -F subj_type=chronyd_t
+<%     } -%>
+<%     if $facts['os']['release']['major'] < '8' { -%>
 -a never,exit -F arch=b64 -S adjtimex -F auid=-1 -F uid=ntp -F subj_type=ntpd_t
-<%   } -%>
+<%     }
+     } -%>
+<%   if $facts['os']['release']['major'] > '6' { -%>
 -a never,exit -F arch=b32 -S adjtimex -F auid=-1 -F uid=chrony -F subj_type=chronyd_t
+<%   } -%>
+<%   if $facts['os']['release']['major'] < '8' { -%>
 -a never,exit -F arch=b32 -S adjtimex -F auid=-1 -F uid=ntp -F subj_type=ntpd_t
-<% } -%>
+<%   }
+   } -%>
 <% if $::auditd::ignore_crypto_key_user { -%>
 -a always,exclude -F msgtype=CRYPTO_KEY_USER
 <% } -%>

--- a/templates/rule_profiles/common/head.epp
+++ b/templates/rule_profiles/common/head.epp
@@ -3,7 +3,7 @@
 ## For audit 1.6.5 and higher
 ##
 
-<% if $::auditd::ignore_errors { -%>
+<% if $auditd::ignore_errors { -%>
 # Ignore errors
 # This may sound counterintuitive, but we'd rather skip bad rules and load the
 # rest than miss half the file.  Warnings are still logged in the daemon
@@ -14,7 +14,7 @@
 ## Remove any existing rules
 -D
 
-<% if $::auditd::ignore_failures { -%>
+<% if $auditd::ignore_failures { -%>
 ## Continue loading rules on failure.
 # Particularly with the automatically generated nature of these rules in
 # Puppet, it is possible that one or more may fail to load. We want to continue
@@ -25,13 +25,24 @@
 ## Increase buffer size to handle the increased number of messages.
 ## Feel free to increase this if the machine panic's
 # Default: 8192
--b <%= $::auditd::config::audit_profiles::_buffer_size %>
+-b <%= $auditd::config::audit_profiles::_buffer_size %>
+
+## The time to wait when the backlog limit is reached before queueing more
+## audit events. Smaller numbers are more aggressive but may cause excessive
+## system load.
+# Default: 60000
+--backlog_wait_time <%= $auditd::backlog_wait_time %>
 
 ## Set failure mode
 # Default: 2
--f <%= $::auditd::failure_mode %>
+-f <%= $auditd::failure_mode %>
 
 ## Rate limit messages
 # Default: 0
 # If you set this to non-zero, you almost definitely want to set -f to 1 above.
--r <%= $::auditd::rate %>
+-r <%= $auditd::rate %>
+
+<% if $auditd::loginuid_immutable { -%>
+## Set the loginuid to be immutable
+--loginuid-immutable
+<% } -%>

--- a/templates/rule_profiles/simp/base.epp
+++ b/templates/rule_profiles/simp/base.epp
@@ -1,129 +1,136 @@
 #### auditd::config::audit_profiles::simp Audit Rules ####
-<% if $auditd::config::audit_profiles::simp::audit_unsuccessful_file_operations  { -%>
+<% if $auditd::config::audit_profiles::simp::audit_32bit_operations { -%>
+# 64-bit systems should generally never call the 32-bit API. 32-bit syscalls
+# may be a sign of someone exploiting a hole in the API.
+-a exit,always -F arch=b32 -S all -F key=<%= $auditd::config::audit_profiles::simp::audit_32bit_operations_tag -%>
+<% } -%>
 
-## Audit unsuccessful file operations
-# CCE-26712-0
-# CCE-26651-0
-# RHEL-07-030500
-# RHEL-07-030510
-# RHEL-07-030520
-# RHEL-07-030530
-# RHEL-07-030540
-# RHEL-07-030550
+<% if $auditd::config::audit_profiles::simp::audit_network_ipv4_accept { -%>
 <%   if $facts['hardwaremodel'] == "x86_64"  { -%>
--a always,exit -F arch=b64 -S creat,mkdir,mknod,link,symlink,mkdirat,mknodat,linkat,symlinkat,openat,open_by_handle_at,open,close,rename,renameat,truncate,ftruncate,rmdir,unlink,unlinkat -F exit=-EACCES -k <%= $auditd::config::audit_profiles::simp::audit_unsuccessful_file_operations_tag %>
--a always,exit -F arch=b64 -S creat,mkdir,mknod,link,symlink,mkdirat,mknodat,linkat,symlinkat,openat,open_by_handle_at,open,close,rename,renameat,truncate,ftruncate,rmdir,unlink,unlinkat -F exit=-EPERM -k <%= $auditd::config::audit_profiles::simp::audit_unsuccessful_file_operations_tag %>
+-a exit,always -F arch=b64 -S accept -F a0=2 -F key=<%= $auditd::config::audit_profiles::simp::audit_network_ipv4_accept_tag %>
 <%   } -%>
--a always,exit -F arch=b32 -S creat,mkdir,mknod,link,symlink,mkdirat,mknodat,linkat,symlinkat,openat,open_by_handle_at,open,close,rename,renameat,truncate,ftruncate,rmdir,unlink,unlinkat -F exit=-EACCES -k <%= $auditd::config::audit_profiles::simp::audit_unsuccessful_file_operations_tag %>
--a always,exit -F arch=b32 -S creat,mkdir,mknod,link,symlink,mkdirat,mknodat,linkat,symlinkat,openat,open_by_handle_at,open,close,rename,renameat,truncate,ftruncate,rmdir,unlink,unlinkat -F exit=-EPERM -k <%= $auditd::config::audit_profiles::simp::audit_unsuccessful_file_operations_tag %>
+-a exit,always -F arch=b32 -S accept -F a0=2 -F key=<%= $auditd::config::audit_profiles::simp::audit_network_ipv4_accept_tag %>
+<% } -%>
+<% if $auditd::config::audit_profiles::simp::audit_network_ipv6_accept { -%>
+<%   if $facts['hardwaremodel'] == "x86_64"  { -%>
+-a exit,always -F arch=b64 -S accept -F a0=10 -F key=<%= $auditd::config::audit_profiles::simp::audit_network_ipv6_accept_tag %>
+<%   } -%>
+-a exit,always -F arch=b32 -S accept -F a0=10 -F key=<%= $auditd::config::audit_profiles::simp::audit_network_ipv6_accept_tag %>
+<% } -%>
+<% if $auditd::config::audit_profiles::simp::audit_network_ipv4_connect { -%>
+<%   if $facts['hardwaremodel'] == "x86_64"  { -%>
+-a exit,always -F arch=b64 -S connect -F a0=2 -F key=<%= $auditd::config::audit_profiles::simp::audit_network_ipv4_connect_tag %>
+<%   } -%>
+-a exit,always -F arch=b32 -S connect -F a0=2 -F key=<%= $auditd::config::audit_profiles::simp::audit_network_ipv4_connect_tag %>
+<% } -%>
+<% if $auditd::config::audit_profiles::simp::audit_network_ipv6_connect { -%>
+<%   if $facts['hardwaremodel'] == "x86_64"  { -%>
+-a exit,always -F arch=b64 -S connect -F a0=10 -F key=<%= $auditd::config::audit_profiles::simp::audit_network_ipv6_connect_tag %>
+<%   } -%>
+-a exit,always -F arch=b32 -S connect -F a0=10 -F key=<%= $auditd::config::audit_profiles::simp::audit_network_ipv6_connect_tag %>
+<% } -%>
 
--a always,exit -F perm=a -F exit=-EACCES -k <%= $auditd::config::audit_profiles::simp::audit_unsuccessful_file_operations_tag %>
--a always,exit -F perm=a -F exit=-EPERM -k <%= $auditd::config::audit_profiles::simp::audit_unsuccessful_file_operations_tag %>
+<% if $auditd::config::audit_profiles::simp::audit_unsuccessful_file_operations  { -%>
+## Audit unsuccessful file operations
+<%   if $facts['hardwaremodel'] == "x86_64"  { -%>
+-a exit,always -F arch=b64 -S creat,mkdir,mknod,link,symlink,mkdirat,mknodat,linkat,symlinkat,openat,open_by_handle_at,open,close,rename,renameat,truncate,ftruncate,rmdir,unlink,unlinkat -F exit=-EACCES -k <%= $auditd::config::audit_profiles::simp::audit_unsuccessful_file_operations_tag %>
+-a exit,always -F arch=b64 -S creat,mkdir,mknod,link,symlink,mkdirat,mknodat,linkat,symlinkat,openat,open_by_handle_at,open,close,rename,renameat,truncate,ftruncate,rmdir,unlink,unlinkat -F exit=-EPERM -k <%= $auditd::config::audit_profiles::simp::audit_unsuccessful_file_operations_tag %>
+<%   } -%>
+-a exit,always -F arch=b32 -S creat,mkdir,mknod,link,symlink,mkdirat,mknodat,linkat,symlinkat,openat,open_by_handle_at,open,close,rename,renameat,truncate,ftruncate,rmdir,unlink,unlinkat -F exit=-EACCES -k <%= $auditd::config::audit_profiles::simp::audit_unsuccessful_file_operations_tag %>
+-a exit,always -F arch=b32 -S creat,mkdir,mknod,link,symlink,mkdirat,mknodat,linkat,symlinkat,openat,open_by_handle_at,open,close,rename,renameat,truncate,ftruncate,rmdir,unlink,unlinkat -F exit=-EPERM -k <%= $auditd::config::audit_profiles::simp::audit_unsuccessful_file_operations_tag %>
+
+-a exit,always -F perm=a -F exit=-EACCES -k <%= $auditd::config::audit_profiles::simp::audit_unsuccessful_file_operations_tag %>
+-a exit,always -F perm=a -F exit=-EPERM -k <%= $auditd::config::audit_profiles::simp::audit_unsuccessful_file_operations_tag %>
 <% } -%>
 <% if $auditd::config::audit_profiles::simp::audit_passwd_cmds  { -%>
 
 ## Audit the execution of password commands
-# RHEL-07-030630
--a always,exit -F path=/usr/bin/passwd -F perm=x -k <%= $auditd::config::audit_profiles::simp::audit_passwd_cmds_tag %>
+-a exit,always -F path=/usr/bin/passwd -F perm=x -k <%= $auditd::config::audit_profiles::simp::audit_passwd_cmds_tag %>
 <%   if $facts['os']['release']['major'] > '6'  { -%>
--a always,exit -F path=/bin/passwd -F perm=x -k <%= $auditd::config::audit_profiles::simp::audit_passwd_cmds_tag %>
+-a exit,always -F path=/bin/passwd -F perm=x -k <%= $auditd::config::audit_profiles::simp::audit_passwd_cmds_tag %>
 <%   } -%>
 
-# RHEL-07-030640
 <%   if $facts['os']['release']['major'] > '6'  { -%>
--a always,exit -F path=/usr/sbin/unix_chkpwd -F perm=x -k <%= $auditd::config::audit_profiles::simp::audit_passwd_cmds_tag %>
+-a exit,always -F path=/usr/sbin/unix_chkpwd -F perm=x -k <%= $auditd::config::audit_profiles::simp::audit_passwd_cmds_tag %>
 <%   } -%>
--a always,exit -F path=/sbin/unix_chkpwd -F perm=x -k <%= $auditd::config::audit_profiles::simp::audit_passwd_cmds_tag %>
+-a exit,always -F path=/sbin/unix_chkpwd -F perm=x -k <%= $auditd::config::audit_profiles::simp::audit_passwd_cmds_tag %>
 
-# RHEL-07-030650
--a always,exit -F path=/usr/bin/gpasswd -F perm=x -k <%= $auditd::config::audit_profiles::simp::audit_passwd_cmds_tag %>
+-a exit,always -F path=/usr/bin/gpasswd -F perm=x -k <%= $auditd::config::audit_profiles::simp::audit_passwd_cmds_tag %>
 <%   if $facts['os']['release']['major'] > '6'  { -%>
--a always,exit -F path=/bin/gpasswd -F perm=x -k <%= $auditd::config::audit_profiles::simp::audit_passwd_cmds_tag %>
+-a exit,always -F path=/bin/gpasswd -F perm=x -k <%= $auditd::config::audit_profiles::simp::audit_passwd_cmds_tag %>
 <%   } -%>
 
-# RHEL-07-030660
--a always,exit -F path=/usr/bin/chage -F perm=x -k <%= $auditd::config::audit_profiles::simp::audit_passwd_cmds_tag %>
+-a exit,always -F path=/usr/bin/chage -F perm=x -k <%= $auditd::config::audit_profiles::simp::audit_passwd_cmds_tag %>
 <%   if $facts['os']['release']['major'] > '6'  { -%>
--a always,exit -F path=/bin/chage -F perm=x -k <%= $auditd::config::audit_profiles::simp::audit_passwd_cmds_tag %>
+-a exit,always -F path=/bin/chage -F perm=x -k <%= $auditd::config::audit_profiles::simp::audit_passwd_cmds_tag %>
 <%   } -%>
 
-# RHEL-07-030670
--a always,exit -F path=/usr/sbin/userhelper -F perm=x -k <%= $auditd::config::audit_profiles::simp::audit_passwd_cmds_tag %>
+-a exit,always -F path=/usr/sbin/userhelper -F perm=x -k <%= $auditd::config::audit_profiles::simp::audit_passwd_cmds_tag %>
 <%   if $facts['os']['release']['major'] > '6'  { -%>
--a always,exit -F path=/sbin/userhelper -F perm=x -k <%= $auditd::config::audit_profiles::simp::audit_passwd_cmds_tag %>
+-a exit,always -F path=/sbin/userhelper -F perm=x -k <%= $auditd::config::audit_profiles::simp::audit_passwd_cmds_tag %>
 <%   } -%>
 <% } -%>
 <% if $auditd::config::audit_profiles::simp::audit_priv_cmds  { -%>
 
 ## Audit the execution of privilege-related commands
-# RHEL-07-030680
 <%   if $facts['os']['release']['major'] > '6'  { -%>
--a always,exit -F path=/usr/bin/su -F perm=x -k <%= $auditd::config::audit_profiles::simp::audit_priv_cmds_tag %>
+-a exit,always -F path=/usr/bin/su -F perm=x -k <%= $auditd::config::audit_profiles::simp::audit_priv_cmds_tag %>
 <%   } -%>
--a always,exit -F path=/bin/su -F perm=x -k <%= $auditd::config::audit_profiles::simp::audit_priv_cmds_tag %>
+-a exit,always -F path=/bin/su -F perm=x -k <%= $auditd::config::audit_profiles::simp::audit_priv_cmds_tag %>
 
-# RHEL-07-030690
--a always,exit -F path=/usr/bin/sudo -F perm=x -k <%= $auditd::config::audit_profiles::simp::audit_priv_cmds_tag %>
+-a exit,always -F path=/usr/bin/sudo -F perm=x -k <%= $auditd::config::audit_profiles::simp::audit_priv_cmds_tag %>
 <%   if $facts['os']['release']['major'] > '6'  { -%>
--a always,exit -F path=/bin/sudo -F perm=x -k <%= $auditd::config::audit_profiles::simp::audit_priv_cmds_tag %>
+-a exit,always -F path=/bin/sudo -F perm=x -k <%= $auditd::config::audit_profiles::simp::audit_priv_cmds_tag %>
 <%   } -%>
 
-# RHEL-07-030710
--a always,exit -F path=/usr/bin/newgrp -F perm=x -k <%= $auditd::config::audit_profiles::simp::audit_priv_cmds_tag %>
+-a exit,always -F path=/usr/bin/newgrp -F perm=x -k <%= $auditd::config::audit_profiles::simp::audit_priv_cmds_tag %>
 <%   if $facts['os']['release']['major'] > '6'  { -%>
--a always,exit -F path=/bin/newgrp -F perm=x -k <%= $auditd::config::audit_profiles::simp::audit_priv_cmds_tag %>
+-a exit,always -F path=/bin/newgrp -F perm=x -k <%= $auditd::config::audit_profiles::simp::audit_priv_cmds_tag %>
 <%   } -%>
 
-# RHEL-07-030720
--a always,exit -F path=/usr/bin/chsh -F perm=x -k <%= $auditd::config::audit_profiles::simp::audit_priv_cmds_tag %>
+-a exit,always -F path=/usr/bin/chsh -F perm=x -k <%= $auditd::config::audit_profiles::simp::audit_priv_cmds_tag %>
 <%   if $facts['os']['release']['major'] > '6'  { -%>
--a always,exit -F path=/bin/chsh -F perm=x -k <%= $auditd::config::audit_profiles::simp::audit_priv_cmds_tag %>
+-a exit,always -F path=/bin/chsh -F perm=x -k <%= $auditd::config::audit_profiles::simp::audit_priv_cmds_tag %>
 <%   } -%>
 
-# RHEL-07-030730
--a always,exit -F path=/usr/bin/sudoedit -F perm=x -k <%= $auditd::config::audit_profiles::simp::audit_priv_cmds_tag %>
+-a exit,always -F path=/usr/bin/sudoedit -F perm=x -k <%= $auditd::config::audit_profiles::simp::audit_priv_cmds_tag %>
 <%   if $facts['os']['release']['major'] > '6'  { -%>
--a always,exit -F path=/bin/sudoedit -F perm=x -k <%= $auditd::config::audit_profiles::simp::audit_priv_cmds_tag %>
+-a exit,always -F path=/bin/sudoedit -F perm=x -k <%= $auditd::config::audit_profiles::simp::audit_priv_cmds_tag %>
 <%   } -%>
 <% } -%>
 <% if $auditd::config::audit_profiles::simp::audit_postfix_cmds  { -%>
 
 ## Audit the execution of postfix-related commands
-# RHEL-07-030760
--a always,exit -F path=/usr/sbin/postdrop -F perm=x -k <%= $auditd::config::audit_profiles::simp::audit_postfix_cmds_tag %>
+-a exit,always -F path=/usr/sbin/postdrop -F perm=x -k <%= $auditd::config::audit_profiles::simp::audit_postfix_cmds_tag %>
 <%   if $facts['os']['release']['major'] > '6'  { -%>
--a always,exit -F path=/sbin/postdrop -F perm=x -k <%= $auditd::config::audit_profiles::simp::audit_postfix_cmds_tag %>
+-a exit,always -F path=/sbin/postdrop -F perm=x -k <%= $auditd::config::audit_profiles::simp::audit_postfix_cmds_tag %>
 <%   } -%>
 
-# RHEL-07-030770
--a always,exit -F path=/usr/sbin/postqueue -F perm=x -k <%= $auditd::config::audit_profiles::simp::audit_postfix_cmds_tag %>
+-a exit,always -F path=/usr/sbin/postqueue -F perm=x -k <%= $auditd::config::audit_profiles::simp::audit_postfix_cmds_tag %>
 <%   if $facts['os']['release']['major'] > '6'  { -%>
--a always,exit -F path=/sbin/postqueue -F perm=x -k <%= $auditd::config::audit_profiles::simp::audit_postfix_cmds_tag %>
+-a exit,always -F path=/sbin/postqueue -F perm=x -k <%= $auditd::config::audit_profiles::simp::audit_postfix_cmds_tag %>
 <%   } -%>
 <% } -%>
 <% if $auditd::config::audit_profiles::simp::audit_ssh_keysign_cmd  { -%>
 
 ## Audit the execution of the ssh-keysign command
-# RHEL-07-030780
--a always,exit -F path=/usr/libexec/openssh/ssh-keysign -F perm=x -k <%= $auditd::config::audit_profiles::simp::audit_ssh_keysign_cmd_tag %>
+-a exit,always -F path=/usr/libexec/openssh/ssh-keysign -F perm=x -k <%= $auditd::config::audit_profiles::simp::audit_ssh_keysign_cmd_tag %>
 <% } -%>
 <% if $auditd::config::audit_profiles::simp::audit_crontab_cmd  { -%>
 
 ## Audit the execution of the crontab command
-# RHEL-07-030800
--a always,exit -F path=/usr/bin/crontab -F perm=x -k <%= $auditd::config::audit_profiles::simp::audit_crontab_cmd_tag %>
+-a exit,always -F path=/usr/bin/crontab -F perm=x -k <%= $auditd::config::audit_profiles::simp::audit_crontab_cmd_tag %>
 <%   if $facts['os']['release']['major'] > '6'  { -%>
--a always,exit -F path=/bin/crontab -F perm=x -k <%= $auditd::config::audit_profiles::simp::audit_crontab_cmd_tag %>
+-a exit,always -F path=/bin/crontab -F perm=x -k <%= $auditd::config::audit_profiles::simp::audit_crontab_cmd_tag %>
 <%   } -%>
 <% } -%>
 <% if $auditd::config::audit_profiles::simp::audit_pam_timestamp_check_cmd  { -%>
 
 ## Audit the execution of the pam_timestamp_check command
-# RHEL-07-030810
 <%   if $facts['os']['release']['major'] > '6'  { -%>
--a always,exit -F path=/usr/sbin/pam_timestamp_check -F perm=x -k <%= $auditd::config::audit_profiles::simp::audit_pam_timestamp_check_cmd_tag %>
+-a exit,always -F path=/usr/sbin/pam_timestamp_check -F perm=x -k <%= $auditd::config::audit_profiles::simp::audit_pam_timestamp_check_cmd_tag %>
 <%   } -%>
--a always,exit -F path=/sbin/pam_timestamp_check -F perm=x -k <%= $auditd::config::audit_profiles::simp::audit_pam_timestamp_check_cmd_tag %>
+-a exit,always -F path=/sbin/pam_timestamp_check -F perm=x -k <%= $auditd::config::audit_profiles::simp::audit_pam_timestamp_check_cmd_tag %>
 <% } -%>
 <% if $auditd::config::audit_profiles::simp::audit_selinux_cmds  { -%>
 
@@ -131,98 +138,59 @@
 # NOTE:  These rules come before the *xattr* checks, to ensure the
 #        correct tag is recorded.
 #
-# RHEL-07-030560
--a always,exit -F path=/usr/sbin/semanage -F perm=x -k <%= $auditd::config::audit_profiles::simp::audit_selinux_cmds_tag %>
+-a exit,always -F path=/usr/sbin/semanage -F perm=x -k <%= $auditd::config::audit_profiles::simp::audit_selinux_cmds_tag %>
 <%   if $facts['os']['release']['major'] > '6'  { -%>
--a always,exit -F path=/sbin/semanage -F perm=x -k <%= $auditd::config::audit_profiles::simp::audit_selinux_cmds_tag %>
+-a exit,always -F path=/sbin/semanage -F perm=x -k <%= $auditd::config::audit_profiles::simp::audit_selinux_cmds_tag %>
 <%   } -%>
 
-# RHEL-07-030570
--a always,exit -F path=/usr/sbin/setsebool -F perm=x -k <%= $auditd::config::audit_profiles::simp::audit_selinux_cmds_tag %>
+-a exit,always -F path=/usr/sbin/setsebool -F perm=x -k <%= $auditd::config::audit_profiles::simp::audit_selinux_cmds_tag %>
 <%   if $facts['os']['release']['major'] > '6'  { -%>
--a always,exit -F path=/sbin/setsebool -F perm=x -k <%= $auditd::config::audit_profiles::simp::audit_selinux_cmds_tag %>
+-a exit,always -F path=/sbin/setsebool -F perm=x -k <%= $auditd::config::audit_profiles::simp::audit_selinux_cmds_tag %>
 <%   } -%>
 
-# RHEL-07-030580
--a always,exit -F path=/usr/bin/chcon -F perm=x -k <%= $auditd::config::audit_profiles::simp::audit_selinux_cmds_tag %>
+-a exit,always -F path=/usr/bin/chcon -F perm=x -k <%= $auditd::config::audit_profiles::simp::audit_selinux_cmds_tag %>
 <%   if $facts['os']['release']['major'] > '6'  { -%>
--a always,exit -F path=/bin/chcon -F perm=x -k <%= $auditd::config::audit_profiles::simp::audit_selinux_cmds_tag %>
+-a exit,always -F path=/bin/chcon -F perm=x -k <%= $auditd::config::audit_profiles::simp::audit_selinux_cmds_tag %>
 <%   } -%>
 
-# RHEL-07-030590
 <%   if $facts['os']['release']['major'] > '6'  { -%>
--a always,exit -F path=/usr/sbin/setfiles -F perm=x -k <%= $auditd::config::audit_profiles::simp::audit_selinux_cmds_tag %>
+-a exit,always -F path=/usr/sbin/setfiles -F perm=x -k <%= $auditd::config::audit_profiles::simp::audit_selinux_cmds_tag %>
 <%   } -%>
--a always,exit -F path=/sbin/setfiles -F perm=x -k <%= $auditd::config::audit_profiles::simp::audit_selinux_cmds_tag %>
+-a exit,always -F path=/sbin/setfiles -F perm=x -k <%= $auditd::config::audit_profiles::simp::audit_selinux_cmds_tag %>
 <% } -%>
 
 ## Permissions auditing separated by chown, chmod, and attr
-# CCE-26280-8
-# CCE-27173-4
-# CCE-27174-2
-# CCE-27175-9
-# CCE-27177-5
-# CCE-27178-3
-# CCE-27179-1
-# CCE-27180-9
-# CCE-27181-7
-# CCE-27182-5
-# CCE-27183-3
-# CCE-27184-1
-# CCE-27185-8
 <% if $auditd::config::audit_profiles::simp::audit_chown  { -%>
 
-# RHEL-07-030370
-# RHEL-07-030380
-# RHEL-07-030390
-# RHEL-07-030400
 <%   if $facts['hardwaremodel'] == "x86_64"  { -%>
--a always,exit -F arch=b64 -S chown,fchown,fchownat,lchown -k <%= $auditd::config::audit_profiles::simp::audit_chown_tag %>
+-a exit,always -F arch=b64 -S chown,fchown,fchownat,lchown -k <%= $auditd::config::audit_profiles::simp::audit_chown_tag %>
 <%   } -%>
--a always,exit -F arch=b32 -S chown,fchown,fchownat,lchown -k <%= $auditd::config::audit_profiles::simp::audit_chown_tag %>
+-a exit,always -F arch=b32 -S chown,fchown,fchownat,lchown -k <%= $auditd::config::audit_profiles::simp::audit_chown_tag %>
 <% } -%>
 <% if $auditd::config::audit_profiles::simp::audit_chmod  { -%>
 
-# RHEL-07-030410
-# RHEL-07-030420
-# RHEL-07-030430
 <%   if $facts['hardwaremodel'] == "x86_64"  { -%>
--a always,exit -F arch=b64 -S chmod,fchmod,fchmodat -k <%= $auditd::config::audit_profiles::simp::audit_chmod_tag %>
+-a exit,always -F arch=b64 -S chmod,fchmod,fchmodat -k <%= $auditd::config::audit_profiles::simp::audit_chmod_tag %>
 <%   } -%>
--a always,exit -F arch=b32 -S chmod,fchmod,fchmodat -k <%= $auditd::config::audit_profiles::simp::audit_chmod_tag %>
+-a exit,always -F arch=b32 -S chmod,fchmod,fchmodat -k <%= $auditd::config::audit_profiles::simp::audit_chmod_tag %>
 <% } -%>
 <% if $auditd::config::audit_profiles::simp::audit_attr  { -%>
 
-# RHEL-07-030440
-# RHEL-07-030450
-# RHEL-07-030460
-# RHEL-07-030470
-# RHEL-07-030480
-# RHEL-07-030490
 <%   if $facts['hardwaremodel'] == "x86_64"  { -%>
--a always,exit -F arch=b64 -S setxattr,lsetxattr,fsetxattr,removexattr,lremovexattr,fremovexattr -k <%= $auditd::config::audit_profiles::simp::audit_attr_tag %>
+-a exit,always -F arch=b64 -S setxattr,lsetxattr,fsetxattr,removexattr,lremovexattr,fremovexattr -k <%= $auditd::config::audit_profiles::simp::audit_attr_tag %>
 <%   } -%>
--a always,exit -F arch=b32 -S setxattr,lsetxattr,fsetxattr,removexattr,lremovexattr,fremovexattr -k <%= $auditd::config::audit_profiles::simp::audit_attr_tag %>
+-a exit,always -F arch=b32 -S setxattr,lsetxattr,fsetxattr,removexattr,lremovexattr,fremovexattr -k <%= $auditd::config::audit_profiles::simp::audit_attr_tag %>
 <% } -%>
 <% if $auditd::config::audit_profiles::simp::audit_rename_remove  { -%>
 
 ## Audit rename/removal operations
-# RHEL-07-030880
-# RHEL-07-030890
-# RHEL-07-030900
-# RHEL-07-030910
-# RHEL-07-030920
 <%   if $facts['hardwaremodel'] == "x86_64"  { -%>
--a always,exit -F arch=b64 -S rename,renameat,rmdir,unlink,unlinkat -F perm=x -k <%= $auditd::config::audit_profiles::simp::audit_rename_remove_tag %>
+-a exit,always -F arch=b64 -S rename,renameat,rmdir,unlink,unlinkat -F perm=x -k <%= $auditd::config::audit_profiles::simp::audit_rename_remove_tag %>
 <%   } -%>
--a always,exit -F arch=b32 -S rename,renameat,rmdir,unlink,unlinkat -F perm=x -k <%= $auditd::config::audit_profiles::simp::audit_rename_remove_tag %>
+-a exit,always -F arch=b32 -S rename,renameat,rmdir,unlink,unlinkat -F perm=x -k <%= $auditd::config::audit_profiles::simp::audit_rename_remove_tag %>
 <% } -%>
 <% if $auditd::config::audit_profiles::simp::audit_su_root_activity  { -%>
 
-## Audit useful items that someone does when su'ing to root.
-# Had to add an entry in the default_drop rules file for getting rid of
-# anonymous records.  They are only moderately useful and contain *way*
-# too much noise since this covers things like cron as well.
 <%
     if $auditd::config::audit_profiles::simp::root_audit_level =~ /^bas.*/ {
       $_su_rules = join($auditd::config::audit_profiles::simp::basic_root_audit_syscalls, ',')
@@ -234,154 +202,114 @@
       $_su_rules = join($auditd::config::audit_profiles::simp::insane_root_audit_syscalls, ',')
     }
 -%>
+## Audit useful items that someone does when su'ing to root.
 <%   if $facts['hardwaremodel'] == "x86_64"  { -%>
--a always,exit -F arch=b64 -F auid!=0 -F uid=0 -S <%= $_su_rules %> -k <%= $auditd::config::audit_profiles::simp::audit_su_root_activity_tag %>
+-a exit,always -F arch=b64 -F auid!=0 -F uid=0 -S <%= $_su_rules %> -k <%= $auditd::config::audit_profiles::simp::audit_su_root_activity_tag %>
 <%   } -%>
--a always,exit -F arch=b32 -F auid!=0 -F uid=0 -S <%= $_su_rules %> -k <%= $auditd::config::audit_profiles::simp::audit_su_root_activity_tag %>
+-a exit,always -F arch=b32 -F auid!=0 -F uid=0 -S <%= $_su_rules %> -k <%= $auditd::config::audit_profiles::simp::audit_su_root_activity_tag %>
 <% } -%>
 <% if $auditd::config::audit_profiles::simp::audit_suid_sgid  { -%>
 
 ## Audit the execution of suid and sgid binaries.
-# CCE-26457-2
-# RHEL-07-030360
 <%   if $facts['hardwaremodel'] == "x86_64"  { -%>
--a always,exit -F arch=b64 -F euid=0 -F uid!=0 -S execve -k <%= $auditd::config::audit_profiles::simp::audit_suid_sgid_tag %>
+-a exit,always -F arch=b64 -F euid=0 -F uid!=0 -S execve -k <%= $auditd::config::audit_profiles::simp::audit_suid_sgid_tag %>
 <%   } -%>
--a always,exit -F arch=b32 -F euid=0 -F uid!=0 -S execve -k <%= $auditd::config::audit_profiles::simp::audit_suid_sgid_tag %>
+-a exit,always -F arch=b32 -F euid=0 -F uid!=0 -S execve -k <%= $auditd::config::audit_profiles::simp::audit_suid_sgid_tag %>
 <% } -%>
 <% if $auditd::config::audit_profiles::simp::audit_kernel_modules  { -%>
 
 ## Audit the loading and unloading of kernel modules.
-# CCE-26611-4
 <%   if $facts['os']['release']['major'] > '6'  { -%>
 -w /usr/bin/kmod -p x -k <%= $auditd::config::audit_profiles::simp::audit_kernel_modules_tag %>
 -w /bin/kmod -p x -k <%= $auditd::config::audit_profiles::simp::audit_kernel_modules_tag %>
 <%   } -%>
-
-# RHEL-07-030840
 <%   if $facts['os']['release']['major'] > '6'  { -%>
 -w /usr/sbin/insmod -p x -k <%= $auditd::config::audit_profiles::simp::audit_kernel_modules_tag %>
 <%   } -%>
 -w /sbin/insmod -p x -k <%= $auditd::config::audit_profiles::simp::audit_kernel_modules_tag %>
-
-# RHEL-07-030850
 <%   if $facts['os']['release']['major'] > '6'  { -%>
 -w /usr/sbin/rmmod -p x -k <%= $auditd::config::audit_profiles::simp::audit_kernel_modules_tag %>
 <%   } -%>
 -w /sbin/rmmod -p x -k <%= $auditd::config::audit_profiles::simp::audit_kernel_modules_tag %>
-
-# RHEL-07-030860
 <%   if $facts['os']['release']['major'] > '6'  { -%>
 -w /usr/sbin/modprobe -p x -k <%= $auditd::config::audit_profiles::simp::audit_kernel_modules_tag %>
 <%   } -%>
 -w /sbin/modprobe -p x -k <%= $auditd::config::audit_profiles::simp::audit_kernel_modules_tag %>
 
 <%   if $facts['hardwaremodel'] == "x86_64"  { -%>
-# RHEL-07-030819
-# RHEL-07-030820
-# RHEL-07-030821
-# RHEL-07-030830
--a always,exit -F arch=b64 -S create_module,init_module,finit_module,delete_module -k <%= $auditd::config::audit_profiles::simp::audit_kernel_modules_tag %>
--a always,exit -F arch=b32 -S create_module,init_module,finit_module,delete_module -k <%= $auditd::config::audit_profiles::simp::audit_kernel_modules_tag %>
-<%   } else { -%>
--a always,exit -S create_module,init_module,finit_module,delete_module -k <%= $auditd::config::audit_profiles::simp::audit_kernel_modules_tag %>
+-a exit,always -F arch=b64 -S create_module,init_module,finit_module,delete_module -k <%= $auditd::config::audit_profiles::simp::audit_kernel_modules_tag %>
 <%   } -%>
+-a exit,always -F arch=b32 -S create_module,init_module,finit_module,delete_module -k <%= $auditd::config::audit_profiles::simp::audit_kernel_modules_tag %>
 <% } -%>
 <% if $auditd::config::audit_profiles::simp::audit_time  { -%>
 
 ## Audit things that could affect time
-# CCE-27172-6
-# CCE-27203-9
-# CCE-27169-2
-# CCE-27170-0
 <%   if $facts['hardwaremodel'] == "x86_64"  { -%>
--a always,exit -F arch=b32 -S adjtimex,stime,settimeofday -k <%= $auditd::config::audit_profiles::simp::audit_time_tag %>
--a always,exit -F arch=b64 -S adjtimex,settimeofday -k <%= $auditd::config::audit_profiles::simp::audit_time_tag %>
--a always,exit -F arch=b32 -S clock_settime -F a0=0x0 -k <%= $auditd::config::audit_profiles::simp::audit_time_tag %>
--a always,exit -F arch=b64 -S clock_settime -F a0=0x0 -k <%= $auditd::config::audit_profiles::simp::audit_time_tag %>
-<%   } else { -%>
--a always,exit -S adjtimex,stime,clock_settime,settimeofday -k <%= $auditd::config::audit_profiles::simp::audit_time_tag %>
+-a exit,always -F arch=b64 -S adjtimex,settimeofday -k <%= $auditd::config::audit_profiles::simp::audit_time_tag %>
+-a exit,always -F arch=b64 -S clock_settime -F a0=0x0 -k <%= $auditd::config::audit_profiles::simp::audit_time_tag %>
 <%   } -%>
+-a exit,always -F arch=b32 -S adjtimex,stime,settimeofday -k <%= $auditd::config::audit_profiles::simp::audit_time_tag %>
+-a exit,always -F arch=b32 -S clock_settime -F a0=0x0 -k <%= $auditd::config::audit_profiles::simp::audit_time_tag %>
 
-# CCE-27172-6
 -w /etc/localtime -p wa -k <%= $auditd::config::audit_profiles::simp::audit_time_tag %>
 <% } -%>
 <% if $auditd::config::audit_profiles::simp::audit_locale  { -%>
 
 ## Audit things that could affect system locale
-# CCE-26648-6
 <%   if $facts['hardwaremodel'] == "x86_64"  { -%>
--a always,exit -F arch=b32 -S sethostname,setdomainname -k <%= $auditd::config::audit_profiles::simp::audit_locale_tag %>
--a always,exit -F arch=b64 -S sethostname,setdomainname -k <%= $auditd::config::audit_profiles::simp::audit_locale_tag %>
-<%   } else { -%>
--a always,exit -S sethostname -k <%= $auditd::config::audit_profiles::simp::audit_locale_tag %>
+-a exit,always -F arch=b64 -S sethostname,setdomainname -k <%= $auditd::config::audit_profiles::simp::audit_locale_tag %>
 <%   } -%>
+-a exit,always -F arch=b32 -S sethostname,setdomainname -k <%= $auditd::config::audit_profiles::simp::audit_locale_tag %>
+
 -w /etc/issue -p wa -k <%= $auditd::config::audit_profiles::simp::audit_locale_tag %>
 -w /etc/issue.net -p wa -k <%= $auditd::config::audit_profiles::simp::audit_locale_tag %>
 -w /etc/hosts -p wa -k <%= $auditd::config::audit_profiles::simp::audit_locale_tag %>
 -w /etc/hostname -p wa -k <%= $auditd::config::audit_profiles::simp::audit_locale_tag %>
 -w /etc/sysconfig/network -p wa -k <%= $auditd::config::audit_profiles::simp::audit_locale_tag %>
 <%   if $facts['os']['release']['major'] > '6'  { -%>
--a always,exit -F dir=/etc/NetworkManager/ -F perm=wa -k <%= $auditd::config::audit_profiles::simp::audit_locale_tag %>
+-a exit,always -F dir=/etc/NetworkManager/ -F perm=wa -k <%= $auditd::config::audit_profiles::simp::audit_locale_tag %>
 <%   } -%>
 <% } -%>
 <% if $auditd::config::audit_profiles::simp::audit_mount  { -%>
 
 ## Audit mount operations
-# CCE-26573-6
-#
-# RHEL-07-030740
-# RHEL-07-030750
 <%   if $facts['hardwaremodel'] == "x86_64"  { -%>
--a always,exit -F arch=b32 -S mount,umount,umount2 -k <%= $auditd::config::audit_profiles::simp::audit_mount_tag %>
--a always,exit -F arch=b64 -S mount,umount2 -k <%= $auditd::config::audit_profiles::simp::audit_mount_tag %>
-<%   } else { -%>
--a always,exit -S mount,umount,umount2 -k <%= $auditd::config::audit_profiles::simp::audit_mount_tag %>
+-a exit,always -F arch=b64 -S mount,umount2 -k <%= $auditd::config::audit_profiles::simp::audit_mount_tag %>
 <%   } -%>
+-a exit,always -F arch=b32 -S mount,umount,umount2 -k <%= $auditd::config::audit_profiles::simp::audit_mount_tag %>
+
 <%   if $facts['hardwaremodel'] == "x86_64"  { -%>
 <%     if $facts['os']['release']['major'] > '6'  { -%>
--a always,exit -F arch=b64 -F path=/usr/bin/mount -k <%= $auditd::config::audit_profiles::simp::audit_mount_tag %>
+-a exit,always -F arch=b64 -F path=/usr/bin/mount -k <%= $auditd::config::audit_profiles::simp::audit_mount_tag %>
 <%     } -%>
--a always,exit -F arch=b64 -F path=/bin/mount -k <%= $auditd::config::audit_profiles::simp::audit_mount_tag %>
+-a exit,always -F arch=b64 -F path=/bin/mount -k <%= $auditd::config::audit_profiles::simp::audit_mount_tag %>
 <%   } -%>
 <%   if $facts['os']['release']['major'] > '6'  { -%>
--a always,exit -F arch=b32 -F path=/usr/bin/mount -k <%= $auditd::config::audit_profiles::simp::audit_mount_tag %>
+-a exit,always -F arch=b32 -F path=/usr/bin/mount -k <%= $auditd::config::audit_profiles::simp::audit_mount_tag %>
 <%   } -%>
--a always,exit -F arch=b32 -F path=/bin/mount -k <%= $auditd::config::audit_profiles::simp::audit_mount_tag %>
+-a exit,always -F arch=b32 -F path=/bin/mount -k <%= $auditd::config::audit_profiles::simp::audit_mount_tag %>
 <%   if $facts['os']['release']['major'] > '6'  { -%>
--a always,exit -F path=/usr/bin/umount -F perm=x -k <%= $auditd::config::audit_profiles::simp::audit_mount_tag %>
+-a exit,always -F path=/usr/bin/umount -F perm=x -k <%= $auditd::config::audit_profiles::simp::audit_mount_tag %>
 <%   } -%>
--a always,exit -F path=/bin/umount -F perm=x -k <%= $auditd::config::audit_profiles::simp::audit_mount_tag %>
+-a exit,always -F path=/bin/umount -F perm=x -k <%= $auditd::config::audit_profiles::simp::audit_mount_tag %>
 <% } -%>
 <% if $auditd::config::audit_profiles::simp::audit_umask  { -%>
 
 ## Audit umask changes.
-# This is uselessly noisy.
+# This is uselessly noisy in most cases
 <%   if $facts['hardwaremodel'] == "x86_64"  { -%>
--a always,exit -F arch=b64 -S umask -k <%= $auditd::config::audit_profiles::simp::audit_umask_tag %>
+-a exit,always -F arch=b64 -S umask -k <%= $auditd::config::audit_profiles::simp::audit_umask_tag %>
 <%   } -%>
--a always,exit -F arch=b32 -S umask -k <%= $auditd::config::audit_profiles::simp::audit_umask_tag %>
+-a exit,always -F arch=b32 -S umask -k <%= $auditd::config::audit_profiles::simp::audit_umask_tag %>
 <% } -%>
 <% if $auditd::config::audit_profiles::simp::audit_local_account  { -%>
 
 ## Audit local accounts
-# CCE-26664-3
-#
-# RHEL-07-030870
 -w /etc/passwd -p wa -k <%= $auditd::config::audit_profiles::simp::audit_local_account_tag %>
-
-# RHEL-07-030871
 -w /etc/group -p wa -k <%= $auditd::config::audit_profiles::simp::audit_local_account_tag %>
-
-# RHEL-07-030872
 -w /etc/gshadow -p wa -k <%= $auditd::config::audit_profiles::simp::audit_local_account_tag %>
-
-# RHEL-07-030873
 -w /etc/shadow -p wa -k <%= $auditd::config::audit_profiles::simp::audit_local_account_tag %>
-
-# RHEL-07-030874
 -w /etc/security/opasswd -p wa -k <%= $auditd::config::audit_profiles::simp::audit_local_account_tag %>
-
 -w /etc/passwd- -p wa -k <%= $auditd::config::audit_profiles::simp::audit_local_account_tag %>
 -w /etc/group- -p wa -k <%= $auditd::config::audit_profiles::simp::audit_local_account_tag %>
 -w /etc/shadow- -p wa -k <%= $auditd::config::audit_profiles::simp::audit_local_account_tag %>
@@ -389,41 +317,50 @@
 <% if $auditd::config::audit_profiles::simp::audit_selinux_policy  { -%>
 
 ## Audit selinux policy
-# CCE-26657-7
 -w /etc/selinux/ -p wa -k <%= $auditd::config::audit_profiles::simp::audit_selinux_policy_tag %>
 -w /usr/share/selinux/ -p wa -k <%= $auditd::config::audit_profiles::simp::audit_selinux_policy_tag %>
 <% } -%>
 <% if $auditd::config::audit_profiles::simp::audit_login_files  { -%>
 
 ## Audit login files
-# CCE-26691-6
-#
-# RHEL-07-030600
 -w /var/log/tallylog -p wa -k <%= $auditd::config::audit_profiles::simp::audit_login_files_tag %>
-
-# RHEL-07-030610
 -w /var/run/faillock -p wa -k <%= $auditd::config::audit_profiles::simp::audit_login_files_tag %>
-
-# RHEL-07-030620
 -w /var/log/lastlog -p wa -k <%= $auditd::config::audit_profiles::simp::audit_login_files_tag %>
-
 -w /var/log/faillog -p wa -k <%= $auditd::config::audit_profiles::simp::audit_login_files_tag %>
 <% } -%>
 <% if $auditd::config::audit_profiles::simp::audit_session_files  { -%>
 
 ## Audit session files
-# CCE-26610-6
 -w /var/run/utmp -p wa -k <%= $auditd::config::audit_profiles::simp::audit_session_files_tag %>
 -w /var/log/btmp -p wa -k <%= $auditd::config::audit_profiles::simp::audit_session_files_tag %>
 -w /var/log/wtmp -p wa -k <%= $auditd::config::audit_profiles::simp::audit_session_files_tag %>
 <% } -%>
-<% if $auditd::config::audit_profiles::simp::_audit_cfg_sudoers  { -%>
+<% if $auditd::config::audit_profiles::simp::_audit_cfg_sudoers { -%>
 
 ## Audit sudoers configuration files
-# CCE-26662-7
-# RHEL-07-030700
 -w /etc/sudoers -p wa -k <%= $auditd::config::audit_profiles::simp::_audit_cfg_sudoers_tag %>
 -w /etc/sudoers.d/ -p wa -k <%= $auditd::config::audit_profiles::simp::_audit_cfg_sudoers_tag %>
+<% } -%>
+
+<% if $auditd::config::audit_profiles::simp::audit_auditd_cmds { -%>
+## Audit accesses to the audit trail
+<%   $auditd::config::audit_profiles::simp::audit_auditd_cmds_list.each | String $auditd_app | { -%>
+-w <%= $auditd_app %> -p x -k <%= $auditd::config::audit_profiles::simp::audit_auditd_cmds_tag %>
+<%   } -%>
+<% } -%>
+<% if $auditd::config::audit_profiles::simp::audit_systemd and ('systemd' in $facts['init_systems']) { -%>
+
+## Audit systemd components
+-w /bin/systemctl -p x -k <%= $auditd::config::audit_profiles::simp::audit_systemd_tag %>
+-w /usr/bin/systemctl -p x -k <%= $auditd::config::audit_profiles::simp::audit_systemd_tag %>
+-w /etc/systemd/ -p wa -k <%= $auditd::config::audit_profiles::simp::audit_systemd_tag %>
+<% } -%>
+
+<% if $auditd::config::audit_profiles::simp::audit_suspicious_apps { -%>
+## Audit suspicious applications
+<%   $auditd::config::audit_profiles::simp::audit_suspicious_apps_list.each | String $susp_app | { -%>
+-w <%= $susp_app %> -p x -k <%= $auditd::config::audit_profiles::simp::audit_suspicious_apps_tag %>
+<%   } -%>
 <% } -%>
 
 ## Generally good things to audit.
@@ -443,8 +380,6 @@
 -w /etc/hosts.deny -p wa -k <%= $auditd::config::audit_profiles::simp::audit_cfg_sys_tag %>
 -w /etc/initlog.conf -p wa -k <%= $auditd::config::audit_profiles::simp::audit_cfg_sys_tag %>
 -w /etc/inittab -p wa -k <%= $auditd::config::audit_profiles::simp::audit_cfg_sys_tag %>
--w /etc/issue -p wa -k <%= $auditd::config::audit_profiles::simp::audit_cfg_sys_tag %>
--w /etc/issue.net -p wa -k <%= $auditd::config::audit_profiles::simp::audit_cfg_sys_tag %>
 -w /etc/krb5.conf -p wa -k <%= $auditd::config::audit_profiles::simp::audit_cfg_sys_tag %>
 -w /etc/ld.so.conf -p wa -k <%= $auditd::config::audit_profiles::simp::audit_cfg_sys_tag %>
 -w /etc/ld.so.conf.d -p wa -k <%= $auditd::config::audit_profiles::simp::audit_cfg_sys_tag %>
@@ -516,17 +451,19 @@
 <% } -%>
 <% if $auditd::config::audit_profiles::simp::audit_ptrace  { -%>
 <%   if $facts['hardwaremodel'] == "x86_64"  { -%>
--a always,exit -F arch=b32 -S ptrace -k <%= $auditd::config::audit_profiles::simp::audit_ptrace_tag %>
--a always,exit -F arch=b64 -S ptrace -k <%= $auditd::config::audit_profiles::simp::audit_ptrace_tag %>
-<%   } else { -%>
--a always,exit -S ptrace -k <%= $auditd::config::audit_profiles::simp::audit_ptrace_tag %>
+-a exit,always -F arch=b64 -S ptrace -F a0=0x4 -k <%= $auditd::config::audit_profiles::simp::audit_ptrace_tag %>_code_injection
+-a exit,always -F arch=b64 -S ptrace -F a0=0x5 -k <%= $auditd::config::audit_profiles::simp::audit_ptrace_tag %>_data_injection
+-a exit,always -F arch=b64 -S ptrace -F a0=0x6 -k <%= $auditd::config::audit_profiles::simp::audit_ptrace_tag %>_register_injection
+-a exit,always -F arch=b64 -S ptrace -k <%= $auditd::config::audit_profiles::simp::audit_ptrace_tag %>
 <%   } -%>
+-a exit,always -F arch=b32 -S ptrace -F a0=0x4 -k <%= $auditd::config::audit_profiles::simp::audit_ptrace_tag %>_code_injection
+-a exit,always -F arch=b32 -S ptrace -F a0=0x5 -k <%= $auditd::config::audit_profiles::simp::audit_ptrace_tag %>_data_injection
+-a exit,always -F arch=b32 -S ptrace -F a0=0x6 -k <%= $auditd::config::audit_profiles::simp::audit_ptrace_tag %>_register_injection
+-a exit,always -F arch=b32 -S ptrace -k <%= $auditd::config::audit_profiles::simp::audit_ptrace_tag %>
 <% } -%>
 <% if $auditd::config::audit_profiles::simp::audit_personality  { -%>
 <%   if $facts['hardwaremodel'] == "x86_64"  { -%>
--a always,exit -F arch=b32 -S personality -k <%= $auditd::config::audit_profiles::simp::audit_personality_tag %>
--a always,exit -F arch=b64 -S personality -k <%= $auditd::config::audit_profiles::simp::audit_personality_tag %>
-<%   } else  {-%>
--a always,exit -S personality -k <%= $auditd::config::audit_profiles::simp::audit_personality_tag %>
+-a exit,always -F arch=b64 -S personality -k <%= $auditd::config::audit_profiles::simp::audit_personality_tag %>
 <%   } -%>
+-a exit,always -F arch=b32 -S personality -k <%= $auditd::config::audit_profiles::simp::audit_personality_tag %>
 <% } -%>

--- a/templates/rule_profiles/simp/base.epp
+++ b/templates/rule_profiles/simp/base.epp
@@ -9,13 +9,11 @@
 <%   if $facts['hardwaremodel'] == "x86_64"  { -%>
 -a exit,always -F arch=b64 -S accept -F a0=2 -F key=<%= $auditd::config::audit_profiles::simp::audit_network_ipv4_accept_tag %>
 <%   } -%>
--a exit,always -F arch=b32 -S accept -F a0=2 -F key=<%= $auditd::config::audit_profiles::simp::audit_network_ipv4_accept_tag %>
 <% } -%>
 <% if $auditd::config::audit_profiles::simp::audit_network_ipv6_accept { -%>
 <%   if $facts['hardwaremodel'] == "x86_64"  { -%>
 -a exit,always -F arch=b64 -S accept -F a0=10 -F key=<%= $auditd::config::audit_profiles::simp::audit_network_ipv6_accept_tag %>
 <%   } -%>
--a exit,always -F arch=b32 -S accept -F a0=10 -F key=<%= $auditd::config::audit_profiles::simp::audit_network_ipv6_accept_tag %>
 <% } -%>
 <% if $auditd::config::audit_profiles::simp::audit_network_ipv4_connect { -%>
 <%   if $facts['hardwaremodel'] == "x86_64"  { -%>

--- a/templates/rule_profiles/stig/base.epp
+++ b/templates/rule_profiles/stig/base.epp
@@ -3,419 +3,356 @@
 
 ## Audit unsuccessful file operations
 <%   if $facts['hardwaremodel'] == "x86_64" { -%>
-# RHEL-07-030500
--a always,exit -F arch=b64 -S creat -F exit=-EPERM -F auid>=<%= $auditd::config::audit_profiles::stig::uid_min %> -F auid!=4294967295 -k <%= $auditd::config::audit_profiles::stig::audit_unsuccessful_file_operations_tag %>
--a always,exit -F arch=b64 -S creat -F exit=-EACCES -F auid>=<%= $auditd::config::audit_profiles::stig::uid_min %> -F auid!=4294967295 -k <%= $auditd::config::audit_profiles::stig::audit_unsuccessful_file_operations_tag %>
+-a exit,always -F arch=b64 -S creat -F exit=-EPERM -F auid>=<%= $auditd::config::audit_profiles::stig::uid_min %> -F auid!=4294967295 -k <%= $auditd::config::audit_profiles::stig::audit_unsuccessful_file_operations_tag %>
+-a exit,always -F arch=b64 -S creat -F exit=-EACCES -F auid>=<%= $auditd::config::audit_profiles::stig::uid_min %> -F auid!=4294967295 -k <%= $auditd::config::audit_profiles::stig::audit_unsuccessful_file_operations_tag %>
 <%   } -%>
--a always,exit -F arch=b32 -S creat -F exit=-EPERM -F auid>=<%= $auditd::config::audit_profiles::stig::uid_min %> -F auid!=4294967295 -k <%= $auditd::config::audit_profiles::stig::audit_unsuccessful_file_operations_tag %>
--a always,exit -F arch=b32 -S creat -F exit=-EACCES -F auid>=<%= $auditd::config::audit_profiles::stig::uid_min %> -F auid!=4294967295 -k <%= $auditd::config::audit_profiles::stig::audit_unsuccessful_file_operations_tag %>
+-a exit,always -F arch=b32 -S creat -F exit=-EPERM -F auid>=<%= $auditd::config::audit_profiles::stig::uid_min %> -F auid!=4294967295 -k <%= $auditd::config::audit_profiles::stig::audit_unsuccessful_file_operations_tag %>
+-a exit,always -F arch=b32 -S creat -F exit=-EACCES -F auid>=<%= $auditd::config::audit_profiles::stig::uid_min %> -F auid!=4294967295 -k <%= $auditd::config::audit_profiles::stig::audit_unsuccessful_file_operations_tag %>
 
 <%   if $facts['hardwaremodel'] == "x86_64" { -%>
-# RHEL-07-030510
--a always,exit -F arch=b64 -S open -F exit=-EPERM -F auid>=<%= $auditd::config::audit_profiles::stig::uid_min %> -F auid!=4294967295 -k <%= $auditd::config::audit_profiles::stig::audit_unsuccessful_file_operations_tag %>
--a always,exit -F arch=b64 -S open -F exit=-EACCES -F auid>=<%= $auditd::config::audit_profiles::stig::uid_min %> -F auid!=4294967295 -k <%= $auditd::config::audit_profiles::stig::audit_unsuccessful_file_operations_tag %>
+-a exit,always -F arch=b64 -S open -F exit=-EPERM -F auid>=<%= $auditd::config::audit_profiles::stig::uid_min %> -F auid!=4294967295 -k <%= $auditd::config::audit_profiles::stig::audit_unsuccessful_file_operations_tag %>
+-a exit,always -F arch=b64 -S open -F exit=-EACCES -F auid>=<%= $auditd::config::audit_profiles::stig::uid_min %> -F auid!=4294967295 -k <%= $auditd::config::audit_profiles::stig::audit_unsuccessful_file_operations_tag %>
 <%   } -%>
--a always,exit -F arch=b32 -S open -F exit=-EPERM -F auid>=<%= $auditd::config::audit_profiles::stig::uid_min %> -F auid!=4294967295 -k <%= $auditd::config::audit_profiles::stig::audit_unsuccessful_file_operations_tag %>
--a always,exit -F arch=b32 -S open -F exit=-EACCES -F auid>=<%= $auditd::config::audit_profiles::stig::uid_min %> -F auid!=4294967295 -k <%= $auditd::config::audit_profiles::stig::audit_unsuccessful_file_operations_tag %>
+-a exit,always -F arch=b32 -S open -F exit=-EPERM -F auid>=<%= $auditd::config::audit_profiles::stig::uid_min %> -F auid!=4294967295 -k <%= $auditd::config::audit_profiles::stig::audit_unsuccessful_file_operations_tag %>
+-a exit,always -F arch=b32 -S open -F exit=-EACCES -F auid>=<%= $auditd::config::audit_profiles::stig::uid_min %> -F auid!=4294967295 -k <%= $auditd::config::audit_profiles::stig::audit_unsuccessful_file_operations_tag %>
 
 <%   if $facts['hardwaremodel'] == "x86_64" { -%>
-# RHEL-07-030520
--a always,exit -F arch=b64 -S openat -F exit=-EPERM -F auid>=<%= $auditd::config::audit_profiles::stig::uid_min %> -F auid!=4294967295 -k <%= $auditd::config::audit_profiles::stig::audit_unsuccessful_file_operations_tag %>
--a always,exit -F arch=b64 -S openat -F exit=-EACCES -F auid>=<%= $auditd::config::audit_profiles::stig::uid_min %> -F auid!=4294967295 -k <%= $auditd::config::audit_profiles::stig::audit_unsuccessful_file_operations_tag %>
+-a exit,always -F arch=b64 -S openat -F exit=-EPERM -F auid>=<%= $auditd::config::audit_profiles::stig::uid_min %> -F auid!=4294967295 -k <%= $auditd::config::audit_profiles::stig::audit_unsuccessful_file_operations_tag %>
+-a exit,always -F arch=b64 -S openat -F exit=-EACCES -F auid>=<%= $auditd::config::audit_profiles::stig::uid_min %> -F auid!=4294967295 -k <%= $auditd::config::audit_profiles::stig::audit_unsuccessful_file_operations_tag %>
 <%   } -%>
--a always,exit -F arch=b32 -S openat -F exit=-EPERM -F auid>=<%= $auditd::config::audit_profiles::stig::uid_min %> -F auid!=4294967295 -k <%= $auditd::config::audit_profiles::stig::audit_unsuccessful_file_operations_tag %>
--a always,exit -F arch=b32 -S openat -F exit=-EACCES -F auid>=<%= $auditd::config::audit_profiles::stig::uid_min %> -F auid!=4294967295 -k <%= $auditd::config::audit_profiles::stig::audit_unsuccessful_file_operations_tag %>
+-a exit,always -F arch=b32 -S openat -F exit=-EPERM -F auid>=<%= $auditd::config::audit_profiles::stig::uid_min %> -F auid!=4294967295 -k <%= $auditd::config::audit_profiles::stig::audit_unsuccessful_file_operations_tag %>
+-a exit,always -F arch=b32 -S openat -F exit=-EACCES -F auid>=<%= $auditd::config::audit_profiles::stig::uid_min %> -F auid!=4294967295 -k <%= $auditd::config::audit_profiles::stig::audit_unsuccessful_file_operations_tag %>
 
 <%   if $facts['hardwaremodel'] == "x86_64" { -%>
-# RHEL-07-030530
--a always,exit -F arch=b64 -S open_by_handle_at -F exit=-EPERM -F auid>=<%= $auditd::config::audit_profiles::stig::uid_min %> -F auid!=4294967295 -k <%= $auditd::config::audit_profiles::stig::audit_unsuccessful_file_operations_tag %>
--a always,exit -F arch=b64 -S open_by_handle_at -F exit=-EACCES -F auid>=<%= $auditd::config::audit_profiles::stig::uid_min %> -F auid!=4294967295 -k <%= $auditd::config::audit_profiles::stig::audit_unsuccessful_file_operations_tag %>
+-a exit,always -F arch=b64 -S open_by_handle_at -F exit=-EPERM -F auid>=<%= $auditd::config::audit_profiles::stig::uid_min %> -F auid!=4294967295 -k <%= $auditd::config::audit_profiles::stig::audit_unsuccessful_file_operations_tag %>
+-a exit,always -F arch=b64 -S open_by_handle_at -F exit=-EACCES -F auid>=<%= $auditd::config::audit_profiles::stig::uid_min %> -F auid!=4294967295 -k <%= $auditd::config::audit_profiles::stig::audit_unsuccessful_file_operations_tag %>
 <%   } -%>
--a always,exit -F arch=b32 -S open_by_handle_at -F exit=-EPERM -F auid>=<%= $auditd::config::audit_profiles::stig::uid_min %> -F auid!=4294967295 -k <%= $auditd::config::audit_profiles::stig::audit_unsuccessful_file_operations_tag %>
--a always,exit -F arch=b32 -S open_by_handle_at -F exit=-EACCES -F auid>=<%= $auditd::config::audit_profiles::stig::uid_min %> -F auid!=4294967295 -k <%= $auditd::config::audit_profiles::stig::audit_unsuccessful_file_operations_tag %>
+-a exit,always -F arch=b32 -S open_by_handle_at -F exit=-EPERM -F auid>=<%= $auditd::config::audit_profiles::stig::uid_min %> -F auid!=4294967295 -k <%= $auditd::config::audit_profiles::stig::audit_unsuccessful_file_operations_tag %>
+-a exit,always -F arch=b32 -S open_by_handle_at -F exit=-EACCES -F auid>=<%= $auditd::config::audit_profiles::stig::uid_min %> -F auid!=4294967295 -k <%= $auditd::config::audit_profiles::stig::audit_unsuccessful_file_operations_tag %>
 
 <%   if $facts['hardwaremodel'] == "x86_64" { -%>
-# RHEL-07-030540
--a always,exit -F arch=b64 -S truncate -F exit=-EPERM -F auid>=<%= $auditd::config::audit_profiles::stig::uid_min %> -F auid!=4294967295 -k <%= $auditd::config::audit_profiles::stig::audit_unsuccessful_file_operations_tag %>
--a always,exit -F arch=b64 -S truncate -F exit=-EACCES -F auid>=<%= $auditd::config::audit_profiles::stig::uid_min %> -F auid!=4294967295 -k <%= $auditd::config::audit_profiles::stig::audit_unsuccessful_file_operations_tag %>
+-a exit,always -F arch=b64 -S truncate -F exit=-EPERM -F auid>=<%= $auditd::config::audit_profiles::stig::uid_min %> -F auid!=4294967295 -k <%= $auditd::config::audit_profiles::stig::audit_unsuccessful_file_operations_tag %>
+-a exit,always -F arch=b64 -S truncate -F exit=-EACCES -F auid>=<%= $auditd::config::audit_profiles::stig::uid_min %> -F auid!=4294967295 -k <%= $auditd::config::audit_profiles::stig::audit_unsuccessful_file_operations_tag %>
 <%   } -%>
--a always,exit -F arch=b32 -S truncate -F exit=-EPERM -F auid>=<%= $auditd::config::audit_profiles::stig::uid_min %> -F auid!=4294967295 -k <%= $auditd::config::audit_profiles::stig::audit_unsuccessful_file_operations_tag %>
--a always,exit -F arch=b32 -S truncate -F exit=-EACCES -F auid>=<%= $auditd::config::audit_profiles::stig::uid_min %> -F auid!=4294967295 -k <%= $auditd::config::audit_profiles::stig::audit_unsuccessful_file_operations_tag %>
+-a exit,always -F arch=b32 -S truncate -F exit=-EPERM -F auid>=<%= $auditd::config::audit_profiles::stig::uid_min %> -F auid!=4294967295 -k <%= $auditd::config::audit_profiles::stig::audit_unsuccessful_file_operations_tag %>
+-a exit,always -F arch=b32 -S truncate -F exit=-EACCES -F auid>=<%= $auditd::config::audit_profiles::stig::uid_min %> -F auid!=4294967295 -k <%= $auditd::config::audit_profiles::stig::audit_unsuccessful_file_operations_tag %>
 
 <%   if $facts['hardwaremodel'] == "x86_64" { -%>
-# RHEL-07-030550
--a always,exit -F arch=b64 -S ftruncate -F exit=-EPERM -F auid>=<%= $auditd::config::audit_profiles::stig::uid_min %> -F auid!=4294967295 -k <%= $auditd::config::audit_profiles::stig::audit_unsuccessful_file_operations_tag %>
--a always,exit -F arch=b64 -S ftruncate -F exit=-EACCES -F auid>=<%= $auditd::config::audit_profiles::stig::uid_min %> -F auid!=4294967295 -k <%= $auditd::config::audit_profiles::stig::audit_unsuccessful_file_operations_tag %>
+-a exit,always -F arch=b64 -S ftruncate -F exit=-EPERM -F auid>=<%= $auditd::config::audit_profiles::stig::uid_min %> -F auid!=4294967295 -k <%= $auditd::config::audit_profiles::stig::audit_unsuccessful_file_operations_tag %>
+-a exit,always -F arch=b64 -S ftruncate -F exit=-EACCES -F auid>=<%= $auditd::config::audit_profiles::stig::uid_min %> -F auid!=4294967295 -k <%= $auditd::config::audit_profiles::stig::audit_unsuccessful_file_operations_tag %>
 <%   } -%>
--a always,exit -F arch=b32 -S ftruncate -F exit=-EPERM -F auid>=<%= $auditd::config::audit_profiles::stig::uid_min %> -F auid!=4294967295 -k <%= $auditd::config::audit_profiles::stig::audit_unsuccessful_file_operations_tag %>
--a always,exit -F arch=b32 -S ftruncate -F exit=-EACCES -F auid>=<%= $auditd::config::audit_profiles::stig::uid_min %> -F auid!=4294967295 -k <%= $auditd::config::audit_profiles::stig::audit_unsuccessful_file_operations_tag %>
+-a exit,always -F arch=b32 -S ftruncate -F exit=-EPERM -F auid>=<%= $auditd::config::audit_profiles::stig::uid_min %> -F auid!=4294967295 -k <%= $auditd::config::audit_profiles::stig::audit_unsuccessful_file_operations_tag %>
+-a exit,always -F arch=b32 -S ftruncate -F exit=-EACCES -F auid>=<%= $auditd::config::audit_profiles::stig::uid_min %> -F auid!=4294967295 -k <%= $auditd::config::audit_profiles::stig::audit_unsuccessful_file_operations_tag %>
 <% } -%>
 <% if $auditd::config::audit_profiles::stig::audit_passwd_cmds { -%>
 
 ## Audit the execution of password commands
-# RHEL-07-030630
--a always,exit -F path=/usr/bin/passwd -F perm=x -F auid>=<%= $auditd::config::audit_profiles::stig::uid_min %> -F auid!=4294967295 -k <%= $auditd::config::audit_profiles::stig::audit_passwd_cmds_tag %>
+-a exit,always -F path=/usr/bin/passwd -F perm=x -F auid>=<%= $auditd::config::audit_profiles::stig::uid_min %> -F auid!=4294967295 -k <%= $auditd::config::audit_profiles::stig::audit_passwd_cmds_tag %>
 <%   if $facts['os']['release']['major'] > '6' { -%>
--a always,exit -F path=/bin/passwd -F perm=x -F auid>=<%= $auditd::config::audit_profiles::stig::uid_min %> -F auid!=4294967295 -k <%= $auditd::config::audit_profiles::stig::audit_passwd_cmds_tag %>
+-a exit,always -F path=/bin/passwd -F perm=x -F auid>=<%= $auditd::config::audit_profiles::stig::uid_min %> -F auid!=4294967295 -k <%= $auditd::config::audit_profiles::stig::audit_passwd_cmds_tag %>
 <%   } -%>
 
-# RHEL-07-030640
 <%   if $facts['os']['release']['major'] > '6' { -%>
--a always,exit -F path=/usr/sbin/unix_chkpwd -F perm=x -F auid>=<%= $auditd::config::audit_profiles::stig::uid_min %> -F auid!=4294967295 -k <%= $auditd::config::audit_profiles::stig::audit_passwd_cmds_tag %>
+-a exit,always -F path=/usr/sbin/unix_chkpwd -F perm=x -F auid>=<%= $auditd::config::audit_profiles::stig::uid_min %> -F auid!=4294967295 -k <%= $auditd::config::audit_profiles::stig::audit_passwd_cmds_tag %>
 <%   } -%>
--a always,exit -F path=/sbin/unix_chkpwd -F perm=x -F auid>=<%= $auditd::config::audit_profiles::stig::uid_min %> -F auid!=4294967295 -k <%= $auditd::config::audit_profiles::stig::audit_passwd_cmds_tag %>
+-a exit,always -F path=/sbin/unix_chkpwd -F perm=x -F auid>=<%= $auditd::config::audit_profiles::stig::uid_min %> -F auid!=4294967295 -k <%= $auditd::config::audit_profiles::stig::audit_passwd_cmds_tag %>
 
-# RHEL-07-030650
--a always,exit -F path=/usr/bin/gpasswd -F perm=x -F auid>=<%= $auditd::config::audit_profiles::stig::uid_min %> -F auid!=4294967295 -k <%= $auditd::config::audit_profiles::stig::audit_passwd_cmds_tag %>
+-a exit,always -F path=/usr/bin/gpasswd -F perm=x -F auid>=<%= $auditd::config::audit_profiles::stig::uid_min %> -F auid!=4294967295 -k <%= $auditd::config::audit_profiles::stig::audit_passwd_cmds_tag %>
 <%   if $facts['os']['release']['major'] > '6' { -%>
--a always,exit -F path=/bin/gpasswd -F perm=x -F auid>=<%= $auditd::config::audit_profiles::stig::uid_min %> -F auid!=4294967295 -k <%= $auditd::config::audit_profiles::stig::audit_passwd_cmds_tag %>
+-a exit,always -F path=/bin/gpasswd -F perm=x -F auid>=<%= $auditd::config::audit_profiles::stig::uid_min %> -F auid!=4294967295 -k <%= $auditd::config::audit_profiles::stig::audit_passwd_cmds_tag %>
 <%   } -%>
 
-# RHEL-07-030660
--a always,exit -F path=/usr/bin/chage -F perm=x -F auid>=<%= $auditd::config::audit_profiles::stig::uid_min %> -F auid!=4294967295 -k <%= $auditd::config::audit_profiles::stig::audit_passwd_cmds_tag %>
+-a exit,always -F path=/usr/bin/chage -F perm=x -F auid>=<%= $auditd::config::audit_profiles::stig::uid_min %> -F auid!=4294967295 -k <%= $auditd::config::audit_profiles::stig::audit_passwd_cmds_tag %>
 <%   if $facts['os']['release']['major'] > '6' { -%>
--a always,exit -F path=/bin/chage -F perm=x -F auid>=<%= $auditd::config::audit_profiles::stig::uid_min %> -F auid!=4294967295 -k <%= $auditd::config::audit_profiles::stig::audit_passwd_cmds_tag %>
+-a exit,always -F path=/bin/chage -F perm=x -F auid>=<%= $auditd::config::audit_profiles::stig::uid_min %> -F auid!=4294967295 -k <%= $auditd::config::audit_profiles::stig::audit_passwd_cmds_tag %>
 <%   } -%>
 
-# RHEL-07-030670
--a always,exit -F path=/usr/sbin/userhelper -F perm=x -F auid>=<%= $auditd::config::audit_profiles::stig::uid_min %> -F auid!=4294967295 -k <%= $auditd::config::audit_profiles::stig::audit_passwd_cmds_tag %>
+-a exit,always -F path=/usr/sbin/userhelper -F perm=x -F auid>=<%= $auditd::config::audit_profiles::stig::uid_min %> -F auid!=4294967295 -k <%= $auditd::config::audit_profiles::stig::audit_passwd_cmds_tag %>
 <%   if $facts['os']['release']['major'] > '6' { -%>
--a always,exit -F path=/sbin/userhelper -F perm=x -F auid>=<%= $auditd::config::audit_profiles::stig::uid_min %> -F auid!=4294967295 -k <%= $auditd::config::audit_profiles::stig::audit_passwd_cmds_tag %>
+-a exit,always -F path=/sbin/userhelper -F perm=x -F auid>=<%= $auditd::config::audit_profiles::stig::uid_min %> -F auid!=4294967295 -k <%= $auditd::config::audit_profiles::stig::audit_passwd_cmds_tag %>
 <%   } -%>
 <% } -%>
 <% if $auditd::config::audit_profiles::stig::audit_priv_cmds { -%>
 
 ## Audit the execution of privilege-related commands
-# RHEL-07-030680
 <%   if $facts['os']['release']['major'] > '6' { -%>
--a always,exit -F path=/usr/bin/su -F perm=x -F auid>=<%= $auditd::config::audit_profiles::stig::uid_min %> -F auid!=4294967295 -k <%= $auditd::config::audit_profiles::stig::audit_priv_cmds_tag %>
+-a exit,always -F path=/usr/bin/su -F perm=x -F auid>=<%= $auditd::config::audit_profiles::stig::uid_min %> -F auid!=4294967295 -k <%= $auditd::config::audit_profiles::stig::audit_priv_cmds_tag %>
 <%   } -%>
--a always,exit -F path=/bin/su -F perm=x -F auid>=<%= $auditd::config::audit_profiles::stig::uid_min %> -F auid!=4294967295 -k <%= $auditd::config::audit_profiles::stig::audit_priv_cmds_tag %>
+-a exit,always -F path=/bin/su -F perm=x -F auid>=<%= $auditd::config::audit_profiles::stig::uid_min %> -F auid!=4294967295 -k <%= $auditd::config::audit_profiles::stig::audit_priv_cmds_tag %>
 
-# RHEL-07-030690
--a always,exit -F path=/usr/bin/sudo -F perm=x -F auid>=<%= $auditd::config::audit_profiles::stig::uid_min %> -F auid!=4294967295 -k <%= $auditd::config::audit_profiles::stig::audit_priv_cmds_tag %>
+-a exit,always -F path=/usr/bin/sudo -F perm=x -F auid>=<%= $auditd::config::audit_profiles::stig::uid_min %> -F auid!=4294967295 -k <%= $auditd::config::audit_profiles::stig::audit_priv_cmds_tag %>
 <%   if $facts['os']['release']['major'] > '6' { -%>
--a always,exit -F path=/bin/sudo -F perm=x -F auid>=<%= $auditd::config::audit_profiles::stig::uid_min %> -F auid!=4294967295 -k <%= $auditd::config::audit_profiles::stig::audit_priv_cmds_tag %>
+-a exit,always -F path=/bin/sudo -F perm=x -F auid>=<%= $auditd::config::audit_profiles::stig::uid_min %> -F auid!=4294967295 -k <%= $auditd::config::audit_profiles::stig::audit_priv_cmds_tag %>
 <%   } -%>
 
-# RHEL-07-030710
--a always,exit -F path=/usr/bin/newgrp -F perm=x -F auid>=<%= $auditd::config::audit_profiles::stig::uid_min %> -F auid!=4294967295 -k <%= $auditd::config::audit_profiles::stig::audit_priv_cmds_tag %>
+-a exit,always -F path=/usr/bin/newgrp -F perm=x -F auid>=<%= $auditd::config::audit_profiles::stig::uid_min %> -F auid!=4294967295 -k <%= $auditd::config::audit_profiles::stig::audit_priv_cmds_tag %>
 <%   if $facts['os']['release']['major'] > '6' { -%>
--a always,exit -F path=/bin/newgrp -F perm=x -F auid>=<%= $auditd::config::audit_profiles::stig::uid_min %> -F auid!=4294967295 -k <%= $auditd::config::audit_profiles::stig::audit_priv_cmds_tag %>
+-a exit,always -F path=/bin/newgrp -F perm=x -F auid>=<%= $auditd::config::audit_profiles::stig::uid_min %> -F auid!=4294967295 -k <%= $auditd::config::audit_profiles::stig::audit_priv_cmds_tag %>
 <%   } -%>
 
-# RHEL-07-030720
--a always,exit -F path=/usr/bin/chsh -F perm=x -F auid>=<%= $auditd::config::audit_profiles::stig::uid_min %> -F auid!=4294967295 -k <%= $auditd::config::audit_profiles::stig::audit_priv_cmds_tag %>
+-a exit,always -F path=/usr/bin/chsh -F perm=x -F auid>=<%= $auditd::config::audit_profiles::stig::uid_min %> -F auid!=4294967295 -k <%= $auditd::config::audit_profiles::stig::audit_priv_cmds_tag %>
 <%   if $facts['os']['release']['major'] > '6' { -%>
--a always,exit -F path=/bin/chsh -F perm=x -F auid>=<%= $auditd::config::audit_profiles::stig::uid_min %> -F auid!=4294967295 -k <%= $auditd::config::audit_profiles::stig::audit_priv_cmds_tag %>
+-a exit,always -F path=/bin/chsh -F perm=x -F auid>=<%= $auditd::config::audit_profiles::stig::uid_min %> -F auid!=4294967295 -k <%= $auditd::config::audit_profiles::stig::audit_priv_cmds_tag %>
 <%   } -%>
 
-# RHEL-07-030730
--a always,exit -F path=/usr/bin/sudoedit -F perm=x -F auid>=<%= $auditd::config::audit_profiles::stig::uid_min %> -F auid!=4294967295 -k <%= $auditd::config::audit_profiles::stig::audit_priv_cmds_tag %>
+-a exit,always -F path=/usr/bin/sudoedit -F perm=x -F auid>=<%= $auditd::config::audit_profiles::stig::uid_min %> -F auid!=4294967295 -k <%= $auditd::config::audit_profiles::stig::audit_priv_cmds_tag %>
 <%   if $facts['os']['release']['major'] > '6' { -%>
--a always,exit -F path=/bin/sudoedit -F perm=x -F auid>=<%= $auditd::config::audit_profiles::stig::uid_min %> -F auid!=4294967295 -k <%= $auditd::config::audit_profiles::stig::audit_priv_cmds_tag %>
+-a exit,always -F path=/bin/sudoedit -F perm=x -F auid>=<%= $auditd::config::audit_profiles::stig::uid_min %> -F auid!=4294967295 -k <%= $auditd::config::audit_profiles::stig::audit_priv_cmds_tag %>
 <%   } -%>
 <% } -%>
 <% if $auditd::config::audit_profiles::stig::audit_postfix_cmds { -%>
 
 ## Audit the execution of postfix-related commands
-# RHEL-07-030760
--a always,exit -F path=/usr/sbin/postdrop -F perm=x -F auid>=<%= $auditd::config::audit_profiles::stig::uid_min %> -F auid!=4294967295 -k <%= $auditd::config::audit_profiles::stig::audit_postfix_cmds_tag %>
+-a exit,always -F path=/usr/sbin/postdrop -F perm=x -F auid>=<%= $auditd::config::audit_profiles::stig::uid_min %> -F auid!=4294967295 -k <%= $auditd::config::audit_profiles::stig::audit_postfix_cmds_tag %>
 <%   if $facts['os']['release']['major'] > '6' { -%>
--a always,exit -F path=/sbin/postdrop -F perm=x -F auid>=<%= $auditd::config::audit_profiles::stig::uid_min %> -F auid!=4294967295 -k <%= $auditd::config::audit_profiles::stig::audit_postfix_cmds_tag %>
+-a exit,always -F path=/sbin/postdrop -F perm=x -F auid>=<%= $auditd::config::audit_profiles::stig::uid_min %> -F auid!=4294967295 -k <%= $auditd::config::audit_profiles::stig::audit_postfix_cmds_tag %>
 <%   } -%>
 
-# RHEL-07-030770
--a always,exit -F path=/usr/sbin/postqueue -F perm=x -F auid>=<%= $auditd::config::audit_profiles::stig::uid_min %> -F auid!=4294967295 -k <%= $auditd::config::audit_profiles::stig::audit_postfix_cmds_tag %>
+-a exit,always -F path=/usr/sbin/postqueue -F perm=x -F auid>=<%= $auditd::config::audit_profiles::stig::uid_min %> -F auid!=4294967295 -k <%= $auditd::config::audit_profiles::stig::audit_postfix_cmds_tag %>
 <%   if $facts['os']['release']['major'] > '6' { -%>
--a always,exit -F path=/sbin/postqueue -F perm=x -F auid>=<%= $auditd::config::audit_profiles::stig::uid_min %> -F auid!=4294967295 -k <%= $auditd::config::audit_profiles::stig::audit_postfix_cmds_tag %>
+-a exit,always -F path=/sbin/postqueue -F perm=x -F auid>=<%= $auditd::config::audit_profiles::stig::uid_min %> -F auid!=4294967295 -k <%= $auditd::config::audit_profiles::stig::audit_postfix_cmds_tag %>
 <%   } -%>
 <% } -%>
 <% if $auditd::config::audit_profiles::stig::audit_ssh_keysign_cmd { -%>
 
 ## Audit the execution of the ssh-keysign command
-# RHEL-07-030780
--a always,exit -F path=/usr/libexec/openssh/ssh-keysign -F perm=x -F auid>=<%= $auditd::config::audit_profiles::stig::uid_min %> -F auid!=4294967295 -k <%= $auditd::config::audit_profiles::stig::audit_ssh_keysign_cmd_tag %>
+-a exit,always -F path=/usr/libexec/openssh/ssh-keysign -F perm=x -F auid>=<%= $auditd::config::audit_profiles::stig::uid_min %> -F auid!=4294967295 -k <%= $auditd::config::audit_profiles::stig::audit_ssh_keysign_cmd_tag %>
 <% } -%>
 <% if $auditd::config::audit_profiles::stig::audit_crontab_cmd { -%>
 
 ## Audit the execution of the crontab command
-# RHEL-07-030800
--a always,exit -F path=/usr/bin/crontab -F perm=x -F auid>=<%= $auditd::config::audit_profiles::stig::uid_min %> -F auid!=4294967295 -k <%= $auditd::config::audit_profiles::stig::audit_crontab_cmd_tag %>
+-a exit,always -F path=/usr/bin/crontab -F perm=x -F auid>=<%= $auditd::config::audit_profiles::stig::uid_min %> -F auid!=4294967295 -k <%= $auditd::config::audit_profiles::stig::audit_crontab_cmd_tag %>
 <%   if $facts['os']['release']['major'] > '6' { -%>
--a always,exit -F path=/bin/crontab -F perm=x -F auid>=<%= $auditd::config::audit_profiles::stig::uid_min %> -F auid!=4294967295 -k <%= $auditd::config::audit_profiles::stig::audit_crontab_cmd_tag %>
+-a exit,always -F path=/bin/crontab -F perm=x -F auid>=<%= $auditd::config::audit_profiles::stig::uid_min %> -F auid!=4294967295 -k <%= $auditd::config::audit_profiles::stig::audit_crontab_cmd_tag %>
 <%   } -%>
 <% } -%>
 <% if $auditd::config::audit_profiles::stig::audit_pam_timestamp_check_cmd { -%>
 
 ## Audit the execution of the pam_timestamp_check command
-# RHEL-07-030810
 <%   if $facts['os']['release']['major'] > '6' { -%>
--a always,exit -F path=/usr/sbin/pam_timestamp_check -F perm=x -F auid>=<%= $auditd::config::audit_profiles::stig::uid_min %> -F auid!=4294967295 -k <%= $auditd::config::audit_profiles::stig::audit_pam_timestamp_check_cmd_tag %>
+-a exit,always -F path=/usr/sbin/pam_timestamp_check -F perm=x -F auid>=<%= $auditd::config::audit_profiles::stig::uid_min %> -F auid!=4294967295 -k <%= $auditd::config::audit_profiles::stig::audit_pam_timestamp_check_cmd_tag %>
 <%   } -%>
--a always,exit -F path=/sbin/pam_timestamp_check -F perm=x -F auid>=<%= $auditd::config::audit_profiles::stig::uid_min %> -F auid!=4294967295 -k <%= $auditd::config::audit_profiles::stig::audit_pam_timestamp_check_cmd_tag %>
+-a exit,always -F path=/sbin/pam_timestamp_check -F perm=x -F auid>=<%= $auditd::config::audit_profiles::stig::uid_min %> -F auid!=4294967295 -k <%= $auditd::config::audit_profiles::stig::audit_pam_timestamp_check_cmd_tag %>
 <% } -%>
 <% if $auditd::config::audit_profiles::stig::audit_selinux_cmds { -%>
 
 ## Audit selinux commands
-# RHEL-07-030560
--a always,exit -F path=/usr/sbin/semanage -F perm=x -F auid>=<%= $auditd::config::audit_profiles::stig::uid_min %> -F auid!=4294967295 -k <%= $auditd::config::audit_profiles::stig::audit_selinux_cmds_tag %>
+-a exit,always -F path=/usr/sbin/semanage -F perm=x -F auid>=<%= $auditd::config::audit_profiles::stig::uid_min %> -F auid!=4294967295 -k <%= $auditd::config::audit_profiles::stig::audit_selinux_cmds_tag %>
 <%   if $facts['os']['release']['major'] > '6' { -%>
--a always,exit -F path=/sbin/semanage -F perm=x -F auid>=<%= $auditd::config::audit_profiles::stig::uid_min %> -F auid!=4294967295 -k <%= $auditd::config::audit_profiles::stig::audit_selinux_cmds_tag %>
+-a exit,always -F path=/sbin/semanage -F perm=x -F auid>=<%= $auditd::config::audit_profiles::stig::uid_min %> -F auid!=4294967295 -k <%= $auditd::config::audit_profiles::stig::audit_selinux_cmds_tag %>
 <%   } -%>
 
-# RHEL-07-030570
--a always,exit -F path=/usr/sbin/setsebool -F perm=x -F auid>=<%= $auditd::config::audit_profiles::stig::uid_min %> -F auid!=4294967295 -k <%= $auditd::config::audit_profiles::stig::audit_selinux_cmds_tag %>
+-a exit,always -F path=/usr/sbin/setsebool -F perm=x -F auid>=<%= $auditd::config::audit_profiles::stig::uid_min %> -F auid!=4294967295 -k <%= $auditd::config::audit_profiles::stig::audit_selinux_cmds_tag %>
 <%   if $facts['os']['release']['major'] > '6' { -%>
--a always,exit -F path=/sbin/setsebool -F perm=x -F auid>=<%= $auditd::config::audit_profiles::stig::uid_min %> -F auid!=4294967295 -k <%= $auditd::config::audit_profiles::stig::audit_selinux_cmds_tag %>
+-a exit,always -F path=/sbin/setsebool -F perm=x -F auid>=<%= $auditd::config::audit_profiles::stig::uid_min %> -F auid!=4294967295 -k <%= $auditd::config::audit_profiles::stig::audit_selinux_cmds_tag %>
 <%   } -%>
 
-# RHEL-07-030580
--a always,exit -F path=/usr/bin/chcon -F perm=x -F auid>=<%= $auditd::config::audit_profiles::stig::uid_min %> -F auid!=4294967295 -k <%= $auditd::config::audit_profiles::stig::audit_selinux_cmds_tag %>
+-a exit,always -F path=/usr/bin/chcon -F perm=x -F auid>=<%= $auditd::config::audit_profiles::stig::uid_min %> -F auid!=4294967295 -k <%= $auditd::config::audit_profiles::stig::audit_selinux_cmds_tag %>
 <%   if $facts['os']['release']['major'] > '6' { -%>
--a always,exit -F path=/bin/chcon -F perm=x -F auid>=<%= $auditd::config::audit_profiles::stig::uid_min %> -F auid!=4294967295 -k <%= $auditd::config::audit_profiles::stig::audit_selinux_cmds_tag %>
+-a exit,always -F path=/bin/chcon -F perm=x -F auid>=<%= $auditd::config::audit_profiles::stig::uid_min %> -F auid!=4294967295 -k <%= $auditd::config::audit_profiles::stig::audit_selinux_cmds_tag %>
 <%   } -%>
 
-# RHEL-07-030590
 <%   if $facts['os']['release']['major'] > '6' { -%>
--a always,exit -F path=/usr/sbin/setfiles -F perm=x -F auid>=<%= $auditd::config::audit_profiles::stig::uid_min %> -F auid!=4294967295 -k <%= $auditd::config::audit_profiles::stig::audit_selinux_cmds_tag %>
+-a exit,always -F path=/usr/sbin/setfiles -F perm=x -F auid>=<%= $auditd::config::audit_profiles::stig::uid_min %> -F auid!=4294967295 -k <%= $auditd::config::audit_profiles::stig::audit_selinux_cmds_tag %>
 <%   } -%>
--a always,exit -F path=/sbin/setfiles -F perm=x -F auid>=<%= $auditd::config::audit_profiles::stig::uid_min %> -F auid!=4294967295 -k <%= $auditd::config::audit_profiles::stig::audit_selinux_cmds_tag %>
+-a exit,always -F path=/sbin/setfiles -F perm=x -F auid>=<%= $auditd::config::audit_profiles::stig::uid_min %> -F auid!=4294967295 -k <%= $auditd::config::audit_profiles::stig::audit_selinux_cmds_tag %>
 
-# RHEL-07-030590
--a always,exit -F path=/sbin/restorecon -F perm=x -F auid>=<%= $auditd::config::audit_profiles::stig::uid_min %> -F auid!=4294967295 -k <%= $auditd::config::audit_profiles::stig::audit_selinux_cmds_tag %>
+-a exit,always -F path=/sbin/restorecon -F perm=x -F auid>=<%= $auditd::config::audit_profiles::stig::uid_min %> -F auid!=4294967295 -k <%= $auditd::config::audit_profiles::stig::audit_selinux_cmds_tag %>
 <%   if $facts['os']['release']['major'] > '6' { -%>
--a always,exit -F path=/usr/sbin/restorecon -F perm=x -F auid>=<%= $auditd::config::audit_profiles::stig::uid_min %> -F auid!=4294967295 -k <%= $auditd::config::audit_profiles::stig::audit_selinux_cmds_tag %>
+-a exit,always -F path=/usr/sbin/restorecon -F perm=x -F auid>=<%= $auditd::config::audit_profiles::stig::uid_min %> -F auid!=4294967295 -k <%= $auditd::config::audit_profiles::stig::audit_selinux_cmds_tag %>
 <%   } -%>
 <% } -%>
 
 ## Permissions auditing separated by chown, chmod, and attr
 <% if $auditd::config::audit_profiles::stig::audit_chown { -%>
-# RHEL-07-030370
 <%   if $facts['hardwaremodel'] == "x86_64" { -%>
--a always,exit -F arch=b64 -S chown -F auid>=<%= $auditd::config::audit_profiles::stig::uid_min %> -F auid!=4294967295 -k <%= $auditd::config::audit_profiles::stig::audit_chown_tag %>
+-a exit,always -F arch=b64 -S chown -F auid>=<%= $auditd::config::audit_profiles::stig::uid_min %> -F auid!=4294967295 -k <%= $auditd::config::audit_profiles::stig::audit_chown_tag %>
 <%   } -%>
--a always,exit -F arch=b32 -S chown -F auid>=<%= $auditd::config::audit_profiles::stig::uid_min %> -F auid!=4294967295 -k <%= $auditd::config::audit_profiles::stig::audit_chown_tag %>
+-a exit,always -F arch=b32 -S chown -F auid>=<%= $auditd::config::audit_profiles::stig::uid_min %> -F auid!=4294967295 -k <%= $auditd::config::audit_profiles::stig::audit_chown_tag %>
 
-# RHEL-07-030380
 <%   if $facts['hardwaremodel'] == "x86_64" { -%>
--a always,exit -F arch=b64 -S fchown -F auid>=<%= $auditd::config::audit_profiles::stig::uid_min %> -F auid!=4294967295 -k <%= $auditd::config::audit_profiles::stig::audit_chown_tag %>
+-a exit,always -F arch=b64 -S fchown -F auid>=<%= $auditd::config::audit_profiles::stig::uid_min %> -F auid!=4294967295 -k <%= $auditd::config::audit_profiles::stig::audit_chown_tag %>
 <%   } -%>
--a always,exit -F arch=b32 -S fchown -F auid>=<%= $auditd::config::audit_profiles::stig::uid_min %> -F auid!=4294967295 -k <%= $auditd::config::audit_profiles::stig::audit_chown_tag %>
+-a exit,always -F arch=b32 -S fchown -F auid>=<%= $auditd::config::audit_profiles::stig::uid_min %> -F auid!=4294967295 -k <%= $auditd::config::audit_profiles::stig::audit_chown_tag %>
 
-# RHEL-07-030390
 <%   if $facts['hardwaremodel'] == "x86_64" { -%>
--a always,exit -F arch=b64 -S lchown -F auid>=<%= $auditd::config::audit_profiles::stig::uid_min %> -F auid!=4294967295 -k <%= $auditd::config::audit_profiles::stig::audit_chown_tag %>
+-a exit,always -F arch=b64 -S lchown -F auid>=<%= $auditd::config::audit_profiles::stig::uid_min %> -F auid!=4294967295 -k <%= $auditd::config::audit_profiles::stig::audit_chown_tag %>
 <%   } -%>
--a always,exit -F arch=b32 -S lchown -F auid>=<%= $auditd::config::audit_profiles::stig::uid_min %> -F auid!=4294967295 -k <%= $auditd::config::audit_profiles::stig::audit_chown_tag %>
+-a exit,always -F arch=b32 -S lchown -F auid>=<%= $auditd::config::audit_profiles::stig::uid_min %> -F auid!=4294967295 -k <%= $auditd::config::audit_profiles::stig::audit_chown_tag %>
 
-# RHEL-07-030400
 <%   if $facts['hardwaremodel'] == "x86_64" { -%>
--a always,exit -F arch=b64 -S fchownat -F auid>=<%= $auditd::config::audit_profiles::stig::uid_min %> -F auid!=4294967295 -k <%= $auditd::config::audit_profiles::stig::audit_chown_tag %>
+-a exit,always -F arch=b64 -S fchownat -F auid>=<%= $auditd::config::audit_profiles::stig::uid_min %> -F auid!=4294967295 -k <%= $auditd::config::audit_profiles::stig::audit_chown_tag %>
 <%   } -%>
--a always,exit -F arch=b32 -S fchownat -F auid>=<%= $auditd::config::audit_profiles::stig::uid_min %> -F auid!=4294967295 -k <%= $auditd::config::audit_profiles::stig::audit_chown_tag %>
+-a exit,always -F arch=b32 -S fchownat -F auid>=<%= $auditd::config::audit_profiles::stig::uid_min %> -F auid!=4294967295 -k <%= $auditd::config::audit_profiles::stig::audit_chown_tag %>
 <% } -%>
 <% if $auditd::config::audit_profiles::stig::audit_chmod { -%>
 
-# RHEL-07-030410
--a always,exit -F arch=b64 -S chmod -F auid>=<%= $auditd::config::audit_profiles::stig::uid_min %> -F auid!=4294967295 -k <%= $auditd::config::audit_profiles::stig::audit_chmod_tag %>
+-a exit,always -F arch=b64 -S chmod -F auid>=<%= $auditd::config::audit_profiles::stig::uid_min %> -F auid!=4294967295 -k <%= $auditd::config::audit_profiles::stig::audit_chmod_tag %>
 <%   if $facts['hardwaremodel'] == "x86_64" { -%>
--a always,exit -F arch=b32 -S chmod -F auid>=<%= $auditd::config::audit_profiles::stig::uid_min %> -F auid!=4294967295 -k <%= $auditd::config::audit_profiles::stig::audit_chmod_tag %>
+-a exit,always -F arch=b32 -S chmod -F auid>=<%= $auditd::config::audit_profiles::stig::uid_min %> -F auid!=4294967295 -k <%= $auditd::config::audit_profiles::stig::audit_chmod_tag %>
 <%   } -%>
 
-# RHEL-07-030420
--a always,exit -F arch=b64 -S fchmod -F auid>=<%= $auditd::config::audit_profiles::stig::uid_min %> -F auid!=4294967295 -k <%= $auditd::config::audit_profiles::stig::audit_chmod_tag %>
+-a exit,always -F arch=b64 -S fchmod -F auid>=<%= $auditd::config::audit_profiles::stig::uid_min %> -F auid!=4294967295 -k <%= $auditd::config::audit_profiles::stig::audit_chmod_tag %>
 <%   if $facts['hardwaremodel'] == "x86_64" { -%>
--a always,exit -F arch=b32 -S fchmod -F auid>=<%= $auditd::config::audit_profiles::stig::uid_min %> -F auid!=4294967295 -k <%= $auditd::config::audit_profiles::stig::audit_chmod_tag %>
+-a exit,always -F arch=b32 -S fchmod -F auid>=<%= $auditd::config::audit_profiles::stig::uid_min %> -F auid!=4294967295 -k <%= $auditd::config::audit_profiles::stig::audit_chmod_tag %>
 <%   } -%>
 
-# RHEL-07-030430
--a always,exit -F arch=b64 -S fchmodat -F auid>=<%= $auditd::config::audit_profiles::stig::uid_min %> -F auid!=4294967295 -k <%= $auditd::config::audit_profiles::stig::audit_chmod_tag %>
+-a exit,always -F arch=b64 -S fchmodat -F auid>=<%= $auditd::config::audit_profiles::stig::uid_min %> -F auid!=4294967295 -k <%= $auditd::config::audit_profiles::stig::audit_chmod_tag %>
 <%   if $facts['hardwaremodel'] == "x86_64" { -%>
--a always,exit -F arch=b32 -S fchmodat -F auid>=<%= $auditd::config::audit_profiles::stig::uid_min %> -F auid!=4294967295 -k <%= $auditd::config::audit_profiles::stig::audit_chmod_tag %>
+-a exit,always -F arch=b32 -S fchmodat -F auid>=<%= $auditd::config::audit_profiles::stig::uid_min %> -F auid!=4294967295 -k <%= $auditd::config::audit_profiles::stig::audit_chmod_tag %>
 <%   } -%>
 <% } -%>
 <% if $auditd::config::audit_profiles::stig::audit_attr { -%>
 
-# RHEL-07-030440
 <%   if $facts['hardwaremodel'] == "x86_64" { -%>
--a always,exit -F arch=b64 -S setxattr -F auid>=<%= $auditd::config::audit_profiles::stig::uid_min %> -F auid!=4294967295 -k <%= $auditd::config::audit_profiles::stig::audit_attr_tag %>
+-a exit,always -F arch=b64 -S setxattr -F auid>=<%= $auditd::config::audit_profiles::stig::uid_min %> -F auid!=4294967295 -k <%= $auditd::config::audit_profiles::stig::audit_attr_tag %>
 <%   } -%>
--a always,exit -F arch=b32 -S setxattr -F auid>=<%= $auditd::config::audit_profiles::stig::uid_min %> -F auid!=4294967295 -k <%= $auditd::config::audit_profiles::stig::audit_attr_tag %>
+-a exit,always -F arch=b32 -S setxattr -F auid>=<%= $auditd::config::audit_profiles::stig::uid_min %> -F auid!=4294967295 -k <%= $auditd::config::audit_profiles::stig::audit_attr_tag %>
 
-# RHEL-07-030450
 <%   if $facts['hardwaremodel'] == "x86_64" { -%>
--a always,exit -F arch=b64 -S fsetxattr -F auid>=<%= $auditd::config::audit_profiles::stig::uid_min %> -F auid!=4294967295 -k <%= $auditd::config::audit_profiles::stig::audit_attr_tag %>
+-a exit,always -F arch=b64 -S fsetxattr -F auid>=<%= $auditd::config::audit_profiles::stig::uid_min %> -F auid!=4294967295 -k <%= $auditd::config::audit_profiles::stig::audit_attr_tag %>
 <%   } -%>
--a always,exit -F arch=b32 -S fsetxattr -F auid>=<%= $auditd::config::audit_profiles::stig::uid_min %> -F auid!=4294967295 -k <%= $auditd::config::audit_profiles::stig::audit_attr_tag %>
+-a exit,always -F arch=b32 -S fsetxattr -F auid>=<%= $auditd::config::audit_profiles::stig::uid_min %> -F auid!=4294967295 -k <%= $auditd::config::audit_profiles::stig::audit_attr_tag %>
 
-# RHEL-07-030460
 <%   if $facts['hardwaremodel'] == "x86_64" { -%>
--a always,exit -F arch=b64 -S lsetxattr -F auid>=<%= $auditd::config::audit_profiles::stig::uid_min %> -F auid!=4294967295 -k <%= $auditd::config::audit_profiles::stig::audit_attr_tag %>
+-a exit,always -F arch=b64 -S lsetxattr -F auid>=<%= $auditd::config::audit_profiles::stig::uid_min %> -F auid!=4294967295 -k <%= $auditd::config::audit_profiles::stig::audit_attr_tag %>
 <%   } -%>
--a always,exit -F arch=b32 -S lsetxattr -F auid>=<%= $auditd::config::audit_profiles::stig::uid_min %> -F auid!=4294967295 -k <%= $auditd::config::audit_profiles::stig::audit_attr_tag %>
+-a exit,always -F arch=b32 -S lsetxattr -F auid>=<%= $auditd::config::audit_profiles::stig::uid_min %> -F auid!=4294967295 -k <%= $auditd::config::audit_profiles::stig::audit_attr_tag %>
 
-# RHEL-07-030470
 <%   if $facts['hardwaremodel'] == "x86_64" { -%>
--a always,exit -F arch=b64 -S removexattr -F auid>=<%= $auditd::config::audit_profiles::stig::uid_min %> -F auid!=4294967295 -k <%= $auditd::config::audit_profiles::stig::audit_attr_tag %>
+-a exit,always -F arch=b64 -S removexattr -F auid>=<%= $auditd::config::audit_profiles::stig::uid_min %> -F auid!=4294967295 -k <%= $auditd::config::audit_profiles::stig::audit_attr_tag %>
 <%   } -%>
--a always,exit -F arch=b32 -S removexattr -F auid>=<%= $auditd::config::audit_profiles::stig::uid_min %> -F auid!=4294967295 -k <%= $auditd::config::audit_profiles::stig::audit_attr_tag %>
+-a exit,always -F arch=b32 -S removexattr -F auid>=<%= $auditd::config::audit_profiles::stig::uid_min %> -F auid!=4294967295 -k <%= $auditd::config::audit_profiles::stig::audit_attr_tag %>
 
-# RHEL-07-030480
 <%   if $facts['hardwaremodel'] == "x86_64" { -%>
--a always,exit -F arch=b64 -S fremovexattr -F auid>=<%= $auditd::config::audit_profiles::stig::uid_min %> -F auid!=4294967295 -k <%= $auditd::config::audit_profiles::stig::audit_attr_tag %>
+-a exit,always -F arch=b64 -S fremovexattr -F auid>=<%= $auditd::config::audit_profiles::stig::uid_min %> -F auid!=4294967295 -k <%= $auditd::config::audit_profiles::stig::audit_attr_tag %>
 <%   } -%>
--a always,exit -F arch=b32 -S fremovexattr -F auid>=<%= $auditd::config::audit_profiles::stig::uid_min %> -F auid!=4294967295 -k <%= $auditd::config::audit_profiles::stig::audit_attr_tag %>
+-a exit,always -F arch=b32 -S fremovexattr -F auid>=<%= $auditd::config::audit_profiles::stig::uid_min %> -F auid!=4294967295 -k <%= $auditd::config::audit_profiles::stig::audit_attr_tag %>
 
-# RHEL-07-030490
 <%   if $facts['hardwaremodel'] == "x86_64" { -%>
--a always,exit -F arch=b64 -S lremovexattr -F auid>=<%= $auditd::config::audit_profiles::stig::uid_min %> -F auid!=4294967295 -k <%= $auditd::config::audit_profiles::stig::audit_attr_tag %>
+-a exit,always -F arch=b64 -S lremovexattr -F auid>=<%= $auditd::config::audit_profiles::stig::uid_min %> -F auid!=4294967295 -k <%= $auditd::config::audit_profiles::stig::audit_attr_tag %>
 <%   } -%>
--a always,exit -F arch=b32 -S lremovexattr -F auid>=<%= $auditd::config::audit_profiles::stig::uid_min %> -F auid!=4294967295 -k <%= $auditd::config::audit_profiles::stig::audit_attr_tag %>
+-a exit,always -F arch=b32 -S lremovexattr -F auid>=<%= $auditd::config::audit_profiles::stig::uid_min %> -F auid!=4294967295 -k <%= $auditd::config::audit_profiles::stig::audit_attr_tag %>
 <% } -%>
 <% if $auditd::config::audit_profiles::stig::audit_rename_remove { -%>
 
 ## Audit rename/removal operations
-# RHEL-07-030880
 <%   if $facts['hardwaremodel'] == "x86_64" { -%>
--a always,exit -F arch=b64 -S rename -F perm=x -F auid>=<%= $auditd::config::audit_profiles::stig::uid_min %> -F auid!=4294967295 -k <%= $auditd::config::audit_profiles::stig::audit_rename_remove_tag %>
+-a exit,always -F arch=b64 -S rename -F perm=x -F auid>=<%= $auditd::config::audit_profiles::stig::uid_min %> -F auid!=4294967295 -k <%= $auditd::config::audit_profiles::stig::audit_rename_remove_tag %>
 <%   } -%>
--a always,exit -F arch=b32 -S rename -F perm=x -F auid>=<%= $auditd::config::audit_profiles::stig::uid_min %> -F auid!=4294967295 -k <%= $auditd::config::audit_profiles::stig::audit_rename_remove_tag %>
+-a exit,always -F arch=b32 -S rename -F perm=x -F auid>=<%= $auditd::config::audit_profiles::stig::uid_min %> -F auid!=4294967295 -k <%= $auditd::config::audit_profiles::stig::audit_rename_remove_tag %>
 
-# RHEL-07-030890
 <%   if $facts['hardwaremodel'] == "x86_64" { -%>
--a always,exit -F arch=b64 -S renameat -F perm=x -F auid>=<%= $auditd::config::audit_profiles::stig::uid_min %> -F auid!=4294967295 -k <%= $auditd::config::audit_profiles::stig::audit_rename_remove_tag %>
+-a exit,always -F arch=b64 -S renameat -F perm=x -F auid>=<%= $auditd::config::audit_profiles::stig::uid_min %> -F auid!=4294967295 -k <%= $auditd::config::audit_profiles::stig::audit_rename_remove_tag %>
 <%   } -%>
--a always,exit -F arch=b32 -S renameat -F perm=x -F auid>=<%= $auditd::config::audit_profiles::stig::uid_min %> -F auid!=4294967295 -k <%= $auditd::config::audit_profiles::stig::audit_rename_remove_tag %>
+-a exit,always -F arch=b32 -S renameat -F perm=x -F auid>=<%= $auditd::config::audit_profiles::stig::uid_min %> -F auid!=4294967295 -k <%= $auditd::config::audit_profiles::stig::audit_rename_remove_tag %>
 
-# RHEL-07-030900
 <%   if $facts['hardwaremodel'] == "x86_64" { -%>
--a always,exit -F arch=b64 -S rmdir -F perm=x -F auid>=<%= $auditd::config::audit_profiles::stig::uid_min %> -F auid!=4294967295 -k <%= $auditd::config::audit_profiles::stig::audit_rename_remove_tag %>
+-a exit,always -F arch=b64 -S rmdir -F perm=x -F auid>=<%= $auditd::config::audit_profiles::stig::uid_min %> -F auid!=4294967295 -k <%= $auditd::config::audit_profiles::stig::audit_rename_remove_tag %>
 <%   } -%>
--a always,exit -F arch=b32 -S rmdir -F perm=x -F auid>=<%= $auditd::config::audit_profiles::stig::uid_min %> -F auid!=4294967295 -k <%= $auditd::config::audit_profiles::stig::audit_rename_remove_tag %>
+-a exit,always -F arch=b32 -S rmdir -F perm=x -F auid>=<%= $auditd::config::audit_profiles::stig::uid_min %> -F auid!=4294967295 -k <%= $auditd::config::audit_profiles::stig::audit_rename_remove_tag %>
 
-# RHEL-07-030910
 <%   if $facts['hardwaremodel'] == "x86_64" { -%>
--a always,exit -F arch=b64 -S unlink -F perm=x -F auid>=<%= $auditd::config::audit_profiles::stig::uid_min %> -F auid!=4294967295 -k <%= $auditd::config::audit_profiles::stig::audit_rename_remove_tag %>
+-a exit,always -F arch=b64 -S unlink -F perm=x -F auid>=<%= $auditd::config::audit_profiles::stig::uid_min %> -F auid!=4294967295 -k <%= $auditd::config::audit_profiles::stig::audit_rename_remove_tag %>
 <%   } -%>
--a always,exit -F arch=b32 -S unlink -F perm=x -F auid>=<%= $auditd::config::audit_profiles::stig::uid_min %> -F auid!=4294967295 -k <%= $auditd::config::audit_profiles::stig::audit_rename_remove_tag %>
+-a exit,always -F arch=b32 -S unlink -F perm=x -F auid>=<%= $auditd::config::audit_profiles::stig::uid_min %> -F auid!=4294967295 -k <%= $auditd::config::audit_profiles::stig::audit_rename_remove_tag %>
 
-# RHEL-07-030920
 <%   if $facts['hardwaremodel'] == "x86_64" { -%>
--a always,exit -F arch=b64 -S unlinkat -F perm=x -F auid>=<%= $auditd::config::audit_profiles::stig::uid_min %> -F auid!=4294967295 -k <%= $auditd::config::audit_profiles::stig::audit_rename_remove_tag %>
+-a exit,always -F arch=b64 -S unlinkat -F perm=x -F auid>=<%= $auditd::config::audit_profiles::stig::uid_min %> -F auid!=4294967295 -k <%= $auditd::config::audit_profiles::stig::audit_rename_remove_tag %>
 <%   } -%>
--a always,exit -F arch=b32 -S unlinkat -F perm=x -F auid>=<%= $auditd::config::audit_profiles::stig::uid_min %> -F auid!=4294967295 -k <%= $auditd::config::audit_profiles::stig::audit_rename_remove_tag %>
+-a exit,always -F arch=b32 -S unlinkat -F perm=x -F auid>=<%= $auditd::config::audit_profiles::stig::uid_min %> -F auid!=4294967295 -k <%= $auditd::config::audit_profiles::stig::audit_rename_remove_tag %>
 <% } -%>
 <% if $auditd::config::audit_profiles::stig::audit_suid_sgid { -%>
 
 ## Audit the execution of suid and sgid binaries.
-# RHEL-07-030360
 <%   $auditd::config::audit_profiles::stig::_suid_sgid_cmds.each |$cmd| { -%>
--a always,exit -F path=<%= $cmd %> -F perm=x -F auid>=<%= $auditd::config::audit_profiles::stig::uid_min %> -F auid!=4294967295 -k <%= $auditd::config::audit_profiles::stig::audit_suid_sgid_tag %>
+-a exit,always -F path=<%= $cmd %> -F perm=x -F auid>=<%= $auditd::config::audit_profiles::stig::uid_min %> -F auid!=4294967295 -k <%= $auditd::config::audit_profiles::stig::audit_suid_sgid_tag %>
 <%   } -%>
 <% } -%>
 <% if $auditd::config::audit_profiles::stig::audit_kernel_modules { -%>
 
 ## Audit the loading and unloading of kernel modules.
-# RHEL-07-030840
 <%   if $facts['os']['release']['major'] > '6' { -%>
 -w /usr/sbin/insmod -p x -F auid!=4294967295 -k <%= $auditd::config::audit_profiles::stig::audit_kernel_modules_tag %>
 <%   } -%>
 -w /sbin/insmod -p x -F auid!=4294967295 -k <%= $auditd::config::audit_profiles::stig::audit_kernel_modules_tag %>
 
-# RHEL-07-030850
 <%   if $facts['os']['release']['major'] > '6' { -%>
 -w /usr/sbin/rmmod -p x -F auid!=4294967295 -k <%= $auditd::config::audit_profiles::stig::audit_kernel_modules_tag %>
 <%   } -%>
 -w /sbin/rmmod -p x -F auid!=4294967295 -k <%= $auditd::config::audit_profiles::stig::audit_kernel_modules_tag %>
 
-# RHEL-07-030860
 <%   if $facts['os']['release']['major'] > '6' { -%>
 -w /usr/sbin/modprobe -p x -F auid!=4294967295 -k <%= $auditd::config::audit_profiles::stig::audit_kernel_modules_tag %>
 <%   } -%>
 -w /sbin/modprobe -p x -F auid!=4294967295 -k <%= $auditd::config::audit_profiles::stig::audit_kernel_modules_tag %>
 
-# RHEL-07-030819
 <%   if $facts['hardwaremodel'] == "x86_64" { -%>
--a always,exit -F arch=b64 -S create_module -k <%= $auditd::config::audit_profiles::stig::audit_kernel_modules_tag %>
+-a exit,always -F arch=b64 -S create_module -k <%= $auditd::config::audit_profiles::stig::audit_kernel_modules_tag %>
 <%   } -%>
--a always,exit -F arch=b32 -S create_module -k <%= $auditd::config::audit_profiles::stig::audit_kernel_modules_tag %>
+-a exit,always -F arch=b32 -S create_module -k <%= $auditd::config::audit_profiles::stig::audit_kernel_modules_tag %>
 
-# RHEL-07-030820
 <%   if $facts['hardwaremodel'] == "x86_64" { -%>
--a always,exit -F arch=b64 -S init_module -k <%= $auditd::config::audit_profiles::stig::audit_kernel_modules_tag %>
+-a exit,always -F arch=b64 -S init_module -k <%= $auditd::config::audit_profiles::stig::audit_kernel_modules_tag %>
 <%   } -%>
--a always,exit -F arch=b32 -S init_module -k <%= $auditd::config::audit_profiles::stig::audit_kernel_modules_tag %>
+-a exit,always -F arch=b32 -S init_module -k <%= $auditd::config::audit_profiles::stig::audit_kernel_modules_tag %>
 
-# RHEL-07-030821
 <%   if $facts['hardwaremodel'] == "x86_64" { -%>
--a always,exit -F arch=b64 -S finit_module -k <%= $auditd::config::audit_profiles::stig::audit_kernel_modules_tag %>
+-a exit,always -F arch=b64 -S finit_module -k <%= $auditd::config::audit_profiles::stig::audit_kernel_modules_tag %>
 <%   } -%>
--a always,exit -F arch=b32 -S finit_module -k <%= $auditd::config::audit_profiles::stig::audit_kernel_modules_tag %>
+-a exit,always -F arch=b32 -S finit_module -k <%= $auditd::config::audit_profiles::stig::audit_kernel_modules_tag %>
 
-# RHEL-07-030830
 <%   if $facts['hardwaremodel'] == "x86_64" { -%>
--a always,exit -F arch=b64 -S delete_module -k <%= $auditd::config::audit_profiles::stig::audit_kernel_modules_tag %>
+-a exit,always -F arch=b64 -S delete_module -k <%= $auditd::config::audit_profiles::stig::audit_kernel_modules_tag %>
 <%   } -%>
--a always,exit -F arch=b32 -S delete_module -k <%= $auditd::config::audit_profiles::stig::audit_kernel_modules_tag %>
+-a exit,always -F arch=b32 -S delete_module -k <%= $auditd::config::audit_profiles::stig::audit_kernel_modules_tag %>
 <% } -%>
 <% if $auditd::config::audit_profiles::stig::audit_mount { -%>
 
 ## Audit mount operations
-# RHEL-07-030740
 <%   if $facts['hardwaremodel'] == "x86_64" { -%>
--a always,exit -F arch=b64 -S mount -F auid>=<%= $auditd::config::audit_profiles::stig::uid_min %> -F auid!=4294967295 -k <%= $auditd::config::audit_profiles::stig::audit_mount_tag %>
+-a exit,always -F arch=b64 -S mount -F auid>=<%= $auditd::config::audit_profiles::stig::uid_min %> -F auid!=4294967295 -k <%= $auditd::config::audit_profiles::stig::audit_mount_tag %>
 <%     if $facts['os']['release']['major'] > '6' { -%>
--a always,exit -F arch=b64 -F path=/usr/bin/mount -F auid>=<%= $auditd::config::audit_profiles::stig::uid_min %> -F auid!=4294967295 -k <%= $auditd::config::audit_profiles::stig::audit_mount_tag %>
+-a exit,always -F arch=b64 -F path=/usr/bin/mount -F auid>=<%= $auditd::config::audit_profiles::stig::uid_min %> -F auid!=4294967295 -k <%= $auditd::config::audit_profiles::stig::audit_mount_tag %>
 <%     } -%>
--a always,exit -F arch=b64 -F path=/bin/mount -F auid>=<%= $auditd::config::audit_profiles::stig::uid_min %> -F auid!=4294967295 -k <%= $auditd::config::audit_profiles::stig::audit_mount_tag %>
+-a exit,always -F arch=b64 -F path=/bin/mount -F auid>=<%= $auditd::config::audit_profiles::stig::uid_min %> -F auid!=4294967295 -k <%= $auditd::config::audit_profiles::stig::audit_mount_tag %>
 <%   } -%>
--a always,exit -F arch=b32 -S mount -F auid>=<%= $auditd::config::audit_profiles::stig::uid_min %> -F auid!=4294967295 -k <%= $auditd::config::audit_profiles::stig::audit_mount_tag %>
+-a exit,always -F arch=b32 -S mount -F auid>=<%= $auditd::config::audit_profiles::stig::uid_min %> -F auid!=4294967295 -k <%= $auditd::config::audit_profiles::stig::audit_mount_tag %>
 <%   if $facts['os']['release']['major'] > '6' { -%>
--a always,exit -F arch=b32 -F path=/usr/bin/mount -F auid>=<%= $auditd::config::audit_profiles::stig::uid_min %> -F auid!=4294967295 -k <%= $auditd::config::audit_profiles::stig::audit_mount_tag %>
+-a exit,always -F arch=b32 -F path=/usr/bin/mount -F auid>=<%= $auditd::config::audit_profiles::stig::uid_min %> -F auid!=4294967295 -k <%= $auditd::config::audit_profiles::stig::audit_mount_tag %>
 <%   } -%>
--a always,exit -F arch=b32 -F path=/bin/mount -F auid>=<%= $auditd::config::audit_profiles::stig::uid_min %> -F auid!=4294967295 -k <%= $auditd::config::audit_profiles::stig::audit_mount_tag %>
+-a exit,always -F arch=b32 -F path=/bin/mount -F auid>=<%= $auditd::config::audit_profiles::stig::uid_min %> -F auid!=4294967295 -k <%= $auditd::config::audit_profiles::stig::audit_mount_tag %>
 
-# RHEL-07-030750
 <%   if $facts['os']['release']['major'] > '6' { -%>
--a always,exit -F path=/usr/bin/umount -F perm=x -F auid>=<%= $auditd::config::audit_profiles::stig::uid_min %> -F auid!=4294967295 -k <%= $auditd::config::audit_profiles::stig::audit_mount_tag %>
+-a exit,always -F path=/usr/bin/umount -F perm=x -F auid>=<%= $auditd::config::audit_profiles::stig::uid_min %> -F auid!=4294967295 -k <%= $auditd::config::audit_profiles::stig::audit_mount_tag %>
 <%   } -%>
--a always,exit -F path=/bin/umount -F perm=x -F auid>=<%= $auditd::config::audit_profiles::stig::uid_min %> -F auid!=4294967295 -k <%= $auditd::config::audit_profiles::stig::audit_mount_tag %>
+-a exit,always -F path=/bin/umount -F perm=x -F auid>=<%= $auditd::config::audit_profiles::stig::uid_min %> -F auid!=4294967295 -k <%= $auditd::config::audit_profiles::stig::audit_mount_tag %>
 <% } -%>
 <% if $auditd::config::audit_profiles::stig::audit_local_account { -%>
 
 ## Audit local accounts
-# RHEL-07-030870
 -w /etc/passwd -p wa -k <%= $auditd::config::audit_profiles::stig::audit_local_account_tag %>
 
-# RHEL-07-030871
 -w /etc/group -p wa -k <%= $auditd::config::audit_profiles::stig::audit_local_account_tag %>
 
-# RHEL-07-030872
 -w /etc/gshadow -p wa -k <%= $auditd::config::audit_profiles::stig::audit_local_account_tag %>
 
-# RHEL-07-030873
 -w /etc/shadow -p wa -k <%= $auditd::config::audit_profiles::stig::audit_local_account_tag %>
 
-# RHEL-07-030874
 -w /etc/security/opasswd -p wa -k <%= $auditd::config::audit_profiles::stig::audit_local_account_tag %>
 <% } -%>
 <% if $auditd::config::audit_profiles::stig::audit_login_files { -%>
 
 ## Audit login files
-# RHEL-07-030600
 -w /var/log/tallylog -p wa -k <%= $auditd::config::audit_profiles::stig::audit_login_files_tag %>
 
-# RHEL-07-030610
 -w /var/run/faillock -p wa -k <%= $auditd::config::audit_profiles::stig::audit_login_files_tag %>
 
-# RHEL-07-030620
 -w /var/log/lastlog -p wa -k <%= $auditd::config::audit_profiles::stig::audit_login_files_tag %>
 <% } -%>
 <% if $auditd::config::audit_profiles::stig::audit_cfg_sudoers { -%>
 
 ## Audit sudoers configuration files
-# RHEL-07-030700
 -w /etc/sudoers -p wa -k <%= $auditd::config::audit_profiles::stig::audit_cfg_sudoers_tag %>
 -w /etc/sudoers.d/ -p wa -k <%= $auditd::config::audit_profiles::stig::audit_cfg_sudoers_tag %>
 <% } -%>


### PR DESCRIPTION
- Allow users to knockout entries from arrays specified in Hiera
- Multiple rules added based on best practices mostly pulled from
  /usr/share/doc/auditd:
  - Audit 32 bit operations on 64 bit systems
  - Audit calls to the auditd CLI commands
  - Audit IPv4 and IPv6 inbound connections
  - Optionally audit IPv4 and IPv6 outbound connections
  - Audit suspicious applications
  - Audit systemd
  - Audit the auditd configuration space
  - Ignore time daemon logs (clutter)
  - Ignore CRYPTO_KEY_USER logs (clutter)
  - Add ability to set the backlog_wait_time
  - Set loginuid_immutable

NOTE: The compliance acceptance tests will not pass until
https://github.com/inspec/inspec/pull/4665 is merged and released in
inspec.

SIMP-7139 #close