### PR TITLE
(SIMP-7829) - Compliance Updates

### DIFF
--- a/CHANGELOG
+++ b/CHANGELOG
@@ -1,3 +1,9 @@
+* Wed Jun 24 2020 Trevor Vaughan <tvaughan@onyxpoint.com> - 8.5.1-0
+- Added a File statement for /etc/audit/audit.rules.prev to prevent unnecessary
+  flapping
+- Ensure that the inspec tests don't run if there isn't a profile available
+- Ensure that kmod is audited in all STIG modes on EL7+
+
 * Mon Jun 15 2020 Jan Fickler <jan.fickler@webfleet.com> - 8.5.1-0
 - Fix regex substitution for bad path characters
 

--- a/Gemfile
+++ b/Gemfile
@@ -25,5 +25,5 @@ end
 group :system_tests do
   gem 'beaker'
   gem 'beaker-rspec'
-  gem 'simp-beaker-helpers', ENV.fetch('SIMP_BEAKER_HELPERS_VERSION', ['>= 1.17.0', '< 2.0.0'])
+  gem 'simp-beaker-helpers', ENV.fetch('SIMP_BEAKER_HELPERS_VERSION', ['>= 1.18.5', '< 2.0.0'])
 end

--- a/Gemfile
+++ b/Gemfile
@@ -25,5 +25,5 @@ end
 group :system_tests do
   gem 'beaker'
   gem 'beaker-rspec'
-  gem 'simp-beaker-helpers', ENV.fetch('SIMP_BEAKER_HELPERS_VERSION', ['>= 1.18.5', '< 2.0.0'])
+  gem 'simp-beaker-helpers', ENV.fetch('SIMP_BEAKER_HELPERS_VERSION', ['>= 1.18.7', '< 2.0.0'])
 end

--- a/manifests/config.pp
+++ b/manifests/config.pp
@@ -42,7 +42,10 @@ class auditd::config {
     purge   => true
   }
 
