### PR TITLE
(SIMP-MAINT) Bump puppet agent version to 5.5.16

### DIFF
--- a/.gitlab-ci.yml
+++ b/.gitlab-ci.yml
@@ -5,9 +5,9 @@
 # https://puppet.com/docs/pe/2018.1/overview/getting_support_for_pe.html
 # ------------------------------------------------------------------------------
 # Release       Puppet   Ruby   EOL
-# SIMP 6.3      5.5.10   2.4.5  TBD***
-# PE 2018.1     5.5.8    2.4.5  2020-05 (LTS)***
-# PE 2019.0     6.0      2.5.1  2019-08-31^^^
+# SIMP 6.3      5.5.16   2.4.5  TBD***
+# PE 2018.1     5.5.16   2.4.5  2020-05 (LTS)***
+# PE 2019.0     6.0      2.5.3  2019-08-31^^^
 #
 # *** = Modules created for SIMP 6.3+ are not required to support Puppet < 5.5
 ---
@@ -69,10 +69,10 @@ variables:
     BEAKER_PUPPET_COLLECTION: 'puppet5'
     MATRIX_RUBY_VERSION: '2.4'
 
-.pup_5_5_10: &pup_5_5_10
+.pup_5_5_17: &pup_5_5_16
   image: 'ruby:2.4'
   variables:
-    PUPPET_VERSION: '5.5.10'
+    PUPPET_VERSION: '5.5.16'
     BEAKER_PUPPET_COLLECTION: 'puppet5'
     MATRIX_RUBY_VERSION: '2.4'
 
@@ -149,8 +149,8 @@ pup5-unit:
   <<: *pup_5
   <<: *unit_tests
 
-pup5.5.10-unit:
-  <<: *pup_5_5_10
+pup5.5.16-unit:
+  <<: *pup_5_5_16
   <<: *unit_tests
 
 pup6-unit:
@@ -159,26 +159,26 @@ pup6-unit:
 
 # Acceptance tests
 # ==============================================================================
-pup5.5.10:
-  <<: *pup_5_5_10
+pup5.5.16:
+  <<: *pup_5_5_16
   <<: *acceptance_base
   script:
     - 'bundle exec rake beaker:suites'
 
-pup5.5.10-fips:
-  <<: *pup_5_5_10
+pup5.5.16-fips:
+  <<: *pup_5_5_16
   <<: *acceptance_base
   script:
     - 'BEAKER_fips=yes bundle exec rake beaker:suites'
 
-pup5.5.10-oel:
-  <<: *pup_5_5_10
+pup5.5.16-oel:
+  <<: *pup_5_5_16
   <<: *acceptance_base
   script:
     - 'bundle exec rake beaker:suites[default,oel]'
 
-pup5.5.10-oel-fips:
-  <<: *pup_5_5_10
+pup5.5.16-oel-fips:
+  <<: *pup_5_5_16
   <<: *acceptance_base
   <<: *only_with_SIMP_FULL_MATRIX
   script:
@@ -197,8 +197,8 @@ pup6-fips:
     - 'BEAKER_fips=yes bundle exec rake beaker:suites'
 
 
-pup5.5.10-fips-compliance:
-  <<: *pup_5_5_10
+pup5.5.16-fips-compliance:
+  <<: *pup_5_5_16
   <<: *compliance_base
   script:
     - 'BEAKER_fips=yes bundle exec rake beaker:suites[compliance]'

--- a/.gitlab-ci.yml
+++ b/.gitlab-ci.yml
@@ -69,7 +69,7 @@ variables:
     BEAKER_PUPPET_COLLECTION: 'puppet5'
     MATRIX_RUBY_VERSION: '2.4'
 
-.pup_5_5_17: &pup_5_5_16
+.pup_5_5_16: &pup_5_5_16
   image: 'ruby:2.4'
   variables:
     PUPPET_VERSION: '5.5.16'


### PR DESCRIPTION
EL8 doesn't have a 5.5.10 release available so the minimum version
should be bumped to 5.5.16 to align with 2018.1.9(LTS)