### PR TITLE
Add missing augeasproviders_grub dependency

### DIFF
--- a/metadata.json
+++ b/metadata.json
@@ -20,6 +20,10 @@
     {
       "name": "simp/simplib",
       "version_requirement": ">= 3.6.0 < 5.0.0"
+    },
+    {
+      "name": "herculesteam/augeasproviders_grub",
+      "version_requirement": ">= 2.4.0 < 4.0.0"
     }
   ],
   "simp": {


### PR DESCRIPTION
Needed by `auditd::config::grub` even if `grub_enable == false`.

`augeasproviders_grub` provides the `kernel_parameter` type.