### PR TITLE
(SIMP-8791) auditd cannot be enabled in specific case

### DIFF
--- a/.gitlab-ci.yml
+++ b/.gitlab-ci.yml
@@ -194,10 +194,10 @@ variables:
     BEAKER_PUPPET_COLLECTION: 'puppet5'
     MATRIX_RUBY_VERSION: '2.4'
 
-.pup_5_5_20: &pup_5_5_20
+.pup_5_5_22: &pup_5_5_22
   image: 'ruby:2.4'
   variables:
-    PUPPET_VERSION: '5.5.20'
+    PUPPET_VERSION: '5.5.22'
     BEAKER_PUPPET_COLLECTION: 'puppet5'
     MATRIX_RUBY_VERSION: '2.4'
 
@@ -285,8 +285,8 @@ pup5-unit:
   <<: *unit_tests
   <<: *with_SIMP_SPEC_MATRIX_LEVEL_2
 
-pup5.5.20-unit:
-  <<: *pup_5_5_20
+pup5.5.22-unit:
+  <<: *pup_5_5_22
   <<: *unit_tests
 
 pup6-unit:
@@ -308,26 +308,26 @@ pup6.16.0-unit:
 # Repo-specific content
 # ==============================================================================
 
-pup5.5.20:
-  <<: *pup_5_5_20
+pup5.5.22:
+  <<: *pup_5_5_22
   <<: *acceptance_base
   script:
     - 'bundle exec rake beaker:suites'
 
-pup5.5.20-fips:
-  <<: *pup_5_5_20
+pup5.5.22-fips:
+  <<: *pup_5_5_22
   <<: *acceptance_base
   script:
     - 'BEAKER_fips=yes bundle exec rake beaker:suites'
 
-pup5.5.20-oel:
-  <<: *pup_5_5_20
+pup5.5.22-oel:
+  <<: *pup_5_5_22
   <<: *acceptance_base
   script:
     - 'bundle exec rake beaker:suites[default,oel]'
 
-pup5.5.20-oel-fips:
-  <<: *pup_5_5_20
+pup5.5.22-oel-fips:
+  <<: *pup_5_5_22
   <<: *acceptance_base
   <<: *with_SIMP_ACCEPTANCE_MATRIX_LEVEL_3
   script:
@@ -346,8 +346,8 @@ pup6-fips:
     - 'BEAKER_fips=yes bundle exec rake beaker:suites'
 
 
-pup5.5.20-fips-compliance:
-  <<: *pup_5_5_20
+pup5.5.22-fips-compliance:
+  <<: *pup_5_5_22
   <<: *compliance_base
   script:
     - 'BEAKER_VAGRANT_MEMSIZE=1536 BEAKER_fips=yes bundle exec rake beaker:suites[compliance]'

--- a/CHANGELOG
+++ b/CHANGELOG
@@ -1,3 +1,9 @@
+* Mon Nov 23 2020 Liz Nemsick <lnemsick.simp@gmail.com> - 8.6.2-0
+- Fixed a bug in which the module could not enable auditing in a system
+  with auditing already disabled in the kernel, when replication of the
+  audit logs to syslog was required.
+  - Manifest would fail to compile because of a nil `auditd_version` fact.
+
 * Wed Sep 23 2020 Trevor Vaughan <tvaughan@onyxpoint.com> - 8.6.1-0
 - Allow auditd space_left and admin_space_left to accept percentages on
   supported versions

--- a/Gemfile
+++ b/Gemfile
@@ -5,7 +5,7 @@ ENV['PDK_DISABLE_ANALYTICS'] ||= 'true'
 gem_sources.each { |gem_source| source gem_source }
 
 group :test do
-  puppet_version = ENV['PUPPET_VERSION'] || '~> 5.5'
+  puppet_version = ENV['PUPPET_VERSION'] || '~> 6.18'
   major_puppet_version = puppet_version.scan(/(\d+)(?:\.|\Z)/).flatten.first.to_i
   gem 'rake'
   gem 'puppet', puppet_version

--- a/manifests/config/logging.pp
+++ b/manifests/config/logging.pp
@@ -10,8 +10,11 @@ class auditd::config::logging {
 #
   assert_private()
 
-  if  versioncmp($facts['auditd_version'], '3.0') < 0 {
-    contain 'auditd::config::audisp'
+  # auditd_version fact is not available until auditing is enabled in the kernel
+  if $facts['auditd_version'] {
+    if  versioncmp($facts['auditd_version'], '3.0') < 0 {
+      contain 'auditd::config::audisp'
+    }
+    contain 'auditd::config::audisp::syslog'
   }
-  contain 'auditd::config::audisp::syslog'
 }

--- a/metadata.json
+++ b/metadata.json
@@ -1,6 +1,6 @@
 {
   "name": "simp-auditd",
-  "version": "8.6.1",
+  "version": "8.6.2",
   "author": "SIMP Team",
   "summary": "A SIMP puppet module for managing auditd and audispd",
   "license": "Apache-2.0",


### PR DESCRIPTION
- Fixed a bug in which the module could not enable auditing in a system
  with auditing already disabled in the kernel, when replication of the
  audit logs to syslog was required.
  - Manifest would fail to compile because of a nil `auditd_version` fact.

SIMP-8791 close