### PR TITLE
fixing regsubs for substituting bad characters

### DIFF
--- a/CHANGELOG
+++ b/CHANGELOG
@@ -1,3 +1,6 @@
+* Mon Jun 15 2020 Jan Fickler <jan.fickler@webfleet.com> - 8.5.1-0
+- Fix regex substitution for bad path characters
+
 * Thu Oct 31 2019 Trevor Vaughan <tvaughan@onyxpoint.com> - 8.5.0-0
 - Allow users to knockout entries from arrays specified in Hiera
 - Multiple rules added based on best practices mostly pulled from

--- a/manifests/rule.pp
+++ b/manifests/rule.pp
@@ -39,7 +39,7 @@ define auditd::rule (
 
   if $auditd::enable {
 
-    $_safe_name = regsubst($name, '(/|\s)', '__')
+    $_safe_name = regsubst($name, '(/|\s)', '__', 'G')
 
     if $order {
       $_order = $order

--- a/metadata.json
+++ b/metadata.json
@@ -1,6 +1,6 @@
 {
   "name": "simp-auditd",
-  "version": "8.5.0",
+  "version": "8.5.1",
   "author": "SIMP Team",
   "summary": "A SIMP puppet module for managing auditd and audispd",
   "license": "Apache-2.0",


### PR DESCRIPTION
The substituation was only for the first bad-character.
This fix will change that to substitute all bad-characters in the $title of the ressource.