### PR TITLE
(SIMP-8123) Fix variables for GLCI acceptance tests

### DIFF
--- a/.gitlab-ci.yml
+++ b/.gitlab-ci.yml
@@ -20,6 +20,7 @@ stages:
   - 'deployment'
 
 variables:
+  PUPPET_VERSION:    'UNDEFINED' # <- Matrixed jobs MUST override this (or fail)
   BUNDLER_VERSION:   '1.17.1'
 
   # Force dependencies into a path the gitlab-runner user can write to.

--- a/.gitlab-ci.yml
+++ b/.gitlab-ci.yml
@@ -112,15 +112,11 @@ variables:
   stage: 'acceptance'
   tags: ['beaker']
   <<: *setup_bundler_env
-  variables:
-    BEAKER_VAGRANT_MEMSIZE: 256
 
 .compliance_base: &compliance_base
   stage: 'compliance'
   tags: ['beaker']
   <<: *setup_bundler_env
-  variables:
-    BEAKER_VAGRANT_MEMSIZE: 1536
 
 
 # Pipeline / testing matrix
@@ -216,13 +212,13 @@ pup5.5.17-fips-compliance:
   <<: *pup_5_5_17
   <<: *compliance_base
   script:
-    - 'BEAKER_fips=yes bundle exec rake beaker:suites[compliance]'
+    - 'BEAKER_VAGRANT_MEMSIZE=1536 BEAKER_fips=yes bundle exec rake beaker:suites[compliance]'
 
 pup6-fips-compliance:
   <<: *pup_6
   <<: *compliance_base
   script:
-    - 'BEAKER_fips=yes bundle exec rake beaker:suites[compliance]'
+    - 'BEAKER_VAGRANT_MEMSIZE=1536 BEAKER_fips=yes bundle exec rake beaker:suites[compliance]'
 
 pup6.16.0:
   <<: *pup_6_16_0
@@ -253,4 +249,4 @@ pup6.16.0-fips-compliance:
   <<: *pup_6_16_0
   <<: *compliance_base
   script:
-    - 'BEAKER_fips=yes bundle exec rake beaker:suites[compliance]'
+    - 'BEAKER_VAGRANT_MEMSIZE=1536 BEAKER_fips=yes bundle exec rake beaker:suites[compliance]'

--- a/spec/acceptance/nodesets/default.yml
+++ b/spec/acceptance/nodesets/default.yml
@@ -4,6 +4,7 @@
   else
     hypervisor = 'vagrant'
   end
+  vagrant_memsize = ENV['BEAKER_VAGRANT_MEMSIZE'] ? ENV['BEAKER_VAGRANT_MEMSIZE'] : 256
 -%>
 HOSTS:
   el7:
@@ -31,9 +32,7 @@ HOSTS:
 CONFIG:
   log_level: verbose
   type: aio
-<% if ENV['BEAKER_VAGRANT_MEMSIZE'] -%>
-  vagrant_memsize: <%= ENV['BEAKER_VAGRANT_MEMSIZE'] %>
-<% end -%>
+  vagrant_memsize: <%= vagrant_memsize %>
 <% if ENV['BEAKER_PUPPET_COLLECTION'] -%>
   puppet_collection: <%= ENV['BEAKER_PUPPET_COLLECTION'] %>
 <% end -%>

--- a/spec/acceptance/nodesets/oel.yml
+++ b/spec/acceptance/nodesets/oel.yml
@@ -4,6 +4,7 @@
   else
     hypervisor = 'vagrant'
   end
+  vagrant_memsize = ENV['BEAKER_VAGRANT_MEMSIZE'] ? ENV['BEAKER_VAGRANT_MEMSIZE'] : 256
 -%>
 HOSTS:
   oel7:
@@ -46,9 +47,7 @@ HOSTS:
 CONFIG:
   log_level: verbose
   type: aio
-<% if ENV['BEAKER_VAGRANT_MEMSIZE'] -%>
-  vagrant_memsize: <%= ENV['BEAKER_VAGRANT_MEMSIZE'] %>
-<% end -%>
+  vagrant_memsize: <%= vagrant_memsize %>
 <% if ENV['BEAKER_PUPPET_COLLECTION'] -%>
   puppet_collection: <%= ENV['BEAKER_PUPPET_COLLECTION'] %>
 <% end -%>

--- a/spec/acceptance/nodesets/rhel8.yml
+++ b/spec/acceptance/nodesets/rhel8.yml
@@ -4,6 +4,7 @@
   else
     hypervisor = 'vagrant'
   end
+  vagrant_memsize = ENV['BEAKER_VAGRANT_MEMSIZE'] ? ENV['BEAKER_VAGRANT_MEMSIZE'] : 256
 -%>
 HOSTS:
   server-el8:
@@ -25,9 +26,7 @@ CONFIG:
   validate: false
   log_level: verbose
   type: aio
-<% if ENV['BEAKER_VAGRANT_MEMSIZE'] -%>
-  vagrant_memsize: <%= ENV['BEAKER_VAGRANT_MEMSIZE'] %>
-<% end -%>
+  vagrant_memsize: <%= vagrant_memsize %>
 <% if ENV['BEAKER_PUPPET_COLLECTION'] -%>
   puppet_collection: <%= ENV['BEAKER_PUPPET_COLLECTION'] %>
 <% end -%>

--- a/spec/acceptance/suites/compliance/local.nodesets/default.yml
+++ b/spec/acceptance/suites/compliance/local.nodesets/default.yml
@@ -1,3 +1,6 @@
+<%
+  vagrant_memsize = ENV['BEAKER_VAGRANT_MEMSIZE'] ? ENV['BEAKER_VAGRANT_MEMSIZE'] : 256
+-%>
 HOSTS:
   el7:
     roles:
@@ -27,6 +30,4 @@ HOSTS:
 CONFIG:
   log_level: verbose
   type:      aio
-<% if ENV['BEAKER_VAGRANT_MEMSIZE'] -%>
-  vagrant_memsize: <%= ENV['BEAKER_VAGRANT_MEMSIZE'] %>
-<% end -%>
+  vagrant_memsize: <%= vagrant_memsize %>


### PR DESCRIPTION
This patch moves the recent `BEAKER_VAGRANT_MEMSIZE` variable out of the 
puppet(sync)-managed section of `.gitlab-ci.yml` and into the compliance 
jobs' `script` sections.

This fixes an issue where the new `variables` section overwrote all YAML
anchor-provided variables, restores the global canary variable 
`PUPPET_VERSION: UNDEFINED`, and persist the nodeset variable
`BEAKER_VAGRANT_MEMSIZE` between puppetsyncs.

SIMP-8123 #close