-  file { '/etc/audit/audit.rules':
+  file { [
+    '/etc/audit/audit.rules',
+    '/etc/audit/audit.rules.prev'
+  ]:
     owner => 'root',
     group => $auditd::log_group,
     mode  => 'o-rwx'

--- a/spec/acceptance/suites/compliance/01_simp_profile_inspec_spec.rb
+++ b/spec/acceptance/suites/compliance/01_simp_profile_inspec_spec.rb
@@ -11,49 +11,61 @@ describe 'run inspec against the appropriate fixtures for simp audit profile' do
     profiles_to_validate.each do |profile|
       context "for profile #{profile}" do
         context "on #{host}" do
-          before(:all) do
-            @inspec = Simp::BeakerHelpers::Inspec.new(host, profile)
-            @inspec_report = {:data => nil}
-          end
+          profile_path = File.join(
+              fixtures_path,
+              'inspec_profiles',
+              "#{fact_on(host, 'operatingsystem')}-#{fact_on(host, 'operatingsystemmajrelease')}-#{profile}"
+            )
 
-          it 'should run inspec' do
-            @inspec.run
-          end
-
-          it 'should have an inspec report' do
-            @inspec_report[:data] = @inspec.process_inspec_results
-
-            info = [
-              'Results:',
-              "  * Passed: #{@inspec_report[:data][:passed]}",
-              "  * Failed: #{@inspec_report[:data][:failed]}",
-              "  * Skipped: #{@inspec_report[:data][:skipped]}"
-            ]
-
-            puts info.join("\n")
-
-            @inspec.write_report(@inspec_report[:data])
-          end
-
-          it 'should have run some tests' do
-            expect(@inspec_report[:data][:failed] + @inspec_report[:data][:passed]).to be > 0
-          end
-
-          it 'should not have any failing tests' do
-            # 2 tests erroneously fail
-            # - 'All privileged function executions must be audited':
-            #    - inspec_profiles/profiles/disa_stig-el7-baseline/controls/V-72095.rb
-            #    - inspec is expecting watches for executables.  We are checking with
-            #      syscalls instead
-            # - 'The system must send rsyslog output to a log aggregation server':
-            #    - inspec_profiles/profiles/disa_stig-el7-baseline/controls/V-72209.rb
-            #    - inspec should skip, as rsyslog is not setup
-
-            if @inspec_report[:data][:failed] > 0
-              puts @inspec_report[:data][:report]
+          unless File.exist?(profile_path)
+            it 'should run inspec' do
+              skip("No matching profile available at #{profile_path}")
+            end
+          else
+            before(:all) do
+              @inspec = Simp::BeakerHelpers::Inspec.new(host, profile)
+              @inspec_report = {:data => nil}
             end
 
-            expect( @inspec_report[:data][:failed] ).to eq(0)
+            it 'should run inspec' do
+              @inspec.run
+            end
+
+            it 'should have an inspec report' do
+              @inspec_report[:data] = @inspec.process_inspec_results
+
+              info = [
+                'Results:',
+                "  * Passed: #{@inspec_report[:data][:passed]}",
+                "  * Failed: #{@inspec_report[:data][:failed]}",
+                "  * Skipped: #{@inspec_report[:data][:skipped]}"
+              ]
+
+              puts info.join("\n")
+
+              @inspec.write_report(@inspec_report[:data])
+            end
+
+            it 'should have run some tests' do
+              expect(@inspec_report[:data][:failed] + @inspec_report[:data][:passed]).to be > 0
+            end
+
+            it 'should not have any failing tests' do
+              # 2 tests erroneously fail
+              # - 'All privileged function executions must be audited':
+              #    - inspec_profiles/profiles/disa_stig-el7-baseline/controls/V-72095.rb
+              #    - inspec is expecting watches for executables.  We are checking with
+              #      syscalls instead
+              # - 'The system must send rsyslog output to a log aggregation server':
+              #    - inspec_profiles/profiles/disa_stig-el7-baseline/controls/V-72209.rb
+              #    - inspec should skip, as rsyslog is not setup
+
+              if @inspec_report[:data][:failed] > 0
+                puts @inspec_report[:data][:report]
+              end
+
+              expect( @inspec_report[:data][:failed] ).to eq(0)
+            end
           end
         end
       end

--- a/spec/acceptance/suites/compliance/21_stig_profile_inspec_spec.rb
+++ b/spec/acceptance/suites/compliance/21_stig_profile_inspec_spec.rb
@@ -11,40 +11,52 @@ describe 'run inspec against the appropriate fixtures for stig audit profile' do
     profiles_to_validate.each do |profile|
       context "for profile #{profile}" do
         context "on #{host}" do
-          before(:all) do
-            @inspec = Simp::BeakerHelpers::Inspec.new(host, profile)
+          profile_path = File.join(
+              fixtures_path,
+              'inspec_profiles',
+              "#{fact_on(host, 'operatingsystem')}-#{fact_on(host, 'operatingsystemmajrelease')}-#{profile}"
+            )
 
-            # If we don't do this, the variable gets reset
-            @inspec_report = { :data => nil }
-          end
+          unless File.exist?(profile_path)
+            it 'should run inspec' do
+              skip("No matching profile available at #{profile_path}")
+            end
+          else
+            before(:all) do
+              @inspec = Simp::BeakerHelpers::Inspec.new(host, profile)
 
-          it 'should run inspec' do
-            @inspec.run
-          end
-
-          it 'should have an inspec report' do
-            @inspec_report[:data] = @inspec.process_inspec_results
-
-            expect(@inspec_report[:data]).to_not be_nil
-
-            @inspec.write_report(@inspec_report[:data])
-          end
-
-          it 'should have run some tests' do
-            expect(@inspec_report[:data][:failed] + @inspec_report[:data][:passed]).to be > 0
-          end
-
-          it 'should not have any failing tests' do
-            # 1 test erroneously fails
-            # - 'The system must send rsyslog output to a log aggregation server':
-            #    - inspec_profiles/profiles/disa_stig-el7-baseline/controls/V-72209.rb
-            #    - inspec should skip, as rsyslog is not setup
-            if @inspec_report[:data][:failed] > 0
-              puts @inspec_report[:data][:global][:failed].join("\n")
-              puts @inspec_report[:data][:report]
+              # If we don't do this, the variable gets reset
+              @inspec_report = { :data => nil }
             end
 
-            expect(@inspec_report[:data][:score] ).to eq(100)
+            it 'should run inspec' do
+              @inspec.run
+            end
+
+            it 'should have an inspec report' do
+              @inspec_report[:data] = @inspec.process_inspec_results
+
+              expect(@inspec_report[:data]).to_not be_nil
+
+              @inspec.write_report(@inspec_report[:data])
+            end
+
+            it 'should have run some tests' do
+              expect(@inspec_report[:data][:failed] + @inspec_report[:data][:passed]).to be > 0
+            end
+
+            it 'should not have any failing tests' do
+              # 1 test erroneously fails
+              # - 'The system must send rsyslog output to a log aggregation server':
+              #    - inspec_profiles/profiles/disa_stig-el7-baseline/controls/V-72209.rb
+              #    - inspec should skip, as rsyslog is not setup
+              if @inspec_report[:data][:failed] > 0
+                puts @inspec_report[:data][:global][:failed].join("\n")
+                puts @inspec_report[:data][:report]
+              end
+
+              expect(@inspec_report[:data][:score] ).to eq(100)
+            end
           end
         end
       end

--- a/spec/acceptance/suites/compliance/22_stig_profile_oscap_spec.rb
+++ b/spec/acceptance/suites/compliance/22_stig_profile_oscap_spec.rb
@@ -26,9 +26,17 @@ describe 'run the SSG against the appropriate fixtures for stig audit profile' d
 
         # TODO: Check this periodically to see if it has been fixed upstream
         # These appear to be broken in the ComplianceAsCode content
+        #
+        # https://github.com/ComplianceAsCode/content/issues/4935
         exclusions = [
           'audit_rules_privileged_',
-          'audit_rules_execution_'
+          'audit_rules_execution_',
+          'audit_rules_kernel_',
+          'audit_rules_dac_',
+          'audit_rules_unsuccessful_',
+          'audit_rules_file_',
+          'audit_rules_media_export',
+          'audit_rules_for_ospp' # Dragged in by EL8 but we're not applying an OSPP profile
         ]
 
         @ssg_report[:data] = @ssg.process_ssg_results(filter, exclusions)

--- a/spec/acceptance/suites/compliance/local.nodesets/default.yml
+++ b/spec/acceptance/suites/compliance/local.nodesets/default.yml
@@ -27,4 +27,4 @@ HOSTS:
 CONFIG:
   log_level: verbose
   type:      aio
-  vagrant_memsize: 256
+  vagrant_memsize: 1024

--- a/spec/acceptance/suites/default/00_base_spec.rb
+++ b/spec/acceptance/suites/default/00_base_spec.rb
@@ -62,14 +62,14 @@ describe 'auditd class with simp audit profile' do
         end
 
         it 'should have the audit package installed' do
-          result = on(host, 'puppet resource package audit')
-          expect(result.output).to_not include("ensure => 'absent'")
+          result = YAML.safe_load(on(host, 'puppet resource package audit --to_yaml').stdout)
+          expect(result['package']['audit']['ensure']).not_to eq('absent')
         end
 
         it 'should activate the auditd service' do
-          result = on(host, 'puppet resource service auditd')
-          expect(result.output).to include("ensure => 'running'")
-          expect(result.output).to include("enable => 'true'")
+          result = YAML.safe_load(on(host, 'puppet resource service auditd --to_yaml').stdout)
+          expect(result['service']['auditd']['ensure']).to eq('running')
+          expect(result['service']['auditd']['enable']).to eq('true')
         end
 
         it 'should load valid rules' do

--- a/spec/acceptance/suites/default/10_alt_audit_profiles_spec.rb
+++ b/spec/acceptance/suites/default/10_alt_audit_profiles_spec.rb
@@ -63,8 +63,8 @@ describe 'auditd class with alternative audit profiles' do
         end
 
         it 'should be running the auditd service' do
-          result = on(host, 'puppet resource service auditd')
-          expect(result.output).to include("ensure => 'running'")
+          result = YAML.safe_load(on(host, 'puppet resource service auditd --to_yaml').stdout)
+          expect(result['service']['auditd']['ensure']).to eq('running')
         end
 
         it 'should load valid rules' do
@@ -88,8 +88,8 @@ describe 'auditd class with alternative audit profiles' do
         end
 
         it 'should be running the auditd service' do
-          result = on(host, 'puppet resource service auditd')
-          expect(result.output).to include("ensure => 'running'")
+          result = YAML.safe_load(on(host, 'puppet resource service auditd --to_yaml').stdout)
+          expect(result['service']['auditd']['ensure']).to eq('running')
         end
 
 
@@ -115,8 +115,8 @@ describe 'auditd class with alternative audit profiles' do
         end
 
         it 'should be running the auditd service' do
-          result = on(host, 'puppet resource service auditd')
-          expect(result.output).to include("ensure => 'running'")
+          result = YAML.safe_load(on(host, 'puppet resource service auditd --to_yaml').stdout)
+          expect(result['service']['auditd']['ensure']).to eq('running')
         end
 
         it 'should load valid rules' do

--- a/spec/acceptance/suites/default/99_disable_audit_kernel_spec.rb
+++ b/spec/acceptance/suites/default/99_disable_audit_kernel_spec.rb
@@ -33,9 +33,10 @@ describe 'auditd class with simp auditd profile' do
         # Note: In SIMP, svckill will take care of actually disabling auditd if
         # it is no longer managed. Here, we're not including svckill by default.
         it 'should not kill the auditd service' do
-          result = on(host, 'puppet resource service auditd')
-          expect(result.output).to include("ensure => 'running'")
-          expect(result.output).to include("enable => 'true'")
+          result = YAML.safe_load(on(host, 'puppet resource service auditd --to_yaml').stdout)
+
+          expect(result['service']['auditd']['ensure']).to eq('running')
+          expect(result['service']['auditd']['enable']).to eq('true')
         end
 
         it 'should require reboot on subsequent run' do

--- a/spec/classes/config/audit_profiles/expected/stig_el7_all_custom_tags.txt
+++ b/spec/classes/config/audit_profiles/expected/stig_el7_all_custom_tags.txt
@@ -205,6 +205,8 @@
 -a exit,always -F path=/usr/sbin/usernetctl -F perm=x -F auid>=1000 -F auid!=4294967295 -k my_suid_sgid
 
 ## Audit the loading and unloading of kernel modules.
+-w /usr/bin/kmod -p x -F auid!=4294967295 -k my_kernel_modules
+-w /bin/kmod -p x -F auid!=4294967295 -k my_kernel_modules
 -w /usr/sbin/insmod -p x -F auid!=4294967295 -k my_kernel_modules
 -w /sbin/insmod -p x -F auid!=4294967295 -k my_kernel_modules
 

--- a/spec/classes/config/audit_profiles/expected/stig_el7_base_rules.txt
+++ b/spec/classes/config/audit_profiles/expected/stig_el7_base_rules.txt
@@ -205,6 +205,8 @@
 -a exit,always -F path=/usr/sbin/usernetctl -F perm=x -F auid>=1000 -F auid!=4294967295 -k setuid/setgid
 
 ## Audit the loading and unloading of kernel modules.
+-w /usr/bin/kmod -p x -F auid!=4294967295 -k module-change
+-w /bin/kmod -p x -F auid!=4294967295 -k module-change
 -w /usr/sbin/insmod -p x -F auid!=4294967295 -k module-change
 -w /sbin/insmod -p x -F auid!=4294967295 -k module-change
 

--- a/spec/classes/config_spec.rb
+++ b/spec/classes/config_spec.rb
@@ -33,6 +33,13 @@ describe 'auditd' do
             })
           }
           it {
+            is_expected.to contain_file('/etc/audit/audit.rules.prev').with({
+              :owner => 'root',
+              :group => 'root',
+              :mode  => 'o-rwx'
+            })
+          }
+          it {
             is_expected.to contain_file('/etc/audit').with({
               :ensure  => 'directory',
               :owner   => 'root',
@@ -105,6 +112,13 @@ describe 'auditd' do
           }
           it {
             is_expected.to contain_file('/etc/audit/audit.rules').with({
+              :owner => 'root',
+              :group => 'rspec',
+              :mode  => 'o-rwx'
+            })
+          }
+          it {
+            is_expected.to contain_file('/etc/audit/audit.rules.prev').with({
               :owner => 'root',
               :group => 'rspec',
               :mode  => 'o-rwx'

--- a/templates/rule_profiles/stig/base.epp
+++ b/templates/rule_profiles/stig/base.epp
@@ -273,6 +273,10 @@
 
 ## Audit the loading and unloading of kernel modules.
 <%   if $facts['os']['release']['major'] > '6' { -%>
+-w /usr/bin/kmod -p x -F auid!=4294967295 -k <%= $auditd::config::audit_profiles::stig::audit_kernel_modules_tag %>
+-w /bin/kmod -p x -F auid!=4294967295 -k <%= $auditd::config::audit_profiles::stig::audit_kernel_modules_tag %>
+<%   } -%>
+<%   if $facts['os']['release']['major'] > '6' { -%>
 -w /usr/sbin/insmod -p x -F auid!=4294967295 -k <%= $auditd::config::audit_profiles::stig::audit_kernel_modules_tag %>
 <%   } -%>
 -w /sbin/insmod -p x -F auid!=4294967295 -k <%= $auditd::config::audit_profiles::stig::audit_kernel_modules_tag %>


### PR DESCRIPTION
- Added a File statement for /etc/audit/audit.rules.prev to prevent unnecessary
  flapping
- Ensure that the inspec tests don't run if there isn't a profile available
- Ensure that kmod is audited in all STIG modes on EL7+

[SIMP-7829] #close

[SIMP-7829]: https://simp-project.atlassian.net/browse/SIMP-7829