### PR TITLE
(SIMP-MAINT) Set permissions on /var/log/audit.

### DIFF
--- a/CHANGELOG
+++ b/CHANGELOG
@@ -1,3 +1,6 @@
+* Fri May 27 2022 Zach Schulte <zschulte@broadinstitute.org> - 8.7.3
+- Fix the permissions on `/var/log/audit`
+
 * Fri May 13 2022 Mike Riddle <mike@sicura.us> - 8.7.2
 - Changed the auditd_sample_rulesets fact to look in both
   /usr/share/audit/sample-rules and /usr/share/doc/audit*/rules for

--- a/manifests/config.pp
+++ b/manifests/config.pp
@@ -89,16 +89,11 @@ class auditd::config {
   }
 
   file { '/var/log/audit':
-    ensure => 'directory',
-    owner  => 'root',
-    group  => $auditd::log_group,
-    mode   => 'o-rwx'
-  }
-
-  file { $auditd::log_file:
-    owner => 'root',
-    group => $auditd::log_group,
-    mode  => $log_file_mode
+    ensure  => 'directory',
+    owner   => 'root',
+    group   => $auditd::log_group,
+    mode    => $log_file_mode,
+    recurse => true
   }
 
   if $auditd::syslog {

--- a/metadata.json
+++ b/metadata.json
@@ -1,6 +1,6 @@
 {
   "name": "simp-auditd",
-  "version": "8.7.2",
+  "version": "8.7.3",
   "author": "SIMP Team",
   "summary": "A SIMP puppet module for managing auditd and audispd",
   "license": "Apache-2.0",

--- a/spec/classes/config_spec.rb
+++ b/spec/classes/config_spec.rb
@@ -53,17 +53,11 @@ describe 'auditd' do
           it { is_expected.to_not contain_class('auditd::config::logging').that_notifies('Class[auditd::service]') }
           it {
             is_expected.to contain_file('/var/log/audit').with({
-              :ensure => 'directory',
-              :owner  => 'root',
-              :group  => 'root',
-              :mode   => 'o-rwx'
-            })
-          }
-          it {
-            is_expected.to contain_file('/var/log/audit/audit.log').with({
-              :owner  => 'root',
-              :group  => 'root',
-              :mode   => '0600'
+              :ensure  => 'directory',
+              :owner   => 'root',
+              :group   => 'root',
+              :mode    => '0600',
+              :recurse => true
             })
           }
           it { is_expected.to contain_class('auditd::config::audit_profiles') }
@@ -128,18 +122,11 @@ describe 'auditd' do
 
           it {
             is_expected.to contain_file('/var/log/audit').with({
-              :ensure => 'directory',
-              :owner  => 'root',
-              :group  => 'rspec',
-              :mode   => 'o-rwx'
-            })
-          }
-
-          it {
-            is_expected.to contain_file('/var/log/audit/audit.log').with({
-              :owner  => 'root',
-              :group  => 'rspec',
-              :mode   => '0640'
+              :ensure  => 'directory',
+              :owner   => 'root',
+              :group   => 'rspec',
+              :mode    => '0640',
+              :recurse => true
             })
           }
         end


### PR DESCRIPTION
Sets the directory permissions to ensure $log_group can traverse the parent directory.

Also sets permissions on /etc/audit/audit.rules.