### PR TITLE
(SIMP-6839) Audit service and kernel config align

### DIFF
--- a/CHANGELOG
+++ b/CHANGELOG
@@ -1,3 +1,9 @@
+* Wed Aug 12 2020 Trevor Vaughan <tvaughan@onyxpoint.com> - 8.5.4-0
+- Ensure that the auditd service is not managed if the kernel is not enforcing
+  auditing
+- Add an acceptance test for toggling disabling auditing without modifying the
+  kernel parameter
+
 * Fri Aug 07 2020 Marcel Fischer <marcel@fury.home.loc> - 8.5.3-0
 - Add `INCREMENTAL_ASYNC` to possible values for `$::auditd::flush`
 

--- a/CHANGELOG
+++ b/CHANGELOG
@@ -1,4 +1,4 @@
-* Wed Aug 12 2020 Trevor Vaughan <tvaughan@onyxpoint.com> - 8.5.4-0
+* Wed Aug 12 2020 Trevor Vaughan <tvaughan@onyxpoint.com> - 8.6.0-0
 - Ensure that the auditd service is not managed if the kernel is not enforcing
   auditing
 - Add an acceptance test for toggling disabling auditing without modifying the

--- a/manifests/config.pp
+++ b/manifests/config.pp
@@ -76,7 +76,7 @@ class auditd::config {
     group   => $auditd::log_group,
     mode    => $log_file_mode,
     content => "${_auditd_conf_common}${_auditd_conf_main}${_auditd_conf_last}\n",
-    notify  => Service['auditd']
+    notify  => Class['auditd::service']
   }
 
   if defined('$auditd::plugin_dir') {

--- a/manifests/config/audisp_service.pp
+++ b/manifests/config/audisp_service.pp
@@ -14,7 +14,7 @@ class auditd::config::audisp_service {
   exec { 'Restart Audispd':
     command => '/bin/true',
     unless  => "/usr/bin/pgrep -f ${auditd::dispatcher}",
-    notify  => Service[$auditd::service_name]
+    notify  => Class['auditd::service']
   }
 
 }

--- a/manifests/init.pp
+++ b/manifests/init.pp
@@ -255,6 +255,8 @@ class auditd (
   Boolean                                 $write_logs               = $log_format ? { 'NOLOG' => false, default => true }
 ) {
 
+  include 'auditd::service'
+
   if $enable {
     unless $space_left > $admin_space_left {
       fail('Auditd requires $space_left to be greater than $admin_space_left, otherwise it will not start')
@@ -309,7 +311,6 @@ class auditd (
 
     include 'auditd::install'
     include 'auditd::config'
-    include 'auditd::service'
 
     Class['auditd::install']
     -> Class['auditd::config']

--- a/manifests/service.pp
+++ b/manifests/service.pp
@@ -8,20 +8,40 @@
 # @param enable
 #   ``enable`` state from the service resource
 #
+# @param bypass_kernel_check
+#   Do not check to see if the kernel is enforcing auditing before trying to
+#   manage the service.
+#
+#   * This may be required if auditing is not being actively managed in the
+#     kernel and someone has stopped the auditd service by hand.
+#
+# @param warn_if_reboot_required
+#   Add a ``reboot_notify`` warning if the system requires a reboot before the
+#   service can be managed.
+#
 # @author https://github.com/simp/pupmod-simp-auditd/graphs/contributors
 #
 class auditd::service (
-  $ensure = 'running',
-  $enable = true
+  Variant[String[1],Boolean] $ensure                  = pick(getvar('auditd::enable'), 'running'),
+  Boolean                    $enable                  = pick(getvar('auditd::enable'), true),
+  Boolean                    $bypass_kernel_check     = false,
+  Boolean                    $warn_if_reboot_required = true
 ){
   assert_private()
 
-  # CCE-27058-7
-  service { $::auditd::service_name:
-    ensure  => $ensure,
-    enable  => $enable,
-    start   => "/sbin/service ${auditd::service_name} start",
-    stop    => "/sbin/service ${auditd::service_name} stop",
-    restart => "/sbin/service ${auditd::service_name} restart"
+  if $bypass_kernel_check or dig($facts, 'simplib__auditd', 'kernel_enforcing') {
+    # CCE-27058-7
+    service { $auditd::service_name:
+      ensure  => $ensure,
+      enable  => $enable,
+      start   => "/sbin/service ${auditd::service_name} start",
+      stop    => "/sbin/service ${auditd::service_name} stop",
+      restart => "/sbin/service ${auditd::service_name} restart"
+    }
+  }
+  elsif $warn_if_reboot_required {
+    reboot_notify { "${auditd::service_name} service":
+      reason =>  "The ${auditd::service_name} service cannot be started when the kernel is not enforcing auditing"
+    }
   }
 }

--- a/manifests/service.pp
+++ b/manifests/service.pp
@@ -29,7 +29,7 @@ class auditd::service (
 ){
   assert_private()
 
-  if $bypass_kernel_check or $facts.dig(simplib__auditd', 'kernel_enforcing') {
+  if $bypass_kernel_check or $facts.dig('simplib__auditd', 'kernel_enforcing') {
     # CCE-27058-7
     service { $auditd::service_name:
       ensure  => $ensure,

--- a/manifests/service.pp
+++ b/manifests/service.pp
@@ -29,7 +29,7 @@ class auditd::service (
 ){
   assert_private()
 
-  if $bypass_kernel_check or dig($facts, 'simplib__auditd', 'kernel_enforcing') {
+  if $bypass_kernel_check or $facts.dig(simplib__auditd', 'kernel_enforcing') {
     # CCE-27058-7
     service { $auditd::service_name:
       ensure  => $ensure,

--- a/metadata.json
+++ b/metadata.json
@@ -1,6 +1,6 @@
 {
   "name": "simp-auditd",
-  "version": "8.5.4",
+  "version": "8.6.0",
   "author": "SIMP Team",
   "summary": "A SIMP puppet module for managing auditd and audispd",
   "license": "Apache-2.0",

--- a/metadata.json
+++ b/metadata.json
@@ -1,6 +1,6 @@
 {
   "name": "simp-auditd",
-  "version": "8.5.3",
+  "version": "8.5.4",
   "author": "SIMP Team",
   "summary": "A SIMP puppet module for managing auditd and audispd",
   "license": "Apache-2.0",

--- a/spec/acceptance/suites/default/90_disable_audit_spec.rb
+++ b/spec/acceptance/suites/default/90_disable_audit_spec.rb
@@ -1,10 +1,6 @@
 require 'spec_helper_acceptance'
 
-
-# This set of tests should be last, so that we don't have to
-# reboot the servers to get manifests to apply fully.
-#
-test_name 'disabling kernel auditing via auditd class'
+test_name 'disabling auditing via auditd class'
 
 describe 'auditd class with simp auditd profile' do
   let(:enable_hieradata) {
@@ -20,7 +16,7 @@ describe 'auditd class with simp auditd profile' do
       'pki::cacerts_sources'    => ['file:///etc/pki/simp-testing/pki/cacerts'] ,
       'pki::private_key_source' => "file:///etc/pki/simp-testing/pki/private/%{fqdn}.pem",
       'pki::public_key_source'  => "file:///etc/pki/simp-testing/pki/public/%{fqdn}.pub",
-      'auditd::at_boot' => false
+      'auditd::enable' => false
     }
   }
 
@@ -41,19 +37,17 @@ describe 'auditd class with simp auditd profile' do
         end
       end
 
-      context 'disabling auditd at the kernel level' do
+      context 'disabling auditd' do
         it 'should work with no errors' do
           set_hieradata_on(host, disable_hieradata)
           apply_manifest_on(host, manifest, :catch_failures => true)
         end
 
-        # Note: In SIMP, svckill will take care of actually disabling auditd if
-        # it is no longer managed. Here, we're not including svckill by default.
-        it 'should not kill the auditd service' do
+        it 'should kill the auditd service' do
           result = YAML.safe_load(on(host, 'puppet resource service auditd --to_yaml').stdout)
 
-          expect(result['service']['auditd']['ensure']).to eq('running')
-          expect(result['service']['auditd']['enable']).to eq('true')
+          expect(result['service']['auditd']['ensure']).to eq('stopped')
+          expect(result['service']['auditd']['enable']).to eq('false')
         end
 
         it 'should require reboot on subsequent run' do

--- a/spec/classes/init_spec.rb
+++ b/spec/classes/init_spec.rb
@@ -13,14 +13,23 @@ describe 'auditd' do
   context 'supported operating systems' do
     on_supported_os.each do |os, os_facts|
       context "on #{os}" do
-        let(:facts) {os_facts}
+        let(:facts) do
+          os_facts.merge(
+            {
+              :simplib__auditd => {
+                'enabled' => true,
+                'kernel_enforcing' => true
+              }
+            }
+          )
+        end
 
         context 'auditd with default parameters' do
           let(:params) {{ }}
           it_behaves_like 'a structured module'
           it {
             is_expected.to contain_service('auditd').with({
-              :ensure  => 'running',
+              :ensure  => true,
               :enable  => true,
               :start   => "/sbin/service auditd start",
               :stop    => "/sbin/service auditd stop",
@@ -49,7 +58,7 @@ describe 'auditd' do
           it { is_expected.to contain_class('auditd::config::grub').with_enable(false) }
           it { is_expected.to_not contain_class('auditd::install') }
           it { is_expected.to_not contain_class('auditd::config') }
-          it { is_expected.to_not contain_class('auditd::service') }
+          it { is_expected.to contain_class('auditd::service') }
         end
 
       end


### PR DESCRIPTION
- Ensure that the auditd service is not managed if the kernel is not enforcing
  auditing
- Add an acceptance test for toggling disabling auditing without modifying the
  kernel parameter

SIMP-6839 #comment Ensure that the audit service can be correctly managed based on the kernel state