### PR TITLE
Update of regsubst in rule.pp to detect all slashes in ressource title

### DIFF
--- a/manifests/config/grub.pp
+++ b/manifests/config/grub.pp
@@ -17,5 +17,5 @@ class auditd::config::grub (
 
   kernel_parameter { 'audit': value => $_enable }
 
-  reboot_notify { 'audit': subscribe => Kernel_parameter['audit'] }
+#  reboot_notify { 'audit': subscribe => Kernel_parameter['audit'] }
 }

--- a/manifests/config/grub.pp
+++ b/manifests/config/grub.pp
@@ -17,5 +17,5 @@ class auditd::config::grub (
 
   kernel_parameter { 'audit': value => $_enable }
 
-#  reboot_notify { 'audit': subscribe => Kernel_parameter['audit'] }
+  reboot_notify { 'audit': subscribe => Kernel_parameter['audit'] }
 }

--- a/manifests/rule.pp
+++ b/manifests/rule.pp
@@ -39,7 +39,7 @@ define auditd::rule (
 
   if $auditd::enable {
 
-    $_safe_name = regsubst($name, '(\\\/)', '__', 'G')
+    $_safe_name = regsubst($name, '(\/+)', '__', 'G')
 
     if $order {
       $_order = $order

--- a/manifests/rule.pp
+++ b/manifests/rule.pp
@@ -39,7 +39,7 @@ define auditd::rule (
 
   if $auditd::enable {
 
-    $_safe_name = regsubst($name, '(//)', '__', 'G')
+    $_safe_name = regsubst($name, '(\\\/)', '__', 'G')
 
     if $order {
       $_order = $order

--- a/manifests/rule.pp
+++ b/manifests/rule.pp
@@ -39,7 +39,7 @@ define auditd::rule (
 
   if $auditd::enable {
 
-    $_safe_name = regsubst($name, '(/|\s)', '__')
+    $_safe_name = regsubst($name, '(/+|\s)', '__')
 
     if $order {
       $_order = $order

--- a/manifests/rule.pp
+++ b/manifests/rule.pp
@@ -39,7 +39,7 @@ define auditd::rule (
 
   if $auditd::enable {
 
-    $_safe_name = regsubst($name, '(\/+)', '__', 'G')
+    $_safe_name = regsubst($name, '(\/+|\s)', '__', 'G')
 
     if $order {
       $_order = $order

--- a/manifests/rule.pp
+++ b/manifests/rule.pp
@@ -39,7 +39,7 @@ define auditd::rule (
 
   if $auditd::enable {
 
-    $_safe_name = regsubst($name, '(\/+|\s)', '__')
+    $_safe_name = regsubst($name, '(//)', '__', 'G')
 
     if $order {
       $_order = $order

--- a/manifests/rule.pp
+++ b/manifests/rule.pp
@@ -39,7 +39,7 @@ define auditd::rule (
 
   if $auditd::enable {
 
-    $_safe_name = regsubst($name, '(\/+|\s)', '__', 'G')
+    $_safe_name = regsubst($name, '(/|\s)', '__', 'G')
 
     if $order {
       $_order = $order

--- a/manifests/rule.pp
+++ b/manifests/rule.pp
@@ -39,7 +39,7 @@ define auditd::rule (
 
   if $auditd::enable {
 
-    $_safe_name = regsubst($name, '(/+|\s)', '__')
+    $_safe_name = regsubst($name, '(\/+|\s)', '__')
 
     if $order {
       $_order = $order


### PR DESCRIPTION
This pull request was created because of the issue that if in the ressource-title (or name) is more then one "/"-sign the puppet run fails, because the it was only be substituded the first "/"-sign, not the rest.

This causes the issue that puppet thinks that all after the first "/" is a directory and all of that what follows to and would not be replaced with "__". This issue will appear if the ressource-title looks like a absolute filepath like "/etc/sudoers", then the first will be detected, the second not.

This issue will be solved with this Pull request. I tested it and it works.