### PR TITLE
(SIMP-9602) Switch to 'always,exit'

### DIFF
--- a/CHANGELOG
+++ b/CHANGELOG
@@ -1,3 +1,7 @@
+* Sun Mar 07 2021 Trevor Vaughan <tvaughan@onyxpoint.com> - 8.6.3
+- Switch auditd rules to be 'always,exit' instead of 'exit,always' to match the
+  man pages and general scanner updates.
+
 * Tue Feb 02 2021 Liz Nemsick <lnemsick.simp@gmail.com> - 8.6.3
 - Expanded simp/rsyslog dependendency range to < 9.0.0.
 

--- a/spec/acceptance/suites/default/00_base_spec.rb
+++ b/spec/acceptance/suites/default/00_base_spec.rb
@@ -122,7 +122,7 @@ describe 'auditd class with simp audit profile' do
           # spot check that audit.rules has been generated with SIMP rules
           on(host, %q(grep -qe '^-c$' /etc/audit/audit.rules))
           on(host, %q(grep -qe '\-a never,exit \-F auid=-1' /etc/audit/audit.rules))
-          on(host, %q(grep -qe '\-a exit,always \-F perm=a \-F exit=-EACCES \-k access' /etc/audit/audit.rules))
+          on(host, %q(grep -qe '\-a always,exit \-F perm=a \-F exit=-EACCES \-k access' /etc/audit/audit.rules))
           on(host, %q(grep -qe '\-w /var/log/audit -p wa \-k audit-logs' /etc/audit/audit.rules))
           # spot check that loaded audit rules contain SIMP rules
           # NOTE:  Loaded rules are normalized as follows:

--- a/spec/classes/config/audit_profiles/built_in_spec.rb
+++ b/spec/classes/config/audit_profiles/built_in_spec.rb
@@ -226,19 +226,19 @@ describe 'auditd' do
         it 'disables chmod auditing by default' do
           # chmod is disabled by default (SIMP-2250)
           is_expected.not_to contain_file('/etc/audit/rules.d/50_01_simp_base.rules').with_content(
-            %r(^-a exit,always -F arch=b\d\d -S chmod,fchmod,fchmodat -k chmod$)
+            %r(^-a always,exit -F arch=b\d\d -S chmod,fchmod,fchmodat -k chmod$)
           )
         end
 
         it 'disables rename/remove auditing by default' do
           is_expected.not_to contain_file('/etc/audit/rules.d/50_01_simp_base.rules').with_content(
-            %r(^-a exit,always -F arch=b\d\d -S rename,renameat,rmdir,unlink,unlinkat -F perm=x -k delete)
+            %r(^-a always,exit -F arch=b\d\d -S rename,renameat,rmdir,unlink,unlinkat -F perm=x -k delete)
           )
         end
 
         it 'disables umask auditing by default' do
           is_expected.not_to contain_file('/etc/audit/rules.d/50_01_simp_base.rules').with_content(
-            %r(^-a exit,always -F arch=b\d\d -S umask -k umask)
+            %r(^-a always,exit -F arch=b\d\d -S umask -k umask)
           )
         end
 
@@ -251,11 +251,11 @@ describe 'auditd' do
 
         it 'disables selinux commands auditing by default' do
           is_expected.not_to contain_file('/etc/audit/rules.d/50_01_simp_base.rules').with_content(
-            %r{^-a exit,always -F path=/usr/bin/(chcon|semanage|setsebool) -F perm=x -k privileged-priv_change}
+            %r{^-a always,exit -F path=/usr/bin/(chcon|semanage|setsebool) -F perm=x -k privileged-priv_change}
           )
 
           is_expected.not_to contain_file('/etc/audit/rules.d/50_01_simp_base.rules').with_content(
-            %r(^-a exit,always -F path=/(usr/)?sbin/setfiles -F perm=x -k privileged-priv_change)
+            %r(^-a always,exit -F path=/(usr/)?sbin/setfiles -F perm=x -k privileged-priv_change)
           )
         end
       end

--- a/spec/classes/config/audit_profiles/expected/simp_el6_aggressive_rules.txt
+++ b/spec/classes/config/audit_profiles/expected/simp_el6_aggressive_rules.txt
@@ -1,90 +1,90 @@
 #### auditd::config::audit_profiles::simp Audit Rules ####
 # 64-bit systems should generally never call the 32-bit API. 32-bit syscalls
 # may be a sign of someone exploiting a hole in the API.
--a exit,always -F arch=b32 -S all -F key=32bit-api
--a exit,always -F arch=b64 -S accept -F a0=2 -F key=ipv4_in
--a exit,always -F arch=b64 -S accept -F a0=10 -F key=ipv6_in
+-a always,exit -F arch=b32 -S all -F key=32bit-api
+-a always,exit -F arch=b64 -S accept -F a0=2 -F key=ipv4_in
+-a always,exit -F arch=b64 -S accept -F a0=10 -F key=ipv6_in
 
 ## Audit unsuccessful file operations
--a exit,always -F arch=b64 -S creat,mkdir,mknod,link,symlink,mkdirat,mknodat,linkat,symlinkat,openat,open_by_handle_at,open,close,rename,renameat,truncate,ftruncate,rmdir,unlink,unlinkat -F exit=-EACCES -k access
--a exit,always -F arch=b64 -S creat,mkdir,mknod,link,symlink,mkdirat,mknodat,linkat,symlinkat,openat,open_by_handle_at,open,close,rename,renameat,truncate,ftruncate,rmdir,unlink,unlinkat -F exit=-EPERM -k access
--a exit,always -F arch=b32 -S creat,mkdir,mknod,link,symlink,mkdirat,mknodat,linkat,symlinkat,openat,open_by_handle_at,open,close,rename,renameat,truncate,ftruncate,rmdir,unlink,unlinkat -F exit=-EACCES -k access
--a exit,always -F arch=b32 -S creat,mkdir,mknod,link,symlink,mkdirat,mknodat,linkat,symlinkat,openat,open_by_handle_at,open,close,rename,renameat,truncate,ftruncate,rmdir,unlink,unlinkat -F exit=-EPERM -k access
+-a always,exit -F arch=b64 -S creat,mkdir,mknod,link,symlink,mkdirat,mknodat,linkat,symlinkat,openat,open_by_handle_at,open,close,rename,renameat,truncate,ftruncate,rmdir,unlink,unlinkat -F exit=-EACCES -k access
+-a always,exit -F arch=b64 -S creat,mkdir,mknod,link,symlink,mkdirat,mknodat,linkat,symlinkat,openat,open_by_handle_at,open,close,rename,renameat,truncate,ftruncate,rmdir,unlink,unlinkat -F exit=-EPERM -k access
+-a always,exit -F arch=b32 -S creat,mkdir,mknod,link,symlink,mkdirat,mknodat,linkat,symlinkat,openat,open_by_handle_at,open,close,rename,renameat,truncate,ftruncate,rmdir,unlink,unlinkat -F exit=-EACCES -k access
+-a always,exit -F arch=b32 -S creat,mkdir,mknod,link,symlink,mkdirat,mknodat,linkat,symlinkat,openat,open_by_handle_at,open,close,rename,renameat,truncate,ftruncate,rmdir,unlink,unlinkat -F exit=-EPERM -k access
 
--a exit,always -F perm=a -F exit=-EACCES -k access
--a exit,always -F perm=a -F exit=-EPERM -k access
+-a always,exit -F perm=a -F exit=-EACCES -k access
+-a always,exit -F perm=a -F exit=-EPERM -k access
 
 ## Audit the execution of password commands
--a exit,always -F path=/usr/bin/passwd -F perm=x -k privileged-passwd
+-a always,exit -F path=/usr/bin/passwd -F perm=x -k privileged-passwd
 
--a exit,always -F path=/sbin/unix_chkpwd -F perm=x -k privileged-passwd
+-a always,exit -F path=/sbin/unix_chkpwd -F perm=x -k privileged-passwd
 
--a exit,always -F path=/usr/bin/gpasswd -F perm=x -k privileged-passwd
+-a always,exit -F path=/usr/bin/gpasswd -F perm=x -k privileged-passwd
 
--a exit,always -F path=/usr/bin/chage -F perm=x -k privileged-passwd
+-a always,exit -F path=/usr/bin/chage -F perm=x -k privileged-passwd
 
--a exit,always -F path=/usr/sbin/userhelper -F perm=x -k privileged-passwd
+-a always,exit -F path=/usr/sbin/userhelper -F perm=x -k privileged-passwd
 
 ## Audit the execution of privilege-related commands
--a exit,always -F path=/bin/su -F perm=x -k privileged-priv_change
+-a always,exit -F path=/bin/su -F perm=x -k privileged-priv_change
 
--a exit,always -F path=/usr/bin/sudo -F perm=x -k privileged-priv_change
+-a always,exit -F path=/usr/bin/sudo -F perm=x -k privileged-priv_change
 
--a exit,always -F path=/usr/bin/newgrp -F perm=x -k privileged-priv_change
+-a always,exit -F path=/usr/bin/newgrp -F perm=x -k privileged-priv_change
 
--a exit,always -F path=/usr/bin/chsh -F perm=x -k privileged-priv_change
+-a always,exit -F path=/usr/bin/chsh -F perm=x -k privileged-priv_change
 
--a exit,always -F path=/usr/bin/sudoedit -F perm=x -k privileged-priv_change
+-a always,exit -F path=/usr/bin/sudoedit -F perm=x -k privileged-priv_change
 
 ## Audit the execution of postfix-related commands
--a exit,always -F path=/usr/sbin/postdrop -F perm=x -k privileged-postfix
+-a always,exit -F path=/usr/sbin/postdrop -F perm=x -k privileged-postfix
 
--a exit,always -F path=/usr/sbin/postqueue -F perm=x -k privileged-postfix
+-a always,exit -F path=/usr/sbin/postqueue -F perm=x -k privileged-postfix
 
 ## Audit the execution of the ssh-keysign command
--a exit,always -F path=/usr/libexec/openssh/ssh-keysign -F perm=x -k privileged-ssh
+-a always,exit -F path=/usr/libexec/openssh/ssh-keysign -F perm=x -k privileged-ssh
 
 ## Audit the execution of the crontab command
--a exit,always -F path=/usr/bin/crontab -F perm=x -k privileged-cron
+-a always,exit -F path=/usr/bin/crontab -F perm=x -k privileged-cron
 
 ## Audit the execution of the pam_timestamp_check command
--a exit,always -F path=/sbin/pam_timestamp_check -F perm=x -k privileged-pam
+-a always,exit -F path=/sbin/pam_timestamp_check -F perm=x -k privileged-pam
 
 ## Permissions auditing separated by chown, chmod, and attr
 
--a exit,always -F arch=b64 -S chown,fchown,fchownat,lchown -k chown
--a exit,always -F arch=b32 -S chown,fchown,fchownat,lchown -k chown
+-a always,exit -F arch=b64 -S chown,fchown,fchownat,lchown -k chown
+-a always,exit -F arch=b32 -S chown,fchown,fchownat,lchown -k chown
 
--a exit,always -F arch=b64 -S setxattr,lsetxattr,fsetxattr,removexattr,lremovexattr,fremovexattr -k attr
--a exit,always -F arch=b32 -S setxattr,lsetxattr,fsetxattr,removexattr,lremovexattr,fremovexattr -k attr
+-a always,exit -F arch=b64 -S setxattr,lsetxattr,fsetxattr,removexattr,lremovexattr,fremovexattr -k attr
+-a always,exit -F arch=b32 -S setxattr,lsetxattr,fsetxattr,removexattr,lremovexattr,fremovexattr -k attr
 
 ## Audit useful items that someone does when su'ing to root.
--a exit,always -F arch=b64 -F auid!=0 -F uid=0 -S capset,mknod,mknodat,pivot_root,quotactl,setsid,adjtimex,settimeofday,setuid,swapoff,swapon,execve,rename,renameat,rmdir,unlink,unlinkat -k su-root-activity
--a exit,always -F arch=b32 -F auid!=0 -F uid=0 -S capset,mknod,mknodat,pivot_root,quotactl,setsid,adjtimex,settimeofday,setuid,swapoff,swapon,execve,rename,renameat,rmdir,unlink,unlinkat -k su-root-activity
+-a always,exit -F arch=b64 -F auid!=0 -F uid=0 -S capset,mknod,mknodat,pivot_root,quotactl,setsid,adjtimex,settimeofday,setuid,swapoff,swapon,execve,rename,renameat,rmdir,unlink,unlinkat -k su-root-activity
+-a always,exit -F arch=b32 -F auid!=0 -F uid=0 -S capset,mknod,mknodat,pivot_root,quotactl,setsid,adjtimex,settimeofday,setuid,swapoff,swapon,execve,rename,renameat,rmdir,unlink,unlinkat -k su-root-activity
 
 ## Audit the execution of suid and sgid binaries.
--a exit,always -F arch=b64 -F euid=0 -F uid!=0 -S execve -k suid-root-exec
--a exit,always -F arch=b32 -F euid=0 -F uid!=0 -S execve -k suid-root-exec
+-a always,exit -F arch=b64 -F euid=0 -F uid!=0 -S execve -k suid-root-exec
+-a always,exit -F arch=b32 -F euid=0 -F uid!=0 -S execve -k suid-root-exec
 
 ## Audit the loading and unloading of kernel modules.
 -w /sbin/insmod -p x -k modules
 -w /sbin/rmmod -p x -k modules
 -w /sbin/modprobe -p x -k modules
 
--a exit,always -F arch=b64 -S create_module,init_module,finit_module,delete_module -k modules
--a exit,always -F arch=b32 -S create_module,init_module,finit_module,delete_module -k modules
+-a always,exit -F arch=b64 -S create_module,init_module,finit_module,delete_module -k modules
+-a always,exit -F arch=b32 -S create_module,init_module,finit_module,delete_module -k modules
 
 ## Audit things that could affect time
--a exit,always -F arch=b64 -S adjtimex,settimeofday -k audit_time_rules
--a exit,always -F arch=b64 -S clock_settime -F a0=0x0 -k audit_time_rules
--a exit,always -F arch=b32 -S adjtimex,stime,settimeofday -k audit_time_rules
--a exit,always -F arch=b32 -S clock_settime -F a0=0x0 -k audit_time_rules
+-a always,exit -F arch=b64 -S adjtimex,settimeofday -k audit_time_rules
+-a always,exit -F arch=b64 -S clock_settime -F a0=0x0 -k audit_time_rules
+-a always,exit -F arch=b32 -S adjtimex,stime,settimeofday -k audit_time_rules
+-a always,exit -F arch=b32 -S clock_settime -F a0=0x0 -k audit_time_rules
 
 -w /etc/localtime -p wa -k audit_time_rules
 
 ## Audit things that could affect system locale
--a exit,always -F arch=b64 -S sethostname,setdomainname -k audit_network_modifications
--a exit,always -F arch=b32 -S sethostname,setdomainname -k audit_network_modifications
+-a always,exit -F arch=b64 -S sethostname,setdomainname -k audit_network_modifications
+-a always,exit -F arch=b32 -S sethostname,setdomainname -k audit_network_modifications
 
 -w /etc/issue -p wa -k audit_network_modifications
 -w /etc/issue.net -p wa -k audit_network_modifications
@@ -93,12 +93,12 @@
 -w /etc/sysconfig/network -p wa -k audit_network_modifications
 
 ## Audit mount operations
--a exit,always -F arch=b64 -S mount,umount2 -k mount
--a exit,always -F arch=b32 -S mount,umount,umount2 -k mount
+-a always,exit -F arch=b64 -S mount,umount2 -k mount
+-a always,exit -F arch=b32 -S mount,umount,umount2 -k mount
 
--a exit,always -F arch=b64 -F path=/bin/mount -k mount
--a exit,always -F arch=b32 -F path=/bin/mount -k mount
--a exit,always -F path=/bin/umount -F perm=x -k mount
+-a always,exit -F arch=b64 -F path=/bin/mount -k mount
+-a always,exit -F arch=b32 -F path=/bin/mount -k mount
+-a always,exit -F path=/bin/umount -F perm=x -k mount
 
 ## Audit local accounts
 -w /etc/passwd -p wa -k audit_account_changes
@@ -199,13 +199,13 @@
 -w /etc/yum -p wa -k yum-config
 -w /etc/yum.conf -p wa -k yum-config
 -w /etc/yum.repos.d -p wa -k yum-config
--a exit,always -F arch=b64 -S ptrace -F a0=0x4 -k paranoid_code_injection
--a exit,always -F arch=b64 -S ptrace -F a0=0x5 -k paranoid_data_injection
--a exit,always -F arch=b64 -S ptrace -F a0=0x6 -k paranoid_register_injection
--a exit,always -F arch=b64 -S ptrace -k paranoid
--a exit,always -F arch=b32 -S ptrace -F a0=0x4 -k paranoid_code_injection
--a exit,always -F arch=b32 -S ptrace -F a0=0x5 -k paranoid_data_injection
--a exit,always -F arch=b32 -S ptrace -F a0=0x6 -k paranoid_register_injection
--a exit,always -F arch=b32 -S ptrace -k paranoid
--a exit,always -F arch=b64 -S personality -k paranoid
--a exit,always -F arch=b32 -S personality -k paranoid
+-a always,exit -F arch=b64 -S ptrace -F a0=0x4 -k paranoid_code_injection
+-a always,exit -F arch=b64 -S ptrace -F a0=0x5 -k paranoid_data_injection
+-a always,exit -F arch=b64 -S ptrace -F a0=0x6 -k paranoid_register_injection
+-a always,exit -F arch=b64 -S ptrace -k paranoid
+-a always,exit -F arch=b32 -S ptrace -F a0=0x4 -k paranoid_code_injection
+-a always,exit -F arch=b32 -S ptrace -F a0=0x5 -k paranoid_data_injection
+-a always,exit -F arch=b32 -S ptrace -F a0=0x6 -k paranoid_register_injection
+-a always,exit -F arch=b32 -S ptrace -k paranoid
+-a always,exit -F arch=b64 -S personality -k paranoid
+-a always,exit -F arch=b32 -S personality -k paranoid

--- a/spec/classes/config/audit_profiles/expected/simp_el6_all_rules_custom_tags.txt
+++ b/spec/classes/config/audit_profiles/expected/simp_el6_all_rules_custom_tags.txt
@@ -1,103 +1,103 @@
 #### auditd::config::audit_profiles::simp Audit Rules ####
 # 64-bit systems should generally never call the 32-bit API. 32-bit syscalls
 # may be a sign of someone exploiting a hole in the API.
--a exit,always -F arch=b32 -S all -F key=32bit-api
--a exit,always -F arch=b64 -S accept -F a0=2 -F key=ipv4_in
--a exit,always -F arch=b64 -S accept -F a0=10 -F key=ipv6_in
+-a always,exit -F arch=b32 -S all -F key=32bit-api
+-a always,exit -F arch=b64 -S accept -F a0=2 -F key=ipv4_in
+-a always,exit -F arch=b64 -S accept -F a0=10 -F key=ipv6_in
 
 ## Audit unsuccessful file operations
--a exit,always -F arch=b64 -S creat,mkdir,mknod,link,symlink,mkdirat,mknodat,linkat,symlinkat,openat,open_by_handle_at,open,close,rename,renameat,truncate,ftruncate,rmdir,unlink,unlinkat -F exit=-EACCES -k my_unsuccessful_file_operations
--a exit,always -F arch=b64 -S creat,mkdir,mknod,link,symlink,mkdirat,mknodat,linkat,symlinkat,openat,open_by_handle_at,open,close,rename,renameat,truncate,ftruncate,rmdir,unlink,unlinkat -F exit=-EPERM -k my_unsuccessful_file_operations
--a exit,always -F arch=b32 -S creat,mkdir,mknod,link,symlink,mkdirat,mknodat,linkat,symlinkat,openat,open_by_handle_at,open,close,rename,renameat,truncate,ftruncate,rmdir,unlink,unlinkat -F exit=-EACCES -k my_unsuccessful_file_operations
--a exit,always -F arch=b32 -S creat,mkdir,mknod,link,symlink,mkdirat,mknodat,linkat,symlinkat,openat,open_by_handle_at,open,close,rename,renameat,truncate,ftruncate,rmdir,unlink,unlinkat -F exit=-EPERM -k my_unsuccessful_file_operations
+-a always,exit -F arch=b64 -S creat,mkdir,mknod,link,symlink,mkdirat,mknodat,linkat,symlinkat,openat,open_by_handle_at,open,close,rename,renameat,truncate,ftruncate,rmdir,unlink,unlinkat -F exit=-EACCES -k my_unsuccessful_file_operations
+-a always,exit -F arch=b64 -S creat,mkdir,mknod,link,symlink,mkdirat,mknodat,linkat,symlinkat,openat,open_by_handle_at,open,close,rename,renameat,truncate,ftruncate,rmdir,unlink,unlinkat -F exit=-EPERM -k my_unsuccessful_file_operations
+-a always,exit -F arch=b32 -S creat,mkdir,mknod,link,symlink,mkdirat,mknodat,linkat,symlinkat,openat,open_by_handle_at,open,close,rename,renameat,truncate,ftruncate,rmdir,unlink,unlinkat -F exit=-EACCES -k my_unsuccessful_file_operations
+-a always,exit -F arch=b32 -S creat,mkdir,mknod,link,symlink,mkdirat,mknodat,linkat,symlinkat,openat,open_by_handle_at,open,close,rename,renameat,truncate,ftruncate,rmdir,unlink,unlinkat -F exit=-EPERM -k my_unsuccessful_file_operations
 
--a exit,always -F perm=a -F exit=-EACCES -k my_unsuccessful_file_operations
--a exit,always -F perm=a -F exit=-EPERM -k my_unsuccessful_file_operations
+-a always,exit -F perm=a -F exit=-EACCES -k my_unsuccessful_file_operations
+-a always,exit -F perm=a -F exit=-EPERM -k my_unsuccessful_file_operations
 
 ## Audit the execution of password commands
--a exit,always -F path=/usr/bin/passwd -F perm=x -k my_passwd_cmds
+-a always,exit -F path=/usr/bin/passwd -F perm=x -k my_passwd_cmds
 
--a exit,always -F path=/sbin/unix_chkpwd -F perm=x -k my_passwd_cmds
+-a always,exit -F path=/sbin/unix_chkpwd -F perm=x -k my_passwd_cmds
 
--a exit,always -F path=/usr/bin/gpasswd -F perm=x -k my_passwd_cmds
+-a always,exit -F path=/usr/bin/gpasswd -F perm=x -k my_passwd_cmds
 
--a exit,always -F path=/usr/bin/chage -F perm=x -k my_passwd_cmds
+-a always,exit -F path=/usr/bin/chage -F perm=x -k my_passwd_cmds
 
--a exit,always -F path=/usr/sbin/userhelper -F perm=x -k my_passwd_cmds
+-a always,exit -F path=/usr/sbin/userhelper -F perm=x -k my_passwd_cmds
 
 ## Audit the execution of privilege-related commands
--a exit,always -F path=/bin/su -F perm=x -k my_priv_cmds
+-a always,exit -F path=/bin/su -F perm=x -k my_priv_cmds
 
--a exit,always -F path=/usr/bin/sudo -F perm=x -k my_priv_cmds
+-a always,exit -F path=/usr/bin/sudo -F perm=x -k my_priv_cmds
 
--a exit,always -F path=/usr/bin/newgrp -F perm=x -k my_priv_cmds
+-a always,exit -F path=/usr/bin/newgrp -F perm=x -k my_priv_cmds
 
--a exit,always -F path=/usr/bin/chsh -F perm=x -k my_priv_cmds
+-a always,exit -F path=/usr/bin/chsh -F perm=x -k my_priv_cmds
 
--a exit,always -F path=/usr/bin/sudoedit -F perm=x -k my_priv_cmds
+-a always,exit -F path=/usr/bin/sudoedit -F perm=x -k my_priv_cmds
 
 ## Audit the execution of postfix-related commands
--a exit,always -F path=/usr/sbin/postdrop -F perm=x -k my_postfix_cmds
+-a always,exit -F path=/usr/sbin/postdrop -F perm=x -k my_postfix_cmds
 
--a exit,always -F path=/usr/sbin/postqueue -F perm=x -k my_postfix_cmds
+-a always,exit -F path=/usr/sbin/postqueue -F perm=x -k my_postfix_cmds
 
 ## Audit the execution of the ssh-keysign command
--a exit,always -F path=/usr/libexec/openssh/ssh-keysign -F perm=x -k my_ssh_keysign_cmd
+-a always,exit -F path=/usr/libexec/openssh/ssh-keysign -F perm=x -k my_ssh_keysign_cmd
 
 ## Audit the execution of the crontab command
--a exit,always -F path=/usr/bin/crontab -F perm=x -k my_crontab_cmd
+-a always,exit -F path=/usr/bin/crontab -F perm=x -k my_crontab_cmd
 
 ## Audit the execution of the pam_timestamp_check command
--a exit,always -F path=/sbin/pam_timestamp_check -F perm=x -k my_pam_timestamp_check_cmd
+-a always,exit -F path=/sbin/pam_timestamp_check -F perm=x -k my_pam_timestamp_check_cmd
 
 ## Audit selinux commands
--a exit,always -F path=/usr/sbin/semanage -F perm=x -k my_selinux_cmds
--a exit,always -F path=/usr/sbin/setsebool -F perm=x -k my_selinux_cmds
--a exit,always -F path=/usr/bin/chcon -F perm=x -k my_selinux_cmds
--a exit,always -F path=/sbin/setfiles -F perm=x -k my_selinux_cmds
+-a always,exit -F path=/usr/sbin/semanage -F perm=x -k my_selinux_cmds
+-a always,exit -F path=/usr/sbin/setsebool -F perm=x -k my_selinux_cmds
+-a always,exit -F path=/usr/bin/chcon -F perm=x -k my_selinux_cmds
+-a always,exit -F path=/sbin/setfiles -F perm=x -k my_selinux_cmds
 
 ## Permissions auditing separated by chown, chmod, and attr
 
--a exit,always -F arch=b64 -S chown,fchown,fchownat,lchown -k my_chown
--a exit,always -F arch=b32 -S chown,fchown,fchownat,lchown -k my_chown
+-a always,exit -F arch=b64 -S chown,fchown,fchownat,lchown -k my_chown
+-a always,exit -F arch=b32 -S chown,fchown,fchownat,lchown -k my_chown
 
--a exit,always -F arch=b64 -S chmod,fchmod,fchmodat -k my_chmod
--a exit,always -F arch=b32 -S chmod,fchmod,fchmodat -k my_chmod
+-a always,exit -F arch=b64 -S chmod,fchmod,fchmodat -k my_chmod
+-a always,exit -F arch=b32 -S chmod,fchmod,fchmodat -k my_chmod
 
--a exit,always -F arch=b64 -S setxattr,lsetxattr,fsetxattr,removexattr,lremovexattr,fremovexattr -k my_attr
--a exit,always -F arch=b32 -S setxattr,lsetxattr,fsetxattr,removexattr,lremovexattr,fremovexattr -k my_attr
+-a always,exit -F arch=b64 -S setxattr,lsetxattr,fsetxattr,removexattr,lremovexattr,fremovexattr -k my_attr
+-a always,exit -F arch=b32 -S setxattr,lsetxattr,fsetxattr,removexattr,lremovexattr,fremovexattr -k my_attr
 
 ## Audit rename/removal operations
--a exit,always -F arch=b64 -S rename,renameat,rmdir,unlink,unlinkat -F perm=x -k my_rename_remove
--a exit,always -F arch=b32 -S rename,renameat,rmdir,unlink,unlinkat -F perm=x -k my_rename_remove
+-a always,exit -F arch=b64 -S rename,renameat,rmdir,unlink,unlinkat -F perm=x -k my_rename_remove
+-a always,exit -F arch=b32 -S rename,renameat,rmdir,unlink,unlinkat -F perm=x -k my_rename_remove
 
 ## Audit useful items that someone does when su'ing to root.
--a exit,always -F arch=b64 -F auid!=0 -F uid=0 -S capset,mknod,mknodat,pivot_root,quotactl,setsid,adjtimex,settimeofday,setuid,swapoff,swapon,execve,rename,renameat,rmdir,unlink,unlinkat,write,chown,fchown,fchownat,lchown,creat,fork,vfork,link,linkat,symlink,symlinkat,mkdir,mkdirat -k my_su_root_activity
--a exit,always -F arch=b32 -F auid!=0 -F uid=0 -S capset,mknod,mknodat,pivot_root,quotactl,setsid,adjtimex,settimeofday,setuid,swapoff,swapon,execve,rename,renameat,rmdir,unlink,unlinkat,write,chown,fchown,fchownat,lchown,creat,fork,vfork,link,linkat,symlink,symlinkat,mkdir,mkdirat -k my_su_root_activity
+-a always,exit -F arch=b64 -F auid!=0 -F uid=0 -S capset,mknod,mknodat,pivot_root,quotactl,setsid,adjtimex,settimeofday,setuid,swapoff,swapon,execve,rename,renameat,rmdir,unlink,unlinkat,write,chown,fchown,fchownat,lchown,creat,fork,vfork,link,linkat,symlink,symlinkat,mkdir,mkdirat -k my_su_root_activity
+-a always,exit -F arch=b32 -F auid!=0 -F uid=0 -S capset,mknod,mknodat,pivot_root,quotactl,setsid,adjtimex,settimeofday,setuid,swapoff,swapon,execve,rename,renameat,rmdir,unlink,unlinkat,write,chown,fchown,fchownat,lchown,creat,fork,vfork,link,linkat,symlink,symlinkat,mkdir,mkdirat -k my_su_root_activity
 
 ## Audit the execution of suid and sgid binaries.
--a exit,always -F arch=b64 -F euid=0 -F uid!=0 -S execve -k my_suid_sgid
--a exit,always -F arch=b32 -F euid=0 -F uid!=0 -S execve -k my_suid_sgid
+-a always,exit -F arch=b64 -F euid=0 -F uid!=0 -S execve -k my_suid_sgid
+-a always,exit -F arch=b32 -F euid=0 -F uid!=0 -S execve -k my_suid_sgid
 
 ## Audit the loading and unloading of kernel modules.
 -w /sbin/insmod -p x -k my_kernel_modules
 -w /sbin/rmmod -p x -k my_kernel_modules
 -w /sbin/modprobe -p x -k my_kernel_modules
 
--a exit,always -F arch=b64 -S create_module,init_module,finit_module,delete_module -k my_kernel_modules
--a exit,always -F arch=b32 -S create_module,init_module,finit_module,delete_module -k my_kernel_modules
+-a always,exit -F arch=b64 -S create_module,init_module,finit_module,delete_module -k my_kernel_modules
+-a always,exit -F arch=b32 -S create_module,init_module,finit_module,delete_module -k my_kernel_modules
 
 ## Audit things that could affect time
--a exit,always -F arch=b64 -S adjtimex,settimeofday -k my_time
--a exit,always -F arch=b64 -S clock_settime -F a0=0x0 -k my_time
--a exit,always -F arch=b32 -S adjtimex,stime,settimeofday -k my_time
--a exit,always -F arch=b32 -S clock_settime -F a0=0x0 -k my_time
+-a always,exit -F arch=b64 -S adjtimex,settimeofday -k my_time
+-a always,exit -F arch=b64 -S clock_settime -F a0=0x0 -k my_time
+-a always,exit -F arch=b32 -S adjtimex,stime,settimeofday -k my_time
+-a always,exit -F arch=b32 -S clock_settime -F a0=0x0 -k my_time
 
 -w /etc/localtime -p wa -k my_time
 
 ## Audit things that could affect system locale
--a exit,always -F arch=b64 -S sethostname,setdomainname -k my_locale
--a exit,always -F arch=b32 -S sethostname,setdomainname -k my_locale
+-a always,exit -F arch=b64 -S sethostname,setdomainname -k my_locale
+-a always,exit -F arch=b32 -S sethostname,setdomainname -k my_locale
 
 -w /etc/issue -p wa -k my_locale
 -w /etc/issue.net -p wa -k my_locale
@@ -106,16 +106,16 @@
 -w /etc/sysconfig/network -p wa -k my_locale
 
 ## Audit mount operations
--a exit,always -F arch=b64 -S mount,umount2 -k my_mount
--a exit,always -F arch=b32 -S mount,umount,umount2 -k my_mount
+-a always,exit -F arch=b64 -S mount,umount2 -k my_mount
+-a always,exit -F arch=b32 -S mount,umount,umount2 -k my_mount
 
--a exit,always -F arch=b64 -F path=/bin/mount -k my_mount
--a exit,always -F arch=b32 -F path=/bin/mount -k my_mount
--a exit,always -F path=/bin/umount -F perm=x -k my_mount
+-a always,exit -F arch=b64 -F path=/bin/mount -k my_mount
+-a always,exit -F arch=b32 -F path=/bin/mount -k my_mount
+-a always,exit -F path=/bin/umount -F perm=x -k my_mount
 
 ## Audit umask changes.
--a exit,always -F arch=b64 -S umask -k my_umask
--a exit,always -F arch=b32 -S umask -k my_umask
+-a always,exit -F arch=b64 -S umask -k my_umask
+-a always,exit -F arch=b32 -S umask -k my_umask
 
 ## Audit local accounts
 -w /etc/passwd -p wa -k my_local_account
@@ -218,13 +218,13 @@
 -w /etc/yum.repos.d -p wa -k my_cfg_yum
 -w /usr/bin/yum -p x -k my_yum_cmd
 -w /bin/rpm -p x -k my_rpm_cmd
--a exit,always -F arch=b64 -S ptrace -F a0=0x4 -k paranoid_code_injection
--a exit,always -F arch=b64 -S ptrace -F a0=0x5 -k paranoid_data_injection
--a exit,always -F arch=b64 -S ptrace -F a0=0x6 -k paranoid_register_injection
--a exit,always -F arch=b64 -S ptrace -k my_ptrace
--a exit,always -F arch=b32 -S ptrace -F a0=0x4 -k paranoid_code_injection
--a exit,always -F arch=b32 -S ptrace -F a0=0x5 -k paranoid_data_injection
--a exit,always -F arch=b32 -S ptrace -F a0=0x6 -k paranoid_register_injection
--a exit,always -F arch=b32 -S ptrace -k my_ptrace
--a exit,always -F arch=b64 -S personality -k my_personality
--a exit,always -F arch=b32 -S personality -k my_personality
+-a always,exit -F arch=b64 -S ptrace -F a0=0x4 -k paranoid_code_injection
+-a always,exit -F arch=b64 -S ptrace -F a0=0x5 -k paranoid_data_injection
+-a always,exit -F arch=b64 -S ptrace -F a0=0x6 -k paranoid_register_injection
+-a always,exit -F arch=b64 -S ptrace -k my_ptrace
+-a always,exit -F arch=b32 -S ptrace -F a0=0x4 -k paranoid_code_injection
+-a always,exit -F arch=b32 -S ptrace -F a0=0x5 -k paranoid_data_injection
+-a always,exit -F arch=b32 -S ptrace -F a0=0x6 -k paranoid_register_injection
+-a always,exit -F arch=b32 -S ptrace -k my_ptrace
+-a always,exit -F arch=b64 -S personality -k my_personality
+-a always,exit -F arch=b32 -S personality -k my_personality

--- a/spec/classes/config/audit_profiles/expected/simp_el6_basic_rules.txt
+++ b/spec/classes/config/audit_profiles/expected/simp_el6_basic_rules.txt
@@ -1,90 +1,90 @@
 #### auditd::config::audit_profiles::simp Audit Rules ####
 # 64-bit systems should generally never call the 32-bit API. 32-bit syscalls
 # may be a sign of someone exploiting a hole in the API.
--a exit,always -F arch=b32 -S all -F key=32bit-api
--a exit,always -F arch=b64 -S accept -F a0=2 -F key=ipv4_in
--a exit,always -F arch=b64 -S accept -F a0=10 -F key=ipv6_in
+-a always,exit -F arch=b32 -S all -F key=32bit-api
+-a always,exit -F arch=b64 -S accept -F a0=2 -F key=ipv4_in
+-a always,exit -F arch=b64 -S accept -F a0=10 -F key=ipv6_in
 
 ## Audit unsuccessful file operations
--a exit,always -F arch=b64 -S creat,mkdir,mknod,link,symlink,mkdirat,mknodat,linkat,symlinkat,openat,open_by_handle_at,open,close,rename,renameat,truncate,ftruncate,rmdir,unlink,unlinkat -F exit=-EACCES -k access
--a exit,always -F arch=b64 -S creat,mkdir,mknod,link,symlink,mkdirat,mknodat,linkat,symlinkat,openat,open_by_handle_at,open,close,rename,renameat,truncate,ftruncate,rmdir,unlink,unlinkat -F exit=-EPERM -k access
--a exit,always -F arch=b32 -S creat,mkdir,mknod,link,symlink,mkdirat,mknodat,linkat,symlinkat,openat,open_by_handle_at,open,close,rename,renameat,truncate,ftruncate,rmdir,unlink,unlinkat -F exit=-EACCES -k access
--a exit,always -F arch=b32 -S creat,mkdir,mknod,link,symlink,mkdirat,mknodat,linkat,symlinkat,openat,open_by_handle_at,open,close,rename,renameat,truncate,ftruncate,rmdir,unlink,unlinkat -F exit=-EPERM -k access
+-a always,exit -F arch=b64 -S creat,mkdir,mknod,link,symlink,mkdirat,mknodat,linkat,symlinkat,openat,open_by_handle_at,open,close,rename,renameat,truncate,ftruncate,rmdir,unlink,unlinkat -F exit=-EACCES -k access
+-a always,exit -F arch=b64 -S creat,mkdir,mknod,link,symlink,mkdirat,mknodat,linkat,symlinkat,openat,open_by_handle_at,open,close,rename,renameat,truncate,ftruncate,rmdir,unlink,unlinkat -F exit=-EPERM -k access
+-a always,exit -F arch=b32 -S creat,mkdir,mknod,link,symlink,mkdirat,mknodat,linkat,symlinkat,openat,open_by_handle_at,open,close,rename,renameat,truncate,ftruncate,rmdir,unlink,unlinkat -F exit=-EACCES -k access
+-a always,exit -F arch=b32 -S creat,mkdir,mknod,link,symlink,mkdirat,mknodat,linkat,symlinkat,openat,open_by_handle_at,open,close,rename,renameat,truncate,ftruncate,rmdir,unlink,unlinkat -F exit=-EPERM -k access
 
--a exit,always -F perm=a -F exit=-EACCES -k access
--a exit,always -F perm=a -F exit=-EPERM -k access
+-a always,exit -F perm=a -F exit=-EACCES -k access
+-a always,exit -F perm=a -F exit=-EPERM -k access
 
 ## Audit the execution of password commands
--a exit,always -F path=/usr/bin/passwd -F perm=x -k privileged-passwd
+-a always,exit -F path=/usr/bin/passwd -F perm=x -k privileged-passwd
 
--a exit,always -F path=/sbin/unix_chkpwd -F perm=x -k privileged-passwd
+-a always,exit -F path=/sbin/unix_chkpwd -F perm=x -k privileged-passwd
 
--a exit,always -F path=/usr/bin/gpasswd -F perm=x -k privileged-passwd
+-a always,exit -F path=/usr/bin/gpasswd -F perm=x -k privileged-passwd
 
--a exit,always -F path=/usr/bin/chage -F perm=x -k privileged-passwd
+-a always,exit -F path=/usr/bin/chage -F perm=x -k privileged-passwd
 
--a exit,always -F path=/usr/sbin/userhelper -F perm=x -k privileged-passwd
+-a always,exit -F path=/usr/sbin/userhelper -F perm=x -k privileged-passwd
 
 ## Audit the execution of privilege-related commands
--a exit,always -F path=/bin/su -F perm=x -k privileged-priv_change
+-a always,exit -F path=/bin/su -F perm=x -k privileged-priv_change
 
--a exit,always -F path=/usr/bin/sudo -F perm=x -k privileged-priv_change
+-a always,exit -F path=/usr/bin/sudo -F perm=x -k privileged-priv_change
 
--a exit,always -F path=/usr/bin/newgrp -F perm=x -k privileged-priv_change
+-a always,exit -F path=/usr/bin/newgrp -F perm=x -k privileged-priv_change
 
--a exit,always -F path=/usr/bin/chsh -F perm=x -k privileged-priv_change
+-a always,exit -F path=/usr/bin/chsh -F perm=x -k privileged-priv_change
 
--a exit,always -F path=/usr/bin/sudoedit -F perm=x -k privileged-priv_change
+-a always,exit -F path=/usr/bin/sudoedit -F perm=x -k privileged-priv_change
 
 ## Audit the execution of postfix-related commands
--a exit,always -F path=/usr/sbin/postdrop -F perm=x -k privileged-postfix
+-a always,exit -F path=/usr/sbin/postdrop -F perm=x -k privileged-postfix
 
--a exit,always -F path=/usr/sbin/postqueue -F perm=x -k privileged-postfix
+-a always,exit -F path=/usr/sbin/postqueue -F perm=x -k privileged-postfix
 
 ## Audit the execution of the ssh-keysign command
--a exit,always -F path=/usr/libexec/openssh/ssh-keysign -F perm=x -k privileged-ssh
+-a always,exit -F path=/usr/libexec/openssh/ssh-keysign -F perm=x -k privileged-ssh
 
 ## Audit the execution of the crontab command
--a exit,always -F path=/usr/bin/crontab -F perm=x -k privileged-cron
+-a always,exit -F path=/usr/bin/crontab -F perm=x -k privileged-cron
 
 ## Audit the execution of the pam_timestamp_check command
--a exit,always -F path=/sbin/pam_timestamp_check -F perm=x -k privileged-pam
+-a always,exit -F path=/sbin/pam_timestamp_check -F perm=x -k privileged-pam
 
 ## Permissions auditing separated by chown, chmod, and attr
 
--a exit,always -F arch=b64 -S chown,fchown,fchownat,lchown -k chown
--a exit,always -F arch=b32 -S chown,fchown,fchownat,lchown -k chown
+-a always,exit -F arch=b64 -S chown,fchown,fchownat,lchown -k chown
+-a always,exit -F arch=b32 -S chown,fchown,fchownat,lchown -k chown
 
--a exit,always -F arch=b64 -S setxattr,lsetxattr,fsetxattr,removexattr,lremovexattr,fremovexattr -k attr
--a exit,always -F arch=b32 -S setxattr,lsetxattr,fsetxattr,removexattr,lremovexattr,fremovexattr -k attr
+-a always,exit -F arch=b64 -S setxattr,lsetxattr,fsetxattr,removexattr,lremovexattr,fremovexattr -k attr
+-a always,exit -F arch=b32 -S setxattr,lsetxattr,fsetxattr,removexattr,lremovexattr,fremovexattr -k attr
 
 ## Audit useful items that someone does when su'ing to root.
--a exit,always -F arch=b64 -F auid!=0 -F uid=0 -S capset,mknod,mknodat,pivot_root,quotactl,setsid,adjtimex,settimeofday,setuid,swapoff,swapon -k su-root-activity
--a exit,always -F arch=b32 -F auid!=0 -F uid=0 -S capset,mknod,mknodat,pivot_root,quotactl,setsid,adjtimex,settimeofday,setuid,swapoff,swapon -k su-root-activity
+-a always,exit -F arch=b64 -F auid!=0 -F uid=0 -S capset,mknod,mknodat,pivot_root,quotactl,setsid,adjtimex,settimeofday,setuid,swapoff,swapon -k su-root-activity
+-a always,exit -F arch=b32 -F auid!=0 -F uid=0 -S capset,mknod,mknodat,pivot_root,quotactl,setsid,adjtimex,settimeofday,setuid,swapoff,swapon -k su-root-activity
 
 ## Audit the execution of suid and sgid binaries.
--a exit,always -F arch=b64 -F euid=0 -F uid!=0 -S execve -k suid-root-exec
--a exit,always -F arch=b32 -F euid=0 -F uid!=0 -S execve -k suid-root-exec
+-a always,exit -F arch=b64 -F euid=0 -F uid!=0 -S execve -k suid-root-exec
+-a always,exit -F arch=b32 -F euid=0 -F uid!=0 -S execve -k suid-root-exec
 
 ## Audit the loading and unloading of kernel modules.
 -w /sbin/insmod -p x -k modules
 -w /sbin/rmmod -p x -k modules
 -w /sbin/modprobe -p x -k modules
 
--a exit,always -F arch=b64 -S create_module,init_module,finit_module,delete_module -k modules
--a exit,always -F arch=b32 -S create_module,init_module,finit_module,delete_module -k modules
+-a always,exit -F arch=b64 -S create_module,init_module,finit_module,delete_module -k modules
+-a always,exit -F arch=b32 -S create_module,init_module,finit_module,delete_module -k modules
 
 ## Audit things that could affect time
--a exit,always -F arch=b64 -S adjtimex,settimeofday -k audit_time_rules
--a exit,always -F arch=b64 -S clock_settime -F a0=0x0 -k audit_time_rules
--a exit,always -F arch=b32 -S adjtimex,stime,settimeofday -k audit_time_rules
--a exit,always -F arch=b32 -S clock_settime -F a0=0x0 -k audit_time_rules
+-a always,exit -F arch=b64 -S adjtimex,settimeofday -k audit_time_rules
+-a always,exit -F arch=b64 -S clock_settime -F a0=0x0 -k audit_time_rules
+-a always,exit -F arch=b32 -S adjtimex,stime,settimeofday -k audit_time_rules
+-a always,exit -F arch=b32 -S clock_settime -F a0=0x0 -k audit_time_rules
 
 -w /etc/localtime -p wa -k audit_time_rules
 
 ## Audit things that could affect system locale
--a exit,always -F arch=b64 -S sethostname,setdomainname -k audit_network_modifications
--a exit,always -F arch=b32 -S sethostname,setdomainname -k audit_network_modifications
+-a always,exit -F arch=b64 -S sethostname,setdomainname -k audit_network_modifications
+-a always,exit -F arch=b32 -S sethostname,setdomainname -k audit_network_modifications
 
 -w /etc/issue -p wa -k audit_network_modifications
 -w /etc/issue.net -p wa -k audit_network_modifications
@@ -93,12 +93,12 @@
 -w /etc/sysconfig/network -p wa -k audit_network_modifications
 
 ## Audit mount operations
--a exit,always -F arch=b64 -S mount,umount2 -k mount
--a exit,always -F arch=b32 -S mount,umount,umount2 -k mount
+-a always,exit -F arch=b64 -S mount,umount2 -k mount
+-a always,exit -F arch=b32 -S mount,umount,umount2 -k mount
 
--a exit,always -F arch=b64 -F path=/bin/mount -k mount
--a exit,always -F arch=b32 -F path=/bin/mount -k mount
--a exit,always -F path=/bin/umount -F perm=x -k mount
+-a always,exit -F arch=b64 -F path=/bin/mount -k mount
+-a always,exit -F arch=b32 -F path=/bin/mount -k mount
+-a always,exit -F path=/bin/umount -F perm=x -k mount
 
 ## Audit local accounts
 -w /etc/passwd -p wa -k audit_account_changes
@@ -199,13 +199,13 @@
 -w /etc/yum -p wa -k yum-config
 -w /etc/yum.conf -p wa -k yum-config
 -w /etc/yum.repos.d -p wa -k yum-config
--a exit,always -F arch=b64 -S ptrace -F a0=0x4 -k paranoid_code_injection
--a exit,always -F arch=b64 -S ptrace -F a0=0x5 -k paranoid_data_injection
--a exit,always -F arch=b64 -S ptrace -F a0=0x6 -k paranoid_register_injection
--a exit,always -F arch=b64 -S ptrace -k paranoid
--a exit,always -F arch=b32 -S ptrace -F a0=0x4 -k paranoid_code_injection
--a exit,always -F arch=b32 -S ptrace -F a0=0x5 -k paranoid_data_injection
--a exit,always -F arch=b32 -S ptrace -F a0=0x6 -k paranoid_register_injection
--a exit,always -F arch=b32 -S ptrace -k paranoid
--a exit,always -F arch=b64 -S personality -k paranoid
--a exit,always -F arch=b32 -S personality -k paranoid
+-a always,exit -F arch=b64 -S ptrace -F a0=0x4 -k paranoid_code_injection
+-a always,exit -F arch=b64 -S ptrace -F a0=0x5 -k paranoid_data_injection
+-a always,exit -F arch=b64 -S ptrace -F a0=0x6 -k paranoid_register_injection
+-a always,exit -F arch=b64 -S ptrace -k paranoid
+-a always,exit -F arch=b32 -S ptrace -F a0=0x4 -k paranoid_code_injection
+-a always,exit -F arch=b32 -S ptrace -F a0=0x5 -k paranoid_data_injection
+-a always,exit -F arch=b32 -S ptrace -F a0=0x6 -k paranoid_register_injection
+-a always,exit -F arch=b32 -S ptrace -k paranoid
+-a always,exit -F arch=b64 -S personality -k paranoid
+-a always,exit -F arch=b32 -S personality -k paranoid

--- a/spec/classes/config/audit_profiles/expected/simp_el6_insane_rules.txt
+++ b/spec/classes/config/audit_profiles/expected/simp_el6_insane_rules.txt
@@ -1,90 +1,90 @@
 #### auditd::config::audit_profiles::simp Audit Rules ####
 # 64-bit systems should generally never call the 32-bit API. 32-bit syscalls
 # may be a sign of someone exploiting a hole in the API.
--a exit,always -F arch=b32 -S all -F key=32bit-api
--a exit,always -F arch=b64 -S accept -F a0=2 -F key=ipv4_in
--a exit,always -F arch=b64 -S accept -F a0=10 -F key=ipv6_in
+-a always,exit -F arch=b32 -S all -F key=32bit-api
+-a always,exit -F arch=b64 -S accept -F a0=2 -F key=ipv4_in
+-a always,exit -F arch=b64 -S accept -F a0=10 -F key=ipv6_in
 
 ## Audit unsuccessful file operations
--a exit,always -F arch=b64 -S creat,mkdir,mknod,link,symlink,mkdirat,mknodat,linkat,symlinkat,openat,open_by_handle_at,open,close,rename,renameat,truncate,ftruncate,rmdir,unlink,unlinkat -F exit=-EACCES -k access
--a exit,always -F arch=b64 -S creat,mkdir,mknod,link,symlink,mkdirat,mknodat,linkat,symlinkat,openat,open_by_handle_at,open,close,rename,renameat,truncate,ftruncate,rmdir,unlink,unlinkat -F exit=-EPERM -k access
--a exit,always -F arch=b32 -S creat,mkdir,mknod,link,symlink,mkdirat,mknodat,linkat,symlinkat,openat,open_by_handle_at,open,close,rename,renameat,truncate,ftruncate,rmdir,unlink,unlinkat -F exit=-EACCES -k access
--a exit,always -F arch=b32 -S creat,mkdir,mknod,link,symlink,mkdirat,mknodat,linkat,symlinkat,openat,open_by_handle_at,open,close,rename,renameat,truncate,ftruncate,rmdir,unlink,unlinkat -F exit=-EPERM -k access
+-a always,exit -F arch=b64 -S creat,mkdir,mknod,link,symlink,mkdirat,mknodat,linkat,symlinkat,openat,open_by_handle_at,open,close,rename,renameat,truncate,ftruncate,rmdir,unlink,unlinkat -F exit=-EACCES -k access
+-a always,exit -F arch=b64 -S creat,mkdir,mknod,link,symlink,mkdirat,mknodat,linkat,symlinkat,openat,open_by_handle_at,open,close,rename,renameat,truncate,ftruncate,rmdir,unlink,unlinkat -F exit=-EPERM -k access
+-a always,exit -F arch=b32 -S creat,mkdir,mknod,link,symlink,mkdirat,mknodat,linkat,symlinkat,openat,open_by_handle_at,open,close,rename,renameat,truncate,ftruncate,rmdir,unlink,unlinkat -F exit=-EACCES -k access
+-a always,exit -F arch=b32 -S creat,mkdir,mknod,link,symlink,mkdirat,mknodat,linkat,symlinkat,openat,open_by_handle_at,open,close,rename,renameat,truncate,ftruncate,rmdir,unlink,unlinkat -F exit=-EPERM -k access
 
--a exit,always -F perm=a -F exit=-EACCES -k access
--a exit,always -F perm=a -F exit=-EPERM -k access
+-a always,exit -F perm=a -F exit=-EACCES -k access
+-a always,exit -F perm=a -F exit=-EPERM -k access
 
 ## Audit the execution of password commands
--a exit,always -F path=/usr/bin/passwd -F perm=x -k privileged-passwd
+-a always,exit -F path=/usr/bin/passwd -F perm=x -k privileged-passwd
 
--a exit,always -F path=/sbin/unix_chkpwd -F perm=x -k privileged-passwd
+-a always,exit -F path=/sbin/unix_chkpwd -F perm=x -k privileged-passwd
 
--a exit,always -F path=/usr/bin/gpasswd -F perm=x -k privileged-passwd
+-a always,exit -F path=/usr/bin/gpasswd -F perm=x -k privileged-passwd
 
--a exit,always -F path=/usr/bin/chage -F perm=x -k privileged-passwd
+-a always,exit -F path=/usr/bin/chage -F perm=x -k privileged-passwd
 
--a exit,always -F path=/usr/sbin/userhelper -F perm=x -k privileged-passwd
+-a always,exit -F path=/usr/sbin/userhelper -F perm=x -k privileged-passwd
 
 ## Audit the execution of privilege-related commands
--a exit,always -F path=/bin/su -F perm=x -k privileged-priv_change
+-a always,exit -F path=/bin/su -F perm=x -k privileged-priv_change
 
--a exit,always -F path=/usr/bin/sudo -F perm=x -k privileged-priv_change
+-a always,exit -F path=/usr/bin/sudo -F perm=x -k privileged-priv_change
 
--a exit,always -F path=/usr/bin/newgrp -F perm=x -k privileged-priv_change
+-a always,exit -F path=/usr/bin/newgrp -F perm=x -k privileged-priv_change
 
--a exit,always -F path=/usr/bin/chsh -F perm=x -k privileged-priv_change
+-a always,exit -F path=/usr/bin/chsh -F perm=x -k privileged-priv_change
 
--a exit,always -F path=/usr/bin/sudoedit -F perm=x -k privileged-priv_change
+-a always,exit -F path=/usr/bin/sudoedit -F perm=x -k privileged-priv_change
 
 ## Audit the execution of postfix-related commands
--a exit,always -F path=/usr/sbin/postdrop -F perm=x -k privileged-postfix
+-a always,exit -F path=/usr/sbin/postdrop -F perm=x -k privileged-postfix
 
--a exit,always -F path=/usr/sbin/postqueue -F perm=x -k privileged-postfix
+-a always,exit -F path=/usr/sbin/postqueue -F perm=x -k privileged-postfix
 
 ## Audit the execution of the ssh-keysign command
--a exit,always -F path=/usr/libexec/openssh/ssh-keysign -F perm=x -k privileged-ssh
+-a always,exit -F path=/usr/libexec/openssh/ssh-keysign -F perm=x -k privileged-ssh
 
 ## Audit the execution of the crontab command
--a exit,always -F path=/usr/bin/crontab -F perm=x -k privileged-cron
+-a always,exit -F path=/usr/bin/crontab -F perm=x -k privileged-cron
 
 ## Audit the execution of the pam_timestamp_check command
--a exit,always -F path=/sbin/pam_timestamp_check -F perm=x -k privileged-pam
+-a always,exit -F path=/sbin/pam_timestamp_check -F perm=x -k privileged-pam
 
 ## Permissions auditing separated by chown, chmod, and attr
 
--a exit,always -F arch=b64 -S chown,fchown,fchownat,lchown -k chown
--a exit,always -F arch=b32 -S chown,fchown,fchownat,lchown -k chown
+-a always,exit -F arch=b64 -S chown,fchown,fchownat,lchown -k chown
+-a always,exit -F arch=b32 -S chown,fchown,fchownat,lchown -k chown
 
--a exit,always -F arch=b64 -S setxattr,lsetxattr,fsetxattr,removexattr,lremovexattr,fremovexattr -k attr
--a exit,always -F arch=b32 -S setxattr,lsetxattr,fsetxattr,removexattr,lremovexattr,fremovexattr -k attr
+-a always,exit -F arch=b64 -S setxattr,lsetxattr,fsetxattr,removexattr,lremovexattr,fremovexattr -k attr
+-a always,exit -F arch=b32 -S setxattr,lsetxattr,fsetxattr,removexattr,lremovexattr,fremovexattr -k attr
 
 ## Audit useful items that someone does when su'ing to root.
--a exit,always -F arch=b64 -F auid!=0 -F uid=0 -S capset,mknod,mknodat,pivot_root,quotactl,setsid,adjtimex,settimeofday,setuid,swapoff,swapon,execve,rename,renameat,rmdir,unlink,unlinkat,write,chown,fchown,fchownat,lchown,creat,fork,vfork,link,linkat,symlink,symlinkat,mkdir,mkdirat -k su-root-activity
--a exit,always -F arch=b32 -F auid!=0 -F uid=0 -S capset,mknod,mknodat,pivot_root,quotactl,setsid,adjtimex,settimeofday,setuid,swapoff,swapon,execve,rename,renameat,rmdir,unlink,unlinkat,write,chown,fchown,fchownat,lchown,creat,fork,vfork,link,linkat,symlink,symlinkat,mkdir,mkdirat -k su-root-activity
+-a always,exit -F arch=b64 -F auid!=0 -F uid=0 -S capset,mknod,mknodat,pivot_root,quotactl,setsid,adjtimex,settimeofday,setuid,swapoff,swapon,execve,rename,renameat,rmdir,unlink,unlinkat,write,chown,fchown,fchownat,lchown,creat,fork,vfork,link,linkat,symlink,symlinkat,mkdir,mkdirat -k su-root-activity
+-a always,exit -F arch=b32 -F auid!=0 -F uid=0 -S capset,mknod,mknodat,pivot_root,quotactl,setsid,adjtimex,settimeofday,setuid,swapoff,swapon,execve,rename,renameat,rmdir,unlink,unlinkat,write,chown,fchown,fchownat,lchown,creat,fork,vfork,link,linkat,symlink,symlinkat,mkdir,mkdirat -k su-root-activity
 
 ## Audit the execution of suid and sgid binaries.
--a exit,always -F arch=b64 -F euid=0 -F uid!=0 -S execve -k suid-root-exec
--a exit,always -F arch=b32 -F euid=0 -F uid!=0 -S execve -k suid-root-exec
+-a always,exit -F arch=b64 -F euid=0 -F uid!=0 -S execve -k suid-root-exec
+-a always,exit -F arch=b32 -F euid=0 -F uid!=0 -S execve -k suid-root-exec
 
 ## Audit the loading and unloading of kernel modules.
 -w /sbin/insmod -p x -k modules
 -w /sbin/rmmod -p x -k modules
 -w /sbin/modprobe -p x -k modules
 
--a exit,always -F arch=b64 -S create_module,init_module,finit_module,delete_module -k modules
--a exit,always -F arch=b32 -S create_module,init_module,finit_module,delete_module -k modules
+-a always,exit -F arch=b64 -S create_module,init_module,finit_module,delete_module -k modules
+-a always,exit -F arch=b32 -S create_module,init_module,finit_module,delete_module -k modules
 
 ## Audit things that could affect time
--a exit,always -F arch=b64 -S adjtimex,settimeofday -k audit_time_rules
--a exit,always -F arch=b64 -S clock_settime -F a0=0x0 -k audit_time_rules
--a exit,always -F arch=b32 -S adjtimex,stime,settimeofday -k audit_time_rules
--a exit,always -F arch=b32 -S clock_settime -F a0=0x0 -k audit_time_rules
+-a always,exit -F arch=b64 -S adjtimex,settimeofday -k audit_time_rules
+-a always,exit -F arch=b64 -S clock_settime -F a0=0x0 -k audit_time_rules
+-a always,exit -F arch=b32 -S adjtimex,stime,settimeofday -k audit_time_rules
+-a always,exit -F arch=b32 -S clock_settime -F a0=0x0 -k audit_time_rules
 
 -w /etc/localtime -p wa -k audit_time_rules
 
 ## Audit things that could affect system locale
--a exit,always -F arch=b64 -S sethostname,setdomainname -k audit_network_modifications
--a exit,always -F arch=b32 -S sethostname,setdomainname -k audit_network_modifications
+-a always,exit -F arch=b64 -S sethostname,setdomainname -k audit_network_modifications
+-a always,exit -F arch=b32 -S sethostname,setdomainname -k audit_network_modifications
 
 -w /etc/issue -p wa -k audit_network_modifications
 -w /etc/issue.net -p wa -k audit_network_modifications
@@ -93,12 +93,12 @@
 -w /etc/sysconfig/network -p wa -k audit_network_modifications
 
 ## Audit mount operations
--a exit,always -F arch=b64 -S mount,umount2 -k mount
--a exit,always -F arch=b32 -S mount,umount,umount2 -k mount
+-a always,exit -F arch=b64 -S mount,umount2 -k mount
+-a always,exit -F arch=b32 -S mount,umount,umount2 -k mount
 
--a exit,always -F arch=b64 -F path=/bin/mount -k mount
--a exit,always -F arch=b32 -F path=/bin/mount -k mount
--a exit,always -F path=/bin/umount -F perm=x -k mount
+-a always,exit -F arch=b64 -F path=/bin/mount -k mount
+-a always,exit -F arch=b32 -F path=/bin/mount -k mount
+-a always,exit -F path=/bin/umount -F perm=x -k mount
 
 ## Audit local accounts
 -w /etc/passwd -p wa -k audit_account_changes
@@ -199,13 +199,13 @@
 -w /etc/yum -p wa -k yum-config
 -w /etc/yum.conf -p wa -k yum-config
 -w /etc/yum.repos.d -p wa -k yum-config
--a exit,always -F arch=b64 -S ptrace -F a0=0x4 -k paranoid_code_injection
--a exit,always -F arch=b64 -S ptrace -F a0=0x5 -k paranoid_data_injection
--a exit,always -F arch=b64 -S ptrace -F a0=0x6 -k paranoid_register_injection
--a exit,always -F arch=b64 -S ptrace -k paranoid
--a exit,always -F arch=b32 -S ptrace -F a0=0x4 -k paranoid_code_injection
--a exit,always -F arch=b32 -S ptrace -F a0=0x5 -k paranoid_data_injection
--a exit,always -F arch=b32 -S ptrace -F a0=0x6 -k paranoid_register_injection
--a exit,always -F arch=b32 -S ptrace -k paranoid
--a exit,always -F arch=b64 -S personality -k paranoid
--a exit,always -F arch=b32 -S personality -k paranoid
+-a always,exit -F arch=b64 -S ptrace -F a0=0x4 -k paranoid_code_injection
+-a always,exit -F arch=b64 -S ptrace -F a0=0x5 -k paranoid_data_injection
+-a always,exit -F arch=b64 -S ptrace -F a0=0x6 -k paranoid_register_injection
+-a always,exit -F arch=b64 -S ptrace -k paranoid
+-a always,exit -F arch=b32 -S ptrace -F a0=0x4 -k paranoid_code_injection
+-a always,exit -F arch=b32 -S ptrace -F a0=0x5 -k paranoid_data_injection
+-a always,exit -F arch=b32 -S ptrace -F a0=0x6 -k paranoid_register_injection
+-a always,exit -F arch=b32 -S ptrace -k paranoid
+-a always,exit -F arch=b64 -S personality -k paranoid
+-a always,exit -F arch=b32 -S personality -k paranoid

--- a/spec/classes/config/audit_profiles/expected/simp_el7_aggressive_rules.txt
+++ b/spec/classes/config/audit_profiles/expected/simp_el7_aggressive_rules.txt
@@ -1,84 +1,84 @@
 #### auditd::config::audit_profiles::simp Audit Rules ####
 # 64-bit systems should generally never call the 32-bit API. 32-bit syscalls
 # may be a sign of someone exploiting a hole in the API.
--a exit,always -F arch=b32 -S all -F key=32bit-api
--a exit,always -F arch=b64 -S accept -F a0=2 -F key=ipv4_in
--a exit,always -F arch=b64 -S accept -F a0=10 -F key=ipv6_in
+-a always,exit -F arch=b32 -S all -F key=32bit-api
+-a always,exit -F arch=b64 -S accept -F a0=2 -F key=ipv4_in
+-a always,exit -F arch=b64 -S accept -F a0=10 -F key=ipv6_in
 
 ## Audit unsuccessful file operations
--a exit,always -F arch=b64 -S creat,mkdir,mknod,link,symlink,mkdirat,mknodat,linkat,symlinkat,openat,open_by_handle_at,open,close,rename,renameat,truncate,ftruncate,rmdir,unlink,unlinkat -F exit=-EACCES -k access
--a exit,always -F arch=b64 -S creat,mkdir,mknod,link,symlink,mkdirat,mknodat,linkat,symlinkat,openat,open_by_handle_at,open,close,rename,renameat,truncate,ftruncate,rmdir,unlink,unlinkat -F exit=-EPERM -k access
--a exit,always -F arch=b32 -S creat,mkdir,mknod,link,symlink,mkdirat,mknodat,linkat,symlinkat,openat,open_by_handle_at,open,close,rename,renameat,truncate,ftruncate,rmdir,unlink,unlinkat -F exit=-EACCES -k access
--a exit,always -F arch=b32 -S creat,mkdir,mknod,link,symlink,mkdirat,mknodat,linkat,symlinkat,openat,open_by_handle_at,open,close,rename,renameat,truncate,ftruncate,rmdir,unlink,unlinkat -F exit=-EPERM -k access
+-a always,exit -F arch=b64 -S creat,mkdir,mknod,link,symlink,mkdirat,mknodat,linkat,symlinkat,openat,open_by_handle_at,open,close,rename,renameat,truncate,ftruncate,rmdir,unlink,unlinkat -F exit=-EACCES -k access
+-a always,exit -F arch=b64 -S creat,mkdir,mknod,link,symlink,mkdirat,mknodat,linkat,symlinkat,openat,open_by_handle_at,open,close,rename,renameat,truncate,ftruncate,rmdir,unlink,unlinkat -F exit=-EPERM -k access
+-a always,exit -F arch=b32 -S creat,mkdir,mknod,link,symlink,mkdirat,mknodat,linkat,symlinkat,openat,open_by_handle_at,open,close,rename,renameat,truncate,ftruncate,rmdir,unlink,unlinkat -F exit=-EACCES -k access
+-a always,exit -F arch=b32 -S creat,mkdir,mknod,link,symlink,mkdirat,mknodat,linkat,symlinkat,openat,open_by_handle_at,open,close,rename,renameat,truncate,ftruncate,rmdir,unlink,unlinkat -F exit=-EPERM -k access
 
--a exit,always -F perm=a -F exit=-EACCES -k access
--a exit,always -F perm=a -F exit=-EPERM -k access
+-a always,exit -F perm=a -F exit=-EACCES -k access
+-a always,exit -F perm=a -F exit=-EPERM -k access
 
 ## Audit the execution of password commands
--a exit,always -F path=/usr/bin/passwd -F perm=x -k privileged-passwd
--a exit,always -F path=/bin/passwd -F perm=x -k privileged-passwd
+-a always,exit -F path=/usr/bin/passwd -F perm=x -k privileged-passwd
+-a always,exit -F path=/bin/passwd -F perm=x -k privileged-passwd
 
--a exit,always -F path=/usr/sbin/unix_chkpwd -F perm=x -k privileged-passwd
--a exit,always -F path=/sbin/unix_chkpwd -F perm=x -k privileged-passwd
+-a always,exit -F path=/usr/sbin/unix_chkpwd -F perm=x -k privileged-passwd
+-a always,exit -F path=/sbin/unix_chkpwd -F perm=x -k privileged-passwd
 
--a exit,always -F path=/usr/bin/gpasswd -F perm=x -k privileged-passwd
--a exit,always -F path=/bin/gpasswd -F perm=x -k privileged-passwd
+-a always,exit -F path=/usr/bin/gpasswd -F perm=x -k privileged-passwd
+-a always,exit -F path=/bin/gpasswd -F perm=x -k privileged-passwd
 
--a exit,always -F path=/usr/bin/chage -F perm=x -k privileged-passwd
--a exit,always -F path=/bin/chage -F perm=x -k privileged-passwd
+-a always,exit -F path=/usr/bin/chage -F perm=x -k privileged-passwd
+-a always,exit -F path=/bin/chage -F perm=x -k privileged-passwd
 
--a exit,always -F path=/usr/sbin/userhelper -F perm=x -k privileged-passwd
--a exit,always -F path=/sbin/userhelper -F perm=x -k privileged-passwd
+-a always,exit -F path=/usr/sbin/userhelper -F perm=x -k privileged-passwd
+-a always,exit -F path=/sbin/userhelper -F perm=x -k privileged-passwd
 
 ## Audit the execution of privilege-related commands
--a exit,always -F path=/usr/bin/su -F perm=x -k privileged-priv_change
--a exit,always -F path=/bin/su -F perm=x -k privileged-priv_change
+-a always,exit -F path=/usr/bin/su -F perm=x -k privileged-priv_change
+-a always,exit -F path=/bin/su -F perm=x -k privileged-priv_change
 
--a exit,always -F path=/usr/bin/sudo -F perm=x -k privileged-priv_change
--a exit,always -F path=/bin/sudo -F perm=x -k privileged-priv_change
+-a always,exit -F path=/usr/bin/sudo -F perm=x -k privileged-priv_change
+-a always,exit -F path=/bin/sudo -F perm=x -k privileged-priv_change
 
--a exit,always -F path=/usr/bin/newgrp -F perm=x -k privileged-priv_change
--a exit,always -F path=/bin/newgrp -F perm=x -k privileged-priv_change
+-a always,exit -F path=/usr/bin/newgrp -F perm=x -k privileged-priv_change
+-a always,exit -F path=/bin/newgrp -F perm=x -k privileged-priv_change
 
--a exit,always -F path=/usr/bin/chsh -F perm=x -k privileged-priv_change
--a exit,always -F path=/bin/chsh -F perm=x -k privileged-priv_change
+-a always,exit -F path=/usr/bin/chsh -F perm=x -k privileged-priv_change
+-a always,exit -F path=/bin/chsh -F perm=x -k privileged-priv_change
 
--a exit,always -F path=/usr/bin/sudoedit -F perm=x -k privileged-priv_change
--a exit,always -F path=/bin/sudoedit -F perm=x -k privileged-priv_change
+-a always,exit -F path=/usr/bin/sudoedit -F perm=x -k privileged-priv_change
+-a always,exit -F path=/bin/sudoedit -F perm=x -k privileged-priv_change
 
 ## Audit the execution of postfix-related commands
--a exit,always -F path=/usr/sbin/postdrop -F perm=x -k privileged-postfix
--a exit,always -F path=/sbin/postdrop -F perm=x -k privileged-postfix
+-a always,exit -F path=/usr/sbin/postdrop -F perm=x -k privileged-postfix
+-a always,exit -F path=/sbin/postdrop -F perm=x -k privileged-postfix
 
--a exit,always -F path=/usr/sbin/postqueue -F perm=x -k privileged-postfix
--a exit,always -F path=/sbin/postqueue -F perm=x -k privileged-postfix
+-a always,exit -F path=/usr/sbin/postqueue -F perm=x -k privileged-postfix
+-a always,exit -F path=/sbin/postqueue -F perm=x -k privileged-postfix
 
 ## Audit the execution of the ssh-keysign command
--a exit,always -F path=/usr/libexec/openssh/ssh-keysign -F perm=x -k privileged-ssh
+-a always,exit -F path=/usr/libexec/openssh/ssh-keysign -F perm=x -k privileged-ssh
 
 ## Audit the execution of the crontab command
--a exit,always -F path=/usr/bin/crontab -F perm=x -k privileged-cron
--a exit,always -F path=/bin/crontab -F perm=x -k privileged-cron
+-a always,exit -F path=/usr/bin/crontab -F perm=x -k privileged-cron
+-a always,exit -F path=/bin/crontab -F perm=x -k privileged-cron
 
 ## Audit the execution of the pam_timestamp_check command
--a exit,always -F path=/usr/sbin/pam_timestamp_check -F perm=x -k privileged-pam
--a exit,always -F path=/sbin/pam_timestamp_check -F perm=x -k privileged-pam
+-a always,exit -F path=/usr/sbin/pam_timestamp_check -F perm=x -k privileged-pam
+-a always,exit -F path=/sbin/pam_timestamp_check -F perm=x -k privileged-pam
 
 ## Permissions auditing separated by chown, chmod, and attr
 
--a exit,always -F arch=b64 -S chown,fchown,fchownat,lchown -k chown
--a exit,always -F arch=b32 -S chown,fchown,fchownat,lchown -k chown
+-a always,exit -F arch=b64 -S chown,fchown,fchownat,lchown -k chown
+-a always,exit -F arch=b32 -S chown,fchown,fchownat,lchown -k chown
 
--a exit,always -F arch=b64 -S setxattr,lsetxattr,fsetxattr,removexattr,lremovexattr,fremovexattr -k attr
--a exit,always -F arch=b32 -S setxattr,lsetxattr,fsetxattr,removexattr,lremovexattr,fremovexattr -k attr
+-a always,exit -F arch=b64 -S setxattr,lsetxattr,fsetxattr,removexattr,lremovexattr,fremovexattr -k attr
+-a always,exit -F arch=b32 -S setxattr,lsetxattr,fsetxattr,removexattr,lremovexattr,fremovexattr -k attr
 
 ## Audit useful items that someone does when su'ing to root.
--a exit,always -F arch=b64 -F auid!=0 -F uid=0 -S capset,mknod,mknodat,pivot_root,quotactl,setsid,adjtimex,settimeofday,setuid,swapoff,swapon,execve,rename,renameat,rmdir,unlink,unlinkat -k su-root-activity
--a exit,always -F arch=b32 -F auid!=0 -F uid=0 -S capset,mknod,mknodat,pivot_root,quotactl,setsid,adjtimex,settimeofday,setuid,swapoff,swapon,execve,rename,renameat,rmdir,unlink,unlinkat -k su-root-activity
+-a always,exit -F arch=b64 -F auid!=0 -F uid=0 -S capset,mknod,mknodat,pivot_root,quotactl,setsid,adjtimex,settimeofday,setuid,swapoff,swapon,execve,rename,renameat,rmdir,unlink,unlinkat -k su-root-activity
+-a always,exit -F arch=b32 -F auid!=0 -F uid=0 -S capset,mknod,mknodat,pivot_root,quotactl,setsid,adjtimex,settimeofday,setuid,swapoff,swapon,execve,rename,renameat,rmdir,unlink,unlinkat -k su-root-activity
 
 ## Audit the execution of suid and sgid binaries.
--a exit,always -F arch=b64 -F euid=0 -F uid!=0 -S execve -k suid-root-exec
--a exit,always -F arch=b32 -F euid=0 -F uid!=0 -S execve -k suid-root-exec
+-a always,exit -F arch=b64 -F euid=0 -F uid!=0 -S execve -k suid-root-exec
+-a always,exit -F arch=b32 -F euid=0 -F uid!=0 -S execve -k suid-root-exec
 
 ## Audit the loading and unloading of kernel modules.
 -w /usr/bin/kmod -p x -k modules
@@ -90,38 +90,38 @@
 -w /usr/sbin/modprobe -p x -k modules
 -w /sbin/modprobe -p x -k modules
 
--a exit,always -F arch=b64 -S create_module,init_module,finit_module,delete_module -k modules
--a exit,always -F arch=b32 -S create_module,init_module,finit_module,delete_module -k modules
+-a always,exit -F arch=b64 -S create_module,init_module,finit_module,delete_module -k modules
+-a always,exit -F arch=b32 -S create_module,init_module,finit_module,delete_module -k modules
 
 ## Audit things that could affect time
--a exit,always -F arch=b64 -S adjtimex,settimeofday -k audit_time_rules
--a exit,always -F arch=b64 -S clock_settime -F a0=0x0 -k audit_time_rules
--a exit,always -F arch=b32 -S adjtimex,stime,settimeofday -k audit_time_rules
--a exit,always -F arch=b32 -S clock_settime -F a0=0x0 -k audit_time_rules
+-a always,exit -F arch=b64 -S adjtimex,settimeofday -k audit_time_rules
+-a always,exit -F arch=b64 -S clock_settime -F a0=0x0 -k audit_time_rules
+-a always,exit -F arch=b32 -S adjtimex,stime,settimeofday -k audit_time_rules
+-a always,exit -F arch=b32 -S clock_settime -F a0=0x0 -k audit_time_rules
 
 -w /etc/localtime -p wa -k audit_time_rules
 
 ## Audit things that could affect system locale
--a exit,always -F arch=b64 -S sethostname,setdomainname -k audit_network_modifications
--a exit,always -F arch=b32 -S sethostname,setdomainname -k audit_network_modifications
+-a always,exit -F arch=b64 -S sethostname,setdomainname -k audit_network_modifications
+-a always,exit -F arch=b32 -S sethostname,setdomainname -k audit_network_modifications
 
 -w /etc/issue -p wa -k audit_network_modifications
 -w /etc/issue.net -p wa -k audit_network_modifications
 -w /etc/hosts -p wa -k audit_network_modifications
 -w /etc/hostname -p wa -k audit_network_modifications
 -w /etc/sysconfig/network -p wa -k audit_network_modifications
--a exit,always -F dir=/etc/NetworkManager/ -F perm=wa -k audit_network_modifications
+-a always,exit -F dir=/etc/NetworkManager/ -F perm=wa -k audit_network_modifications
 
 ## Audit mount operations
--a exit,always -F arch=b64 -S mount,umount2 -k mount
--a exit,always -F arch=b32 -S mount,umount,umount2 -k mount
+-a always,exit -F arch=b64 -S mount,umount2 -k mount
+-a always,exit -F arch=b32 -S mount,umount,umount2 -k mount
 
--a exit,always -F arch=b64 -F path=/usr/bin/mount -k mount
--a exit,always -F arch=b64 -F path=/bin/mount -k mount
--a exit,always -F arch=b32 -F path=/usr/bin/mount -k mount
--a exit,always -F arch=b32 -F path=/bin/mount -k mount
--a exit,always -F path=/usr/bin/umount -F perm=x -k mount
--a exit,always -F path=/bin/umount -F perm=x -k mount
+-a always,exit -F arch=b64 -F path=/usr/bin/mount -k mount
+-a always,exit -F arch=b64 -F path=/bin/mount -k mount
+-a always,exit -F arch=b32 -F path=/usr/bin/mount -k mount
+-a always,exit -F arch=b32 -F path=/bin/mount -k mount
+-a always,exit -F path=/usr/bin/umount -F perm=x -k mount
+-a always,exit -F path=/bin/umount -F perm=x -k mount
 
 ## Audit local accounts
 -w /etc/passwd -p wa -k audit_account_changes
@@ -227,13 +227,13 @@
 -w /etc/yum -p wa -k yum-config
 -w /etc/yum.conf -p wa -k yum-config
 -w /etc/yum.repos.d -p wa -k yum-config
--a exit,always -F arch=b64 -S ptrace -F a0=0x4 -k paranoid_code_injection
--a exit,always -F arch=b64 -S ptrace -F a0=0x5 -k paranoid_data_injection
--a exit,always -F arch=b64 -S ptrace -F a0=0x6 -k paranoid_register_injection
--a exit,always -F arch=b64 -S ptrace -k paranoid
--a exit,always -F arch=b32 -S ptrace -F a0=0x4 -k paranoid_code_injection
--a exit,always -F arch=b32 -S ptrace -F a0=0x5 -k paranoid_data_injection
--a exit,always -F arch=b32 -S ptrace -F a0=0x6 -k paranoid_register_injection
--a exit,always -F arch=b32 -S ptrace -k paranoid
--a exit,always -F arch=b64 -S personality -k paranoid
--a exit,always -F arch=b32 -S personality -k paranoid
+-a always,exit -F arch=b64 -S ptrace -F a0=0x4 -k paranoid_code_injection
+-a always,exit -F arch=b64 -S ptrace -F a0=0x5 -k paranoid_data_injection
+-a always,exit -F arch=b64 -S ptrace -F a0=0x6 -k paranoid_register_injection
+-a always,exit -F arch=b64 -S ptrace -k paranoid
+-a always,exit -F arch=b32 -S ptrace -F a0=0x4 -k paranoid_code_injection
+-a always,exit -F arch=b32 -S ptrace -F a0=0x5 -k paranoid_data_injection
+-a always,exit -F arch=b32 -S ptrace -F a0=0x6 -k paranoid_register_injection
+-a always,exit -F arch=b32 -S ptrace -k paranoid
+-a always,exit -F arch=b64 -S personality -k paranoid
+-a always,exit -F arch=b32 -S personality -k paranoid

--- a/spec/classes/config/audit_profiles/expected/simp_el7_all_rules_custom_tags.txt
+++ b/spec/classes/config/audit_profiles/expected/simp_el7_all_rules_custom_tags.txt
@@ -1,104 +1,104 @@
 #### auditd::config::audit_profiles::simp Audit Rules ####
 # 64-bit systems should generally never call the 32-bit API. 32-bit syscalls
 # may be a sign of someone exploiting a hole in the API.
--a exit,always -F arch=b32 -S all -F key=32bit-api
--a exit,always -F arch=b64 -S accept -F a0=2 -F key=ipv4_in
--a exit,always -F arch=b64 -S accept -F a0=10 -F key=ipv6_in
+-a always,exit -F arch=b32 -S all -F key=32bit-api
+-a always,exit -F arch=b64 -S accept -F a0=2 -F key=ipv4_in
+-a always,exit -F arch=b64 -S accept -F a0=10 -F key=ipv6_in
 
 ## Audit unsuccessful file operations
--a exit,always -F arch=b64 -S creat,mkdir,mknod,link,symlink,mkdirat,mknodat,linkat,symlinkat,openat,open_by_handle_at,open,close,rename,renameat,truncate,ftruncate,rmdir,unlink,unlinkat -F exit=-EACCES -k my_unsuccessful_file_operations
--a exit,always -F arch=b64 -S creat,mkdir,mknod,link,symlink,mkdirat,mknodat,linkat,symlinkat,openat,open_by_handle_at,open,close,rename,renameat,truncate,ftruncate,rmdir,unlink,unlinkat -F exit=-EPERM -k my_unsuccessful_file_operations
--a exit,always -F arch=b32 -S creat,mkdir,mknod,link,symlink,mkdirat,mknodat,linkat,symlinkat,openat,open_by_handle_at,open,close,rename,renameat,truncate,ftruncate,rmdir,unlink,unlinkat -F exit=-EACCES -k my_unsuccessful_file_operations
--a exit,always -F arch=b32 -S creat,mkdir,mknod,link,symlink,mkdirat,mknodat,linkat,symlinkat,openat,open_by_handle_at,open,close,rename,renameat,truncate,ftruncate,rmdir,unlink,unlinkat -F exit=-EPERM -k my_unsuccessful_file_operations
+-a always,exit -F arch=b64 -S creat,mkdir,mknod,link,symlink,mkdirat,mknodat,linkat,symlinkat,openat,open_by_handle_at,open,close,rename,renameat,truncate,ftruncate,rmdir,unlink,unlinkat -F exit=-EACCES -k my_unsuccessful_file_operations
+-a always,exit -F arch=b64 -S creat,mkdir,mknod,link,symlink,mkdirat,mknodat,linkat,symlinkat,openat,open_by_handle_at,open,close,rename,renameat,truncate,ftruncate,rmdir,unlink,unlinkat -F exit=-EPERM -k my_unsuccessful_file_operations
+-a always,exit -F arch=b32 -S creat,mkdir,mknod,link,symlink,mkdirat,mknodat,linkat,symlinkat,openat,open_by_handle_at,open,close,rename,renameat,truncate,ftruncate,rmdir,unlink,unlinkat -F exit=-EACCES -k my_unsuccessful_file_operations
+-a always,exit -F arch=b32 -S creat,mkdir,mknod,link,symlink,mkdirat,mknodat,linkat,symlinkat,openat,open_by_handle_at,open,close,rename,renameat,truncate,ftruncate,rmdir,unlink,unlinkat -F exit=-EPERM -k my_unsuccessful_file_operations
 
--a exit,always -F perm=a -F exit=-EACCES -k my_unsuccessful_file_operations
--a exit,always -F perm=a -F exit=-EPERM -k my_unsuccessful_file_operations
+-a always,exit -F perm=a -F exit=-EACCES -k my_unsuccessful_file_operations
+-a always,exit -F perm=a -F exit=-EPERM -k my_unsuccessful_file_operations
 
 ## Audit the execution of password commands
--a exit,always -F path=/usr/bin/passwd -F perm=x -k my_passwd_cmds
--a exit,always -F path=/bin/passwd -F perm=x -k my_passwd_cmds
+-a always,exit -F path=/usr/bin/passwd -F perm=x -k my_passwd_cmds
+-a always,exit -F path=/bin/passwd -F perm=x -k my_passwd_cmds
 
--a exit,always -F path=/usr/sbin/unix_chkpwd -F perm=x -k my_passwd_cmds
--a exit,always -F path=/sbin/unix_chkpwd -F perm=x -k my_passwd_cmds
+-a always,exit -F path=/usr/sbin/unix_chkpwd -F perm=x -k my_passwd_cmds
+-a always,exit -F path=/sbin/unix_chkpwd -F perm=x -k my_passwd_cmds
 
--a exit,always -F path=/usr/bin/gpasswd -F perm=x -k my_passwd_cmds
--a exit,always -F path=/bin/gpasswd -F perm=x -k my_passwd_cmds
+-a always,exit -F path=/usr/bin/gpasswd -F perm=x -k my_passwd_cmds
+-a always,exit -F path=/bin/gpasswd -F perm=x -k my_passwd_cmds
 
--a exit,always -F path=/usr/bin/chage -F perm=x -k my_passwd_cmds
--a exit,always -F path=/bin/chage -F perm=x -k my_passwd_cmds
+-a always,exit -F path=/usr/bin/chage -F perm=x -k my_passwd_cmds
+-a always,exit -F path=/bin/chage -F perm=x -k my_passwd_cmds
 
--a exit,always -F path=/usr/sbin/userhelper -F perm=x -k my_passwd_cmds
--a exit,always -F path=/sbin/userhelper -F perm=x -k my_passwd_cmds
+-a always,exit -F path=/usr/sbin/userhelper -F perm=x -k my_passwd_cmds
+-a always,exit -F path=/sbin/userhelper -F perm=x -k my_passwd_cmds
 
 ## Audit the execution of privilege-related commands
--a exit,always -F path=/usr/bin/su -F perm=x -k my_priv_cmds
--a exit,always -F path=/bin/su -F perm=x -k my_priv_cmds
+-a always,exit -F path=/usr/bin/su -F perm=x -k my_priv_cmds
+-a always,exit -F path=/bin/su -F perm=x -k my_priv_cmds
 
--a exit,always -F path=/usr/bin/sudo -F perm=x -k my_priv_cmds
--a exit,always -F path=/bin/sudo -F perm=x -k my_priv_cmds
+-a always,exit -F path=/usr/bin/sudo -F perm=x -k my_priv_cmds
+-a always,exit -F path=/bin/sudo -F perm=x -k my_priv_cmds
 
--a exit,always -F path=/usr/bin/newgrp -F perm=x -k my_priv_cmds
--a exit,always -F path=/bin/newgrp -F perm=x -k my_priv_cmds
+-a always,exit -F path=/usr/bin/newgrp -F perm=x -k my_priv_cmds
+-a always,exit -F path=/bin/newgrp -F perm=x -k my_priv_cmds
 
--a exit,always -F path=/usr/bin/chsh -F perm=x -k my_priv_cmds
+-a always,exit -F path=/usr/bin/chsh -F perm=x -k my_priv_cmds
 
--a exit,always -F path=/usr/bin/sudoedit -F perm=x -k my_priv_cmds
--a exit,always -F path=/bin/sudoedit -F perm=x -k my_priv_cmds
+-a always,exit -F path=/usr/bin/sudoedit -F perm=x -k my_priv_cmds
+-a always,exit -F path=/bin/sudoedit -F perm=x -k my_priv_cmds
 
 ## Audit the execution of postfix-related commands
--a exit,always -F path=/usr/sbin/postdrop -F perm=x -k my_postfix_cmds
--a exit,always -F path=/sbin/postdrop -F perm=x -k my_postfix_cmds
+-a always,exit -F path=/usr/sbin/postdrop -F perm=x -k my_postfix_cmds
+-a always,exit -F path=/sbin/postdrop -F perm=x -k my_postfix_cmds
 
--a exit,always -F path=/usr/sbin/postqueue -F perm=x -k my_postfix_cmds
--a exit,always -F path=/sbin/postqueue -F perm=x -k my_postfix_cmds
+-a always,exit -F path=/usr/sbin/postqueue -F perm=x -k my_postfix_cmds
+-a always,exit -F path=/sbin/postqueue -F perm=x -k my_postfix_cmds
 
 ## Audit the execution of the ssh-keysign command
--a exit,always -F path=/usr/libexec/openssh/ssh-keysign -F perm=x -k my_ssh_keysign_cmd
+-a always,exit -F path=/usr/libexec/openssh/ssh-keysign -F perm=x -k my_ssh_keysign_cmd
 
 ## Audit the execution of the crontab command
--a exit,always -F path=/usr/bin/crontab -F perm=x -k my_crontab_cmd
--a exit,always -F path=/bin/crontab -F perm=x -k my_crontab_cmd
+-a always,exit -F path=/usr/bin/crontab -F perm=x -k my_crontab_cmd
+-a always,exit -F path=/bin/crontab -F perm=x -k my_crontab_cmd
 
 ## Audit the execution of the pam_timestamp_check command
--a exit,always -F path=/usr/sbin/pam_timestamp_check -F perm=x -k my_pam_timestamp_check_cmd
--a exit,always -F path=/sbin/pam_timestamp_check -F perm=x -k my_pam_timestamp_check_cmd
+-a always,exit -F path=/usr/sbin/pam_timestamp_check -F perm=x -k my_pam_timestamp_check_cmd
+-a always,exit -F path=/sbin/pam_timestamp_check -F perm=x -k my_pam_timestamp_check_cmd
 
 ## Audit selinux commands
 #
--a exit,always -F path=/usr/sbin/semanage -F perm=x -k my_selinux_cmds
--a exit,always -F path=/sbin/semanage -F perm=x -k my_selinux_cmds
+-a always,exit -F path=/usr/sbin/semanage -F perm=x -k my_selinux_cmds
+-a always,exit -F path=/sbin/semanage -F perm=x -k my_selinux_cmds
 
--a exit,always -F path=/usr/sbin/setsebool -F perm=x -k my_selinux_cmds
--a exit,always -F path=/sbin/setsebool -F perm=x -k my_selinux_cmds
+-a always,exit -F path=/usr/sbin/setsebool -F perm=x -k my_selinux_cmds
+-a always,exit -F path=/sbin/setsebool -F perm=x -k my_selinux_cmds
 
--a exit,always -F path=/usr/bin/chcon -F perm=x -k my_selinux_cmds
--a exit,always -F path=/bin/chcon -F perm=x -k my_selinux_cmds
+-a always,exit -F path=/usr/bin/chcon -F perm=x -k my_selinux_cmds
+-a always,exit -F path=/bin/chcon -F perm=x -k my_selinux_cmds
 
--a exit,always -F path=/usr/sbin/setfiles -F perm=x -k my_selinux_cmds
--a exit,always -F path=/sbin/setfiles -F perm=x -k my_selinux_cmds
+-a always,exit -F path=/usr/sbin/setfiles -F perm=x -k my_selinux_cmds
+-a always,exit -F path=/sbin/setfiles -F perm=x -k my_selinux_cmds
 
 ## Permissions auditing separated by chown, chmod, and attr
 
--a exit,always -F arch=b64 -S chown,fchown,fchownat,lchown -k my_chown
--a exit,always -F arch=b32 -S chown,fchown,fchownat,lchown -k my_chown
+-a always,exit -F arch=b64 -S chown,fchown,fchownat,lchown -k my_chown
+-a always,exit -F arch=b32 -S chown,fchown,fchownat,lchown -k my_chown
 
--a exit,always -F arch=b64 -S chmod,fchmod,fchmodat -k my_chmod
--a exit,always -F arch=b32 -S chmod,fchmod,fchmodat -k my_chmod
+-a always,exit -F arch=b64 -S chmod,fchmod,fchmodat -k my_chmod
+-a always,exit -F arch=b32 -S chmod,fchmod,fchmodat -k my_chmod
 
--a exit,always -F arch=b64 -S setxattr,lsetxattr,fsetxattr,removexattr,lremovexattr,fremovexattr -k my_attr
--a exit,always -F arch=b32 -S setxattr,lsetxattr,fsetxattr,removexattr,lremovexattr,fremovexattr -k my_attr
+-a always,exit -F arch=b64 -S setxattr,lsetxattr,fsetxattr,removexattr,lremovexattr,fremovexattr -k my_attr
+-a always,exit -F arch=b32 -S setxattr,lsetxattr,fsetxattr,removexattr,lremovexattr,fremovexattr -k my_attr
 
 ## Audit rename/removal operations
--a exit,always -F arch=b64 -S rename,renameat,rmdir,unlink,unlinkat -F perm=x -k my_rename_remove
--a exit,always -F arch=b32 -S rename,renameat,rmdir,unlink,unlinkat -F perm=x -k my_rename_remove
+-a always,exit -F arch=b64 -S rename,renameat,rmdir,unlink,unlinkat -F perm=x -k my_rename_remove
+-a always,exit -F arch=b32 -S rename,renameat,rmdir,unlink,unlinkat -F perm=x -k my_rename_remove
 
 ## Audit useful items that someone does when su'ing to root.
--a exit,always -F arch=b64 -F auid!=0 -F uid=0 -S capset,mknod,mknodat,pivot_root,quotactl,setsid,adjtimex,settimeofday,setuid,swapoff,swapon,execve,rename,renameat,rmdir,unlink,unlinkat,write,chown,fchown,fchownat,lchown,creat,fork,vfork,link,linkat,symlink,symlinkat,mkdir,mkdirat -k my_su_root_activity
--a exit,always -F arch=b32 -F auid!=0 -F uid=0 -S capset,mknod,mknodat,pivot_root,quotactl,setsid,adjtimex,settimeofday,setuid,swapoff,swapon,execve,rename,renameat,rmdir,unlink,unlinkat,write,chown,fchown,fchownat,lchown,creat,fork,vfork,link,linkat,symlink,symlinkat,mkdir,mkdirat -k my_su_root_activity
+-a always,exit -F arch=b64 -F auid!=0 -F uid=0 -S capset,mknod,mknodat,pivot_root,quotactl,setsid,adjtimex,settimeofday,setuid,swapoff,swapon,execve,rename,renameat,rmdir,unlink,unlinkat,write,chown,fchown,fchownat,lchown,creat,fork,vfork,link,linkat,symlink,symlinkat,mkdir,mkdirat -k my_su_root_activity
+-a always,exit -F arch=b32 -F auid!=0 -F uid=0 -S capset,mknod,mknodat,pivot_root,quotactl,setsid,adjtimex,settimeofday,setuid,swapoff,swapon,execve,rename,renameat,rmdir,unlink,unlinkat,write,chown,fchown,fchownat,lchown,creat,fork,vfork,link,linkat,symlink,symlinkat,mkdir,mkdirat -k my_su_root_activity
 
 ## Audit the execution of suid and sgid binaries.
--a exit,always -F arch=b64 -F euid=0 -F uid!=0 -S execve -k my_suid_sgid
--a exit,always -F arch=b32 -F euid=0 -F uid!=0 -S execve -k my_suid_sgid
+-a always,exit -F arch=b64 -F euid=0 -F uid!=0 -S execve -k my_suid_sgid
+-a always,exit -F arch=b32 -F euid=0 -F uid!=0 -S execve -k my_suid_sgid
 
 ## Audit the loading and unloading of kernel modules.
 -w /usr/bin/kmod -p x -k my_kernel_modules
@@ -110,42 +110,42 @@
 -w /usr/sbin/modprobe -p x -k my_kernel_modules
 -w /sbin/modprobe -p x -k my_kernel_modules
 
--a exit,always -F arch=b64 -S create_module,init_module,finit_module,delete_module -k my_kernel_modules
--a exit,always -F arch=b32 -S create_module,init_module,finit_module,delete_module -k my_kernel_modules
+-a always,exit -F arch=b64 -S create_module,init_module,finit_module,delete_module -k my_kernel_modules
+-a always,exit -F arch=b32 -S create_module,init_module,finit_module,delete_module -k my_kernel_modules
 
 ## Audit things that could affect time
--a exit,always -F arch=b64 -S adjtimex,settimeofday -k my_time
--a exit,always -F arch=b64 -S clock_settime -F a0=0x0 -k my_time
--a exit,always -F arch=b32 -S adjtimex,stime,settimeofday -k my_time
--a exit,always -F arch=b32 -S clock_settime -F a0=0x0 -k my_time
+-a always,exit -F arch=b64 -S adjtimex,settimeofday -k my_time
+-a always,exit -F arch=b64 -S clock_settime -F a0=0x0 -k my_time
+-a always,exit -F arch=b32 -S adjtimex,stime,settimeofday -k my_time
+-a always,exit -F arch=b32 -S clock_settime -F a0=0x0 -k my_time
 
 -w /etc/localtime -p wa -k my_time
 
 ## Audit things that could affect system locale
--a exit,always -F arch=b64 -S sethostname,setdomainname -k my_locale
--a exit,always -F arch=b32 -S sethostname,setdomainname -k my_locale
+-a always,exit -F arch=b64 -S sethostname,setdomainname -k my_locale
+-a always,exit -F arch=b32 -S sethostname,setdomainname -k my_locale
 
 -w /etc/issue -p wa -k my_locale
 -w /etc/issue.net -p wa -k my_locale
 -w /etc/hosts -p wa -k my_locale
 -w /etc/hostname -p wa -k my_locale
 -w /etc/sysconfig/network -p wa -k my_locale
--a exit,always -F dir=/etc/NetworkManager/ -F perm=wa -k my_locale
+-a always,exit -F dir=/etc/NetworkManager/ -F perm=wa -k my_locale
 
 ## Audit mount operations
--a exit,always -F arch=b64 -S mount,umount2 -k my_mount
--a exit,always -F arch=b32 -S mount,umount,umount2 -k my_mount
+-a always,exit -F arch=b64 -S mount,umount2 -k my_mount
+-a always,exit -F arch=b32 -S mount,umount,umount2 -k my_mount
 
--a exit,always -F arch=b64 -F path=/usr/bin/mount -k my_mount
--a exit,always -F arch=b64 -F path=/bin/mount -k my_mount
--a exit,always -F arch=b32 -F path=/usr/bin/mount -k my_mount
--a exit,always -F arch=b32 -F path=/bin/mount -k my_mount
--a exit,always -F path=/usr/bin/umount -F perm=x -k my_mount
--a exit,always -F path=/bin/umount -F perm=x -k my_mount
+-a always,exit -F arch=b64 -F path=/usr/bin/mount -k my_mount
+-a always,exit -F arch=b64 -F path=/bin/mount -k my_mount
+-a always,exit -F arch=b32 -F path=/usr/bin/mount -k my_mount
+-a always,exit -F arch=b32 -F path=/bin/mount -k my_mount
+-a always,exit -F path=/usr/bin/umount -F perm=x -k my_mount
+-a always,exit -F path=/bin/umount -F perm=x -k my_mount
 
 ## Audit umask changes.
--a exit,always -F arch=b64 -S umask -k my_umask
--a exit,always -F arch=b32 -S umask -k my_umask
+-a always,exit -F arch=b64 -S umask -k my_umask
+-a always,exit -F arch=b32 -S umask -k my_umask
 
 ## Audit local accounts
 -w /etc/passwd -p wa -k my_local_account
@@ -255,15 +255,15 @@
 -w /bin/yum -p x -k my_yum_cmd
 -w /usr/bin/rpm -p x -k my_rpm_cmd
 -w /bin/rpm -p x -k my_rpm_cmd
--a exit,always -F arch=b64 -S ptrace -F a0=0x4 -k paranoid_code_injection
--a exit,always -F arch=b64 -S ptrace -F a0=0x5 -k paranoid_data_injection
--a exit,always -F arch=b64 -S ptrace -F a0=0x6 -k paranoid_register_injection
--a exit,always -F arch=b64 -S ptrace -k paranoid
--a exit,always -F arch=b32 -S ptrace -F a0=0x4 -k paranoid_code_injection
--a exit,always -F arch=b32 -S ptrace -F a0=0x5 -k paranoid_data_injection
--a exit,always -F arch=b32 -S ptrace -F a0=0x6 -k paranoid_register_injection
--a exit,always -F arch=b32 -S ptrace -k paranoid
--a exit,always -F arch=b64 -S personality -k paranoid
--a exit,always -F arch=b32 -S personality -k paranoid
--a exit,always -F arch=b64 -S personality -k my_personality
--a exit,always -F arch=b32 -S personality -k my_personality
+-a always,exit -F arch=b64 -S ptrace -F a0=0x4 -k paranoid_code_injection
+-a always,exit -F arch=b64 -S ptrace -F a0=0x5 -k paranoid_data_injection
+-a always,exit -F arch=b64 -S ptrace -F a0=0x6 -k paranoid_register_injection
+-a always,exit -F arch=b64 -S ptrace -k paranoid
+-a always,exit -F arch=b32 -S ptrace -F a0=0x4 -k paranoid_code_injection
+-a always,exit -F arch=b32 -S ptrace -F a0=0x5 -k paranoid_data_injection
+-a always,exit -F arch=b32 -S ptrace -F a0=0x6 -k paranoid_register_injection
+-a always,exit -F arch=b32 -S ptrace -k paranoid
+-a always,exit -F arch=b64 -S personality -k paranoid
+-a always,exit -F arch=b32 -S personality -k paranoid
+-a always,exit -F arch=b64 -S personality -k my_personality
+-a always,exit -F arch=b32 -S personality -k my_personality

--- a/spec/classes/config/audit_profiles/expected/simp_el7_basic_rules.txt
+++ b/spec/classes/config/audit_profiles/expected/simp_el7_basic_rules.txt
@@ -1,84 +1,84 @@
 #### auditd::config::audit_profiles::simp Audit Rules ####
 # 64-bit systems should generally never call the 32-bit API. 32-bit syscalls
 # may be a sign of someone exploiting a hole in the API.
--a exit,always -F arch=b32 -S all -F key=32bit-api
--a exit,always -F arch=b64 -S accept -F a0=2 -F key=ipv4_in
--a exit,always -F arch=b64 -S accept -F a0=10 -F key=ipv6_in
+-a always,exit -F arch=b32 -S all -F key=32bit-api
+-a always,exit -F arch=b64 -S accept -F a0=2 -F key=ipv4_in
+-a always,exit -F arch=b64 -S accept -F a0=10 -F key=ipv6_in
 
 ## Audit unsuccessful file operations
--a exit,always -F arch=b64 -S creat,mkdir,mknod,link,symlink,mkdirat,mknodat,linkat,symlinkat,openat,open_by_handle_at,open,close,rename,renameat,truncate,ftruncate,rmdir,unlink,unlinkat -F exit=-EACCES -k access
--a exit,always -F arch=b64 -S creat,mkdir,mknod,link,symlink,mkdirat,mknodat,linkat,symlinkat,openat,open_by_handle_at,open,close,rename,renameat,truncate,ftruncate,rmdir,unlink,unlinkat -F exit=-EPERM -k access
--a exit,always -F arch=b32 -S creat,mkdir,mknod,link,symlink,mkdirat,mknodat,linkat,symlinkat,openat,open_by_handle_at,open,close,rename,renameat,truncate,ftruncate,rmdir,unlink,unlinkat -F exit=-EACCES -k access
--a exit,always -F arch=b32 -S creat,mkdir,mknod,link,symlink,mkdirat,mknodat,linkat,symlinkat,openat,open_by_handle_at,open,close,rename,renameat,truncate,ftruncate,rmdir,unlink,unlinkat -F exit=-EPERM -k access
+-a always,exit -F arch=b64 -S creat,mkdir,mknod,link,symlink,mkdirat,mknodat,linkat,symlinkat,openat,open_by_handle_at,open,close,rename,renameat,truncate,ftruncate,rmdir,unlink,unlinkat -F exit=-EACCES -k access
+-a always,exit -F arch=b64 -S creat,mkdir,mknod,link,symlink,mkdirat,mknodat,linkat,symlinkat,openat,open_by_handle_at,open,close,rename,renameat,truncate,ftruncate,rmdir,unlink,unlinkat -F exit=-EPERM -k access
+-a always,exit -F arch=b32 -S creat,mkdir,mknod,link,symlink,mkdirat,mknodat,linkat,symlinkat,openat,open_by_handle_at,open,close,rename,renameat,truncate,ftruncate,rmdir,unlink,unlinkat -F exit=-EACCES -k access
+-a always,exit -F arch=b32 -S creat,mkdir,mknod,link,symlink,mkdirat,mknodat,linkat,symlinkat,openat,open_by_handle_at,open,close,rename,renameat,truncate,ftruncate,rmdir,unlink,unlinkat -F exit=-EPERM -k access
 
--a exit,always -F perm=a -F exit=-EACCES -k access
--a exit,always -F perm=a -F exit=-EPERM -k access
+-a always,exit -F perm=a -F exit=-EACCES -k access
+-a always,exit -F perm=a -F exit=-EPERM -k access
 
 ## Audit the execution of password commands
--a exit,always -F path=/usr/bin/passwd -F perm=x -k privileged-passwd
--a exit,always -F path=/bin/passwd -F perm=x -k privileged-passwd
+-a always,exit -F path=/usr/bin/passwd -F perm=x -k privileged-passwd
+-a always,exit -F path=/bin/passwd -F perm=x -k privileged-passwd
 
--a exit,always -F path=/usr/sbin/unix_chkpwd -F perm=x -k privileged-passwd
--a exit,always -F path=/sbin/unix_chkpwd -F perm=x -k privileged-passwd
+-a always,exit -F path=/usr/sbin/unix_chkpwd -F perm=x -k privileged-passwd
+-a always,exit -F path=/sbin/unix_chkpwd -F perm=x -k privileged-passwd
 
--a exit,always -F path=/usr/bin/gpasswd -F perm=x -k privileged-passwd
--a exit,always -F path=/bin/gpasswd -F perm=x -k privileged-passwd
+-a always,exit -F path=/usr/bin/gpasswd -F perm=x -k privileged-passwd
+-a always,exit -F path=/bin/gpasswd -F perm=x -k privileged-passwd
 
--a exit,always -F path=/usr/bin/chage -F perm=x -k privileged-passwd
--a exit,always -F path=/bin/chage -F perm=x -k privileged-passwd
+-a always,exit -F path=/usr/bin/chage -F perm=x -k privileged-passwd
+-a always,exit -F path=/bin/chage -F perm=x -k privileged-passwd
 
--a exit,always -F path=/usr/sbin/userhelper -F perm=x -k privileged-passwd
--a exit,always -F path=/sbin/userhelper -F perm=x -k privileged-passwd
+-a always,exit -F path=/usr/sbin/userhelper -F perm=x -k privileged-passwd
+-a always,exit -F path=/sbin/userhelper -F perm=x -k privileged-passwd
 
 ## Audit the execution of privilege-related commands
--a exit,always -F path=/usr/bin/su -F perm=x -k privileged-priv_change
--a exit,always -F path=/bin/su -F perm=x -k privileged-priv_change
+-a always,exit -F path=/usr/bin/su -F perm=x -k privileged-priv_change
+-a always,exit -F path=/bin/su -F perm=x -k privileged-priv_change
 
--a exit,always -F path=/usr/bin/sudo -F perm=x -k privileged-priv_change
--a exit,always -F path=/bin/sudo -F perm=x -k privileged-priv_change
+-a always,exit -F path=/usr/bin/sudo -F perm=x -k privileged-priv_change
+-a always,exit -F path=/bin/sudo -F perm=x -k privileged-priv_change
 
--a exit,always -F path=/usr/bin/newgrp -F perm=x -k privileged-priv_change
--a exit,always -F path=/bin/newgrp -F perm=x -k privileged-priv_change
+-a always,exit -F path=/usr/bin/newgrp -F perm=x -k privileged-priv_change
+-a always,exit -F path=/bin/newgrp -F perm=x -k privileged-priv_change
 
--a exit,always -F path=/usr/bin/chsh -F perm=x -k privileged-priv_change
--a exit,always -F path=/bin/chsh -F perm=x -k privileged-priv_change
+-a always,exit -F path=/usr/bin/chsh -F perm=x -k privileged-priv_change
+-a always,exit -F path=/bin/chsh -F perm=x -k privileged-priv_change
 
--a exit,always -F path=/usr/bin/sudoedit -F perm=x -k privileged-priv_change
--a exit,always -F path=/bin/sudoedit -F perm=x -k privileged-priv_change
+-a always,exit -F path=/usr/bin/sudoedit -F perm=x -k privileged-priv_change
+-a always,exit -F path=/bin/sudoedit -F perm=x -k privileged-priv_change
 
 ## Audit the execution of postfix-related commands
--a exit,always -F path=/usr/sbin/postdrop -F perm=x -k privileged-postfix
--a exit,always -F path=/sbin/postdrop -F perm=x -k privileged-postfix
+-a always,exit -F path=/usr/sbin/postdrop -F perm=x -k privileged-postfix
+-a always,exit -F path=/sbin/postdrop -F perm=x -k privileged-postfix
 
--a exit,always -F path=/usr/sbin/postqueue -F perm=x -k privileged-postfix
--a exit,always -F path=/sbin/postqueue -F perm=x -k privileged-postfix
+-a always,exit -F path=/usr/sbin/postqueue -F perm=x -k privileged-postfix
+-a always,exit -F path=/sbin/postqueue -F perm=x -k privileged-postfix
 
 ## Audit the execution of the ssh-keysign command
--a exit,always -F path=/usr/libexec/openssh/ssh-keysign -F perm=x -k privileged-ssh
+-a always,exit -F path=/usr/libexec/openssh/ssh-keysign -F perm=x -k privileged-ssh
 
 ## Audit the execution of the crontab command
--a exit,always -F path=/usr/bin/crontab -F perm=x -k privileged-cron
--a exit,always -F path=/bin/crontab -F perm=x -k privileged-cron
+-a always,exit -F path=/usr/bin/crontab -F perm=x -k privileged-cron
+-a always,exit -F path=/bin/crontab -F perm=x -k privileged-cron
 
 ## Audit the execution of the pam_timestamp_check command
--a exit,always -F path=/usr/sbin/pam_timestamp_check -F perm=x -k privileged-pam
--a exit,always -F path=/sbin/pam_timestamp_check -F perm=x -k privileged-pam
+-a always,exit -F path=/usr/sbin/pam_timestamp_check -F perm=x -k privileged-pam
+-a always,exit -F path=/sbin/pam_timestamp_check -F perm=x -k privileged-pam
 
 ## Permissions auditing separated by chown, chmod, and attr
 
--a exit,always -F arch=b64 -S chown,fchown,fchownat,lchown -k chown
--a exit,always -F arch=b32 -S chown,fchown,fchownat,lchown -k chown
+-a always,exit -F arch=b64 -S chown,fchown,fchownat,lchown -k chown
+-a always,exit -F arch=b32 -S chown,fchown,fchownat,lchown -k chown
 
--a exit,always -F arch=b64 -S setxattr,lsetxattr,fsetxattr,removexattr,lremovexattr,fremovexattr -k attr
--a exit,always -F arch=b32 -S setxattr,lsetxattr,fsetxattr,removexattr,lremovexattr,fremovexattr -k attr
+-a always,exit -F arch=b64 -S setxattr,lsetxattr,fsetxattr,removexattr,lremovexattr,fremovexattr -k attr
+-a always,exit -F arch=b32 -S setxattr,lsetxattr,fsetxattr,removexattr,lremovexattr,fremovexattr -k attr
 
 ## Audit useful items that someone does when su'ing to root.
--a exit,always -F arch=b64 -F auid!=0 -F uid=0 -S capset,mknod,mknodat,pivot_root,quotactl,setsid,adjtimex,settimeofday,setuid,swapoff,swapon -k su-root-activity
--a exit,always -F arch=b32 -F auid!=0 -F uid=0 -S capset,mknod,mknodat,pivot_root,quotactl,setsid,adjtimex,settimeofday,setuid,swapoff,swapon -k su-root-activity
+-a always,exit -F arch=b64 -F auid!=0 -F uid=0 -S capset,mknod,mknodat,pivot_root,quotactl,setsid,adjtimex,settimeofday,setuid,swapoff,swapon -k su-root-activity
+-a always,exit -F arch=b32 -F auid!=0 -F uid=0 -S capset,mknod,mknodat,pivot_root,quotactl,setsid,adjtimex,settimeofday,setuid,swapoff,swapon -k su-root-activity
 
 ## Audit the execution of suid and sgid binaries.
--a exit,always -F arch=b64 -F euid=0 -F uid!=0 -S execve -k suid-root-exec
--a exit,always -F arch=b32 -F euid=0 -F uid!=0 -S execve -k suid-root-exec
+-a always,exit -F arch=b64 -F euid=0 -F uid!=0 -S execve -k suid-root-exec
+-a always,exit -F arch=b32 -F euid=0 -F uid!=0 -S execve -k suid-root-exec
 
 ## Audit the loading and unloading of kernel modules.
 -w /usr/bin/kmod -p x -k modules
@@ -90,38 +90,38 @@
 -w /usr/sbin/modprobe -p x -k modules
 -w /sbin/modprobe -p x -k modules
 
--a exit,always -F arch=b64 -S create_module,init_module,finit_module,delete_module -k modules
--a exit,always -F arch=b32 -S create_module,init_module,finit_module,delete_module -k modules
+-a always,exit -F arch=b64 -S create_module,init_module,finit_module,delete_module -k modules
+-a always,exit -F arch=b32 -S create_module,init_module,finit_module,delete_module -k modules
 
 ## Audit things that could affect time
--a exit,always -F arch=b64 -S adjtimex,settimeofday -k audit_time_rules
--a exit,always -F arch=b64 -S clock_settime -F a0=0x0 -k audit_time_rules
--a exit,always -F arch=b32 -S adjtimex,stime,settimeofday -k audit_time_rules
--a exit,always -F arch=b32 -S clock_settime -F a0=0x0 -k audit_time_rules
+-a always,exit -F arch=b64 -S adjtimex,settimeofday -k audit_time_rules
+-a always,exit -F arch=b64 -S clock_settime -F a0=0x0 -k audit_time_rules
+-a always,exit -F arch=b32 -S adjtimex,stime,settimeofday -k audit_time_rules
+-a always,exit -F arch=b32 -S clock_settime -F a0=0x0 -k audit_time_rules
 
 -w /etc/localtime -p wa -k audit_time_rules
 
 ## Audit things that could affect system locale
--a exit,always -F arch=b64 -S sethostname,setdomainname -k audit_network_modifications
--a exit,always -F arch=b32 -S sethostname,setdomainname -k audit_network_modifications
+-a always,exit -F arch=b64 -S sethostname,setdomainname -k audit_network_modifications
+-a always,exit -F arch=b32 -S sethostname,setdomainname -k audit_network_modifications
 
 -w /etc/issue -p wa -k audit_network_modifications
 -w /etc/issue.net -p wa -k audit_network_modifications
 -w /etc/hosts -p wa -k audit_network_modifications
 -w /etc/hostname -p wa -k audit_network_modifications
 -w /etc/sysconfig/network -p wa -k audit_network_modifications
--a exit,always -F dir=/etc/NetworkManager/ -F perm=wa -k audit_network_modifications
+-a always,exit -F dir=/etc/NetworkManager/ -F perm=wa -k audit_network_modifications
 
 ## Audit mount operations
--a exit,always -F arch=b64 -S mount,umount2 -k mount
--a exit,always -F arch=b32 -S mount,umount,umount2 -k mount
+-a always,exit -F arch=b64 -S mount,umount2 -k mount
+-a always,exit -F arch=b32 -S mount,umount,umount2 -k mount
 
--a exit,always -F arch=b64 -F path=/usr/bin/mount -k mount
--a exit,always -F arch=b64 -F path=/bin/mount -k mount
--a exit,always -F arch=b32 -F path=/usr/bin/mount -k mount
--a exit,always -F arch=b32 -F path=/bin/mount -k mount
--a exit,always -F path=/usr/bin/umount -F perm=x -k mount
--a exit,always -F path=/bin/umount -F perm=x -k mount
+-a always,exit -F arch=b64 -F path=/usr/bin/mount -k mount
+-a always,exit -F arch=b64 -F path=/bin/mount -k mount
+-a always,exit -F arch=b32 -F path=/usr/bin/mount -k mount
+-a always,exit -F arch=b32 -F path=/bin/mount -k mount
+-a always,exit -F path=/usr/bin/umount -F perm=x -k mount
+-a always,exit -F path=/bin/umount -F perm=x -k mount
 
 ## Audit local accounts
 -w /etc/passwd -p wa -k audit_account_changes
@@ -227,13 +227,13 @@
 -w /etc/yum -p wa -k yum-config
 -w /etc/yum.conf -p wa -k yum-config
 -w /etc/yum.repos.d -p wa -k yum-config
--a exit,always -F arch=b64 -S ptrace -F a0=0x4 -k paranoid_code_injection
--a exit,always -F arch=b64 -S ptrace -F a0=0x5 -k paranoid_data_injection
--a exit,always -F arch=b64 -S ptrace -F a0=0x6 -k paranoid_register_injection
--a exit,always -F arch=b64 -S ptrace -k paranoid
--a exit,always -F arch=b32 -S ptrace -F a0=0x4 -k paranoid_code_injection
--a exit,always -F arch=b32 -S ptrace -F a0=0x5 -k paranoid_data_injection
--a exit,always -F arch=b32 -S ptrace -F a0=0x6 -k paranoid_register_injection
--a exit,always -F arch=b32 -S ptrace -k paranoid
--a exit,always -F arch=b64 -S personality -k paranoid
--a exit,always -F arch=b32 -S personality -k paranoid
+-a always,exit -F arch=b64 -S ptrace -F a0=0x4 -k paranoid_code_injection
+-a always,exit -F arch=b64 -S ptrace -F a0=0x5 -k paranoid_data_injection
+-a always,exit -F arch=b64 -S ptrace -F a0=0x6 -k paranoid_register_injection
+-a always,exit -F arch=b64 -S ptrace -k paranoid
+-a always,exit -F arch=b32 -S ptrace -F a0=0x4 -k paranoid_code_injection
+-a always,exit -F arch=b32 -S ptrace -F a0=0x5 -k paranoid_data_injection
+-a always,exit -F arch=b32 -S ptrace -F a0=0x6 -k paranoid_register_injection
+-a always,exit -F arch=b32 -S ptrace -k paranoid
+-a always,exit -F arch=b64 -S personality -k paranoid
+-a always,exit -F arch=b32 -S personality -k paranoid

--- a/spec/classes/config/audit_profiles/expected/simp_el7_insane_rules.txt
+++ b/spec/classes/config/audit_profiles/expected/simp_el7_insane_rules.txt
@@ -1,84 +1,84 @@
 #### auditd::config::audit_profiles::simp Audit Rules ####
 # 64-bit systems should generally never call the 32-bit API. 32-bit syscalls
 # may be a sign of someone exploiting a hole in the API.
--a exit,always -F arch=b32 -S all -F key=32bit-api
--a exit,always -F arch=b64 -S accept -F a0=2 -F key=ipv4_in
--a exit,always -F arch=b64 -S accept -F a0=10 -F key=ipv6_in
+-a always,exit -F arch=b32 -S all -F key=32bit-api
+-a always,exit -F arch=b64 -S accept -F a0=2 -F key=ipv4_in
+-a always,exit -F arch=b64 -S accept -F a0=10 -F key=ipv6_in
 
 ## Audit unsuccessful file operations
--a exit,always -F arch=b64 -S creat,mkdir,mknod,link,symlink,mkdirat,mknodat,linkat,symlinkat,openat,open_by_handle_at,open,close,rename,renameat,truncate,ftruncate,rmdir,unlink,unlinkat -F exit=-EACCES -k access
--a exit,always -F arch=b64 -S creat,mkdir,mknod,link,symlink,mkdirat,mknodat,linkat,symlinkat,openat,open_by_handle_at,open,close,rename,renameat,truncate,ftruncate,rmdir,unlink,unlinkat -F exit=-EPERM -k access
--a exit,always -F arch=b32 -S creat,mkdir,mknod,link,symlink,mkdirat,mknodat,linkat,symlinkat,openat,open_by_handle_at,open,close,rename,renameat,truncate,ftruncate,rmdir,unlink,unlinkat -F exit=-EACCES -k access
--a exit,always -F arch=b32 -S creat,mkdir,mknod,link,symlink,mkdirat,mknodat,linkat,symlinkat,openat,open_by_handle_at,open,close,rename,renameat,truncate,ftruncate,rmdir,unlink,unlinkat -F exit=-EPERM -k access
+-a always,exit -F arch=b64 -S creat,mkdir,mknod,link,symlink,mkdirat,mknodat,linkat,symlinkat,openat,open_by_handle_at,open,close,rename,renameat,truncate,ftruncate,rmdir,unlink,unlinkat -F exit=-EACCES -k access
+-a always,exit -F arch=b64 -S creat,mkdir,mknod,link,symlink,mkdirat,mknodat,linkat,symlinkat,openat,open_by_handle_at,open,close,rename,renameat,truncate,ftruncate,rmdir,unlink,unlinkat -F exit=-EPERM -k access
+-a always,exit -F arch=b32 -S creat,mkdir,mknod,link,symlink,mkdirat,mknodat,linkat,symlinkat,openat,open_by_handle_at,open,close,rename,renameat,truncate,ftruncate,rmdir,unlink,unlinkat -F exit=-EACCES -k access
+-a always,exit -F arch=b32 -S creat,mkdir,mknod,link,symlink,mkdirat,mknodat,linkat,symlinkat,openat,open_by_handle_at,open,close,rename,renameat,truncate,ftruncate,rmdir,unlink,unlinkat -F exit=-EPERM -k access
 
--a exit,always -F perm=a -F exit=-EACCES -k access
--a exit,always -F perm=a -F exit=-EPERM -k access
+-a always,exit -F perm=a -F exit=-EACCES -k access
+-a always,exit -F perm=a -F exit=-EPERM -k access
 
 ## Audit the execution of password commands
--a exit,always -F path=/usr/bin/passwd -F perm=x -k privileged-passwd
--a exit,always -F path=/bin/passwd -F perm=x -k privileged-passwd
+-a always,exit -F path=/usr/bin/passwd -F perm=x -k privileged-passwd
+-a always,exit -F path=/bin/passwd -F perm=x -k privileged-passwd
 
--a exit,always -F path=/usr/sbin/unix_chkpwd -F perm=x -k privileged-passwd
--a exit,always -F path=/sbin/unix_chkpwd -F perm=x -k privileged-passwd
+-a always,exit -F path=/usr/sbin/unix_chkpwd -F perm=x -k privileged-passwd
+-a always,exit -F path=/sbin/unix_chkpwd -F perm=x -k privileged-passwd
 
--a exit,always -F path=/usr/bin/gpasswd -F perm=x -k privileged-passwd
--a exit,always -F path=/bin/gpasswd -F perm=x -k privileged-passwd
+-a always,exit -F path=/usr/bin/gpasswd -F perm=x -k privileged-passwd
+-a always,exit -F path=/bin/gpasswd -F perm=x -k privileged-passwd
 
--a exit,always -F path=/usr/bin/chage -F perm=x -k privileged-passwd
--a exit,always -F path=/bin/chage -F perm=x -k privileged-passwd
+-a always,exit -F path=/usr/bin/chage -F perm=x -k privileged-passwd
+-a always,exit -F path=/bin/chage -F perm=x -k privileged-passwd
 
--a exit,always -F path=/usr/sbin/userhelper -F perm=x -k privileged-passwd
--a exit,always -F path=/sbin/userhelper -F perm=x -k privileged-passwd
+-a always,exit -F path=/usr/sbin/userhelper -F perm=x -k privileged-passwd
+-a always,exit -F path=/sbin/userhelper -F perm=x -k privileged-passwd
 
 ## Audit the execution of privilege-related commands
--a exit,always -F path=/usr/bin/su -F perm=x -k privileged-priv_change
--a exit,always -F path=/bin/su -F perm=x -k privileged-priv_change
+-a always,exit -F path=/usr/bin/su -F perm=x -k privileged-priv_change
+-a always,exit -F path=/bin/su -F perm=x -k privileged-priv_change
 
--a exit,always -F path=/usr/bin/sudo -F perm=x -k privileged-priv_change
--a exit,always -F path=/bin/sudo -F perm=x -k privileged-priv_change
+-a always,exit -F path=/usr/bin/sudo -F perm=x -k privileged-priv_change
+-a always,exit -F path=/bin/sudo -F perm=x -k privileged-priv_change
 
--a exit,always -F path=/usr/bin/newgrp -F perm=x -k privileged-priv_change
--a exit,always -F path=/bin/newgrp -F perm=x -k privileged-priv_change
+-a always,exit -F path=/usr/bin/newgrp -F perm=x -k privileged-priv_change
+-a always,exit -F path=/bin/newgrp -F perm=x -k privileged-priv_change
 
--a exit,always -F path=/usr/bin/chsh -F perm=x -k privileged-priv_change
--a exit,always -F path=/bin/chsh -F perm=x -k privileged-priv_change
+-a always,exit -F path=/usr/bin/chsh -F perm=x -k privileged-priv_change
+-a always,exit -F path=/bin/chsh -F perm=x -k privileged-priv_change
 
--a exit,always -F path=/usr/bin/sudoedit -F perm=x -k privileged-priv_change
--a exit,always -F path=/bin/sudoedit -F perm=x -k privileged-priv_change
+-a always,exit -F path=/usr/bin/sudoedit -F perm=x -k privileged-priv_change
+-a always,exit -F path=/bin/sudoedit -F perm=x -k privileged-priv_change
 
 ## Audit the execution of postfix-related commands
--a exit,always -F path=/usr/sbin/postdrop -F perm=x -k privileged-postfix
--a exit,always -F path=/sbin/postdrop -F perm=x -k privileged-postfix
+-a always,exit -F path=/usr/sbin/postdrop -F perm=x -k privileged-postfix
+-a always,exit -F path=/sbin/postdrop -F perm=x -k privileged-postfix
 
--a exit,always -F path=/usr/sbin/postqueue -F perm=x -k privileged-postfix
--a exit,always -F path=/sbin/postqueue -F perm=x -k privileged-postfix
+-a always,exit -F path=/usr/sbin/postqueue -F perm=x -k privileged-postfix
+-a always,exit -F path=/sbin/postqueue -F perm=x -k privileged-postfix
 
 ## Audit the execution of the ssh-keysign command
--a exit,always -F path=/usr/libexec/openssh/ssh-keysign -F perm=x -k privileged-ssh
+-a always,exit -F path=/usr/libexec/openssh/ssh-keysign -F perm=x -k privileged-ssh
 
 ## Audit the execution of the crontab command
--a exit,always -F path=/usr/bin/crontab -F perm=x -k privileged-cron
--a exit,always -F path=/bin/crontab -F perm=x -k privileged-cron
+-a always,exit -F path=/usr/bin/crontab -F perm=x -k privileged-cron
+-a always,exit -F path=/bin/crontab -F perm=x -k privileged-cron
 
 ## Audit the execution of the pam_timestamp_check command
--a exit,always -F path=/usr/sbin/pam_timestamp_check -F perm=x -k privileged-pam
--a exit,always -F path=/sbin/pam_timestamp_check -F perm=x -k privileged-pam
+-a always,exit -F path=/usr/sbin/pam_timestamp_check -F perm=x -k privileged-pam
+-a always,exit -F path=/sbin/pam_timestamp_check -F perm=x -k privileged-pam
 
 ## Permissions auditing separated by chown, chmod, and attr
 
--a exit,always -F arch=b64 -S chown,fchown,fchownat,lchown -k chown
--a exit,always -F arch=b32 -S chown,fchown,fchownat,lchown -k chown
+-a always,exit -F arch=b64 -S chown,fchown,fchownat,lchown -k chown
+-a always,exit -F arch=b32 -S chown,fchown,fchownat,lchown -k chown
 
--a exit,always -F arch=b64 -S setxattr,lsetxattr,fsetxattr,removexattr,lremovexattr,fremovexattr -k attr
--a exit,always -F arch=b32 -S setxattr,lsetxattr,fsetxattr,removexattr,lremovexattr,fremovexattr -k attr
+-a always,exit -F arch=b64 -S setxattr,lsetxattr,fsetxattr,removexattr,lremovexattr,fremovexattr -k attr
+-a always,exit -F arch=b32 -S setxattr,lsetxattr,fsetxattr,removexattr,lremovexattr,fremovexattr -k attr
 
 ## Audit useful items that someone does when su'ing to root.
--a exit,always -F arch=b64 -F auid!=0 -F uid=0 -S capset,mknod,mknodat,pivot_root,quotactl,setsid,adjtimex,settimeofday,setuid,swapoff,swapon,execve,rename,renameat,rmdir,unlink,unlinkat,write,chown,fchown,fchownat,lchown,creat,fork,vfork,link,linkat,symlink,symlinkat,mkdir,mkdirat -k su-root-activity
--a exit,always -F arch=b32 -F auid!=0 -F uid=0 -S capset,mknod,mknodat,pivot_root,quotactl,setsid,adjtimex,settimeofday,setuid,swapoff,swapon,execve,rename,renameat,rmdir,unlink,unlinkat,write,chown,fchown,fchownat,lchown,creat,fork,vfork,link,linkat,symlink,symlinkat,mkdir,mkdirat -k su-root-activity
+-a always,exit -F arch=b64 -F auid!=0 -F uid=0 -S capset,mknod,mknodat,pivot_root,quotactl,setsid,adjtimex,settimeofday,setuid,swapoff,swapon,execve,rename,renameat,rmdir,unlink,unlinkat,write,chown,fchown,fchownat,lchown,creat,fork,vfork,link,linkat,symlink,symlinkat,mkdir,mkdirat -k su-root-activity
+-a always,exit -F arch=b32 -F auid!=0 -F uid=0 -S capset,mknod,mknodat,pivot_root,quotactl,setsid,adjtimex,settimeofday,setuid,swapoff,swapon,execve,rename,renameat,rmdir,unlink,unlinkat,write,chown,fchown,fchownat,lchown,creat,fork,vfork,link,linkat,symlink,symlinkat,mkdir,mkdirat -k su-root-activity
 
 ## Audit the execution of suid and sgid binaries.
--a exit,always -F arch=b64 -F euid=0 -F uid!=0 -S execve -k suid-root-exec
--a exit,always -F arch=b32 -F euid=0 -F uid!=0 -S execve -k suid-root-exec
+-a always,exit -F arch=b64 -F euid=0 -F uid!=0 -S execve -k suid-root-exec
+-a always,exit -F arch=b32 -F euid=0 -F uid!=0 -S execve -k suid-root-exec
 
 ## Audit the loading and unloading of kernel modules.
 -w /usr/bin/kmod -p x -k modules
@@ -90,38 +90,38 @@
 -w /usr/sbin/modprobe -p x -k modules
 -w /sbin/modprobe -p x -k modules
 
--a exit,always -F arch=b64 -S create_module,init_module,finit_module,delete_module -k modules
--a exit,always -F arch=b32 -S create_module,init_module,finit_module,delete_module -k modules
+-a always,exit -F arch=b64 -S create_module,init_module,finit_module,delete_module -k modules
+-a always,exit -F arch=b32 -S create_module,init_module,finit_module,delete_module -k modules
 
 ## Audit things that could affect time
--a exit,always -F arch=b64 -S adjtimex,settimeofday -k audit_time_rules
--a exit,always -F arch=b64 -S clock_settime -F a0=0x0 -k audit_time_rules
--a exit,always -F arch=b32 -S adjtimex,stime,settimeofday -k audit_time_rules
--a exit,always -F arch=b32 -S clock_settime -F a0=0x0 -k audit_time_rules
+-a always,exit -F arch=b64 -S adjtimex,settimeofday -k audit_time_rules
+-a always,exit -F arch=b64 -S clock_settime -F a0=0x0 -k audit_time_rules
+-a always,exit -F arch=b32 -S adjtimex,stime,settimeofday -k audit_time_rules
+-a always,exit -F arch=b32 -S clock_settime -F a0=0x0 -k audit_time_rules
 
 -w /etc/localtime -p wa -k audit_time_rules
 
 ## Audit things that could affect system locale
--a exit,always -F arch=b64 -S sethostname,setdomainname -k audit_network_modifications
--a exit,always -F arch=b32 -S sethostname,setdomainname -k audit_network_modifications
+-a always,exit -F arch=b64 -S sethostname,setdomainname -k audit_network_modifications
+-a always,exit -F arch=b32 -S sethostname,setdomainname -k audit_network_modifications
 
 -w /etc/issue -p wa -k audit_network_modifications
 -w /etc/issue.net -p wa -k audit_network_modifications
 -w /etc/hosts -p wa -k audit_network_modifications
 -w /etc/hostname -p wa -k audit_network_modifications
 -w /etc/sysconfig/network -p wa -k audit_network_modifications
--a exit,always -F dir=/etc/NetworkManager/ -F perm=wa -k audit_network_modifications
+-a always,exit -F dir=/etc/NetworkManager/ -F perm=wa -k audit_network_modifications
 
 ## Audit mount operations
--a exit,always -F arch=b64 -S mount,umount2 -k mount
--a exit,always -F arch=b32 -S mount,umount,umount2 -k mount
+-a always,exit -F arch=b64 -S mount,umount2 -k mount
+-a always,exit -F arch=b32 -S mount,umount,umount2 -k mount
 
--a exit,always -F arch=b64 -F path=/usr/bin/mount -k mount
--a exit,always -F arch=b64 -F path=/bin/mount -k mount
--a exit,always -F arch=b32 -F path=/usr/bin/mount -k mount
--a exit,always -F arch=b32 -F path=/bin/mount -k mount
--a exit,always -F path=/usr/bin/umount -F perm=x -k mount
--a exit,always -F path=/bin/umount -F perm=x -k mount
+-a always,exit -F arch=b64 -F path=/usr/bin/mount -k mount
+-a always,exit -F arch=b64 -F path=/bin/mount -k mount
+-a always,exit -F arch=b32 -F path=/usr/bin/mount -k mount
+-a always,exit -F arch=b32 -F path=/bin/mount -k mount
+-a always,exit -F path=/usr/bin/umount -F perm=x -k mount
+-a always,exit -F path=/bin/umount -F perm=x -k mount
 
 ## Audit local accounts
 -w /etc/passwd -p wa -k audit_account_changes
@@ -227,13 +227,13 @@
 -w /etc/yum -p wa -k yum-config
 -w /etc/yum.conf -p wa -k yum-config
 -w /etc/yum.repos.d -p wa -k yum-config
--a exit,always -F arch=b64 -S ptrace -F a0=0x4 -k paranoid_code_injection
--a exit,always -F arch=b64 -S ptrace -F a0=0x5 -k paranoid_data_injection
--a exit,always -F arch=b64 -S ptrace -F a0=0x6 -k paranoid_register_injection
--a exit,always -F arch=b64 -S ptrace -k paranoid
--a exit,always -F arch=b32 -S ptrace -F a0=0x4 -k paranoid_code_injection
--a exit,always -F arch=b32 -S ptrace -F a0=0x5 -k paranoid_data_injection
--a exit,always -F arch=b32 -S ptrace -F a0=0x6 -k paranoid_register_injection
--a exit,always -F arch=b32 -S ptrace -k paranoid
--a exit,always -F arch=b64 -S personality -k paranoid
--a exit,always -F arch=b32 -S personality -k paranoid
+-a always,exit -F arch=b64 -S ptrace -F a0=0x4 -k paranoid_code_injection
+-a always,exit -F arch=b64 -S ptrace -F a0=0x5 -k paranoid_data_injection
+-a always,exit -F arch=b64 -S ptrace -F a0=0x6 -k paranoid_register_injection
+-a always,exit -F arch=b64 -S ptrace -k paranoid
+-a always,exit -F arch=b32 -S ptrace -F a0=0x4 -k paranoid_code_injection
+-a always,exit -F arch=b32 -S ptrace -F a0=0x5 -k paranoid_data_injection
+-a always,exit -F arch=b32 -S ptrace -F a0=0x6 -k paranoid_register_injection
+-a always,exit -F arch=b32 -S ptrace -k paranoid
+-a always,exit -F arch=b64 -S personality -k paranoid
+-a always,exit -F arch=b32 -S personality -k paranoid

--- a/spec/classes/config/audit_profiles/expected/stig_el6_all_custom_tags.txt
+++ b/spec/classes/config/audit_profiles/expected/stig_el6_all_custom_tags.txt
@@ -1,189 +1,189 @@
 #### auditd::config::audit_profiles::stig Audit Rules ####
 
 ## Audit unsuccessful file operations
--a exit,always -F arch=b64 -S creat -F exit=-EPERM -F auid>=500 -F auid!=4294967295 -k my_unsuccessful_file_operations
--a exit,always -F arch=b64 -S creat -F exit=-EACCES -F auid>=500 -F auid!=4294967295 -k my_unsuccessful_file_operations
--a exit,always -F arch=b32 -S creat -F exit=-EPERM -F auid>=500 -F auid!=4294967295 -k my_unsuccessful_file_operations
--a exit,always -F arch=b32 -S creat -F exit=-EACCES -F auid>=500 -F auid!=4294967295 -k my_unsuccessful_file_operations
+-a always,exit -F arch=b64 -S creat -F exit=-EPERM -F auid>=500 -F auid!=4294967295 -k my_unsuccessful_file_operations
+-a always,exit -F arch=b64 -S creat -F exit=-EACCES -F auid>=500 -F auid!=4294967295 -k my_unsuccessful_file_operations
+-a always,exit -F arch=b32 -S creat -F exit=-EPERM -F auid>=500 -F auid!=4294967295 -k my_unsuccessful_file_operations
+-a always,exit -F arch=b32 -S creat -F exit=-EACCES -F auid>=500 -F auid!=4294967295 -k my_unsuccessful_file_operations
 
--a exit,always -F arch=b64 -S open -F exit=-EPERM -F auid>=500 -F auid!=4294967295 -k my_unsuccessful_file_operations
--a exit,always -F arch=b64 -S open -F exit=-EACCES -F auid>=500 -F auid!=4294967295 -k my_unsuccessful_file_operations
--a exit,always -F arch=b32 -S open -F exit=-EPERM -F auid>=500 -F auid!=4294967295 -k my_unsuccessful_file_operations
--a exit,always -F arch=b32 -S open -F exit=-EACCES -F auid>=500 -F auid!=4294967295 -k my_unsuccessful_file_operations
+-a always,exit -F arch=b64 -S open -F exit=-EPERM -F auid>=500 -F auid!=4294967295 -k my_unsuccessful_file_operations
+-a always,exit -F arch=b64 -S open -F exit=-EACCES -F auid>=500 -F auid!=4294967295 -k my_unsuccessful_file_operations
+-a always,exit -F arch=b32 -S open -F exit=-EPERM -F auid>=500 -F auid!=4294967295 -k my_unsuccessful_file_operations
+-a always,exit -F arch=b32 -S open -F exit=-EACCES -F auid>=500 -F auid!=4294967295 -k my_unsuccessful_file_operations
 
--a exit,always -F arch=b64 -S openat -F exit=-EPERM -F auid>=500 -F auid!=4294967295 -k my_unsuccessful_file_operations
--a exit,always -F arch=b64 -S openat -F exit=-EACCES -F auid>=500 -F auid!=4294967295 -k my_unsuccessful_file_operations
--a exit,always -F arch=b32 -S openat -F exit=-EPERM -F auid>=500 -F auid!=4294967295 -k my_unsuccessful_file_operations
--a exit,always -F arch=b32 -S openat -F exit=-EACCES -F auid>=500 -F auid!=4294967295 -k my_unsuccessful_file_operations
+-a always,exit -F arch=b64 -S openat -F exit=-EPERM -F auid>=500 -F auid!=4294967295 -k my_unsuccessful_file_operations
+-a always,exit -F arch=b64 -S openat -F exit=-EACCES -F auid>=500 -F auid!=4294967295 -k my_unsuccessful_file_operations
+-a always,exit -F arch=b32 -S openat -F exit=-EPERM -F auid>=500 -F auid!=4294967295 -k my_unsuccessful_file_operations
+-a always,exit -F arch=b32 -S openat -F exit=-EACCES -F auid>=500 -F auid!=4294967295 -k my_unsuccessful_file_operations
 
--a exit,always -F arch=b64 -S open_by_handle_at -F exit=-EPERM -F auid>=500 -F auid!=4294967295 -k my_unsuccessful_file_operations
--a exit,always -F arch=b64 -S open_by_handle_at -F exit=-EACCES -F auid>=500 -F auid!=4294967295 -k my_unsuccessful_file_operations
--a exit,always -F arch=b32 -S open_by_handle_at -F exit=-EPERM -F auid>=500 -F auid!=4294967295 -k my_unsuccessful_file_operations
--a exit,always -F arch=b32 -S open_by_handle_at -F exit=-EACCES -F auid>=500 -F auid!=4294967295 -k my_unsuccessful_file_operations
+-a always,exit -F arch=b64 -S open_by_handle_at -F exit=-EPERM -F auid>=500 -F auid!=4294967295 -k my_unsuccessful_file_operations
+-a always,exit -F arch=b64 -S open_by_handle_at -F exit=-EACCES -F auid>=500 -F auid!=4294967295 -k my_unsuccessful_file_operations
+-a always,exit -F arch=b32 -S open_by_handle_at -F exit=-EPERM -F auid>=500 -F auid!=4294967295 -k my_unsuccessful_file_operations
+-a always,exit -F arch=b32 -S open_by_handle_at -F exit=-EACCES -F auid>=500 -F auid!=4294967295 -k my_unsuccessful_file_operations
 
--a exit,always -F arch=b64 -S truncate -F exit=-EPERM -F auid>=500 -F auid!=4294967295 -k my_unsuccessful_file_operations
--a exit,always -F arch=b64 -S truncate -F exit=-EACCES -F auid>=500 -F auid!=4294967295 -k my_unsuccessful_file_operations
--a exit,always -F arch=b32 -S truncate -F exit=-EPERM -F auid>=500 -F auid!=4294967295 -k my_unsuccessful_file_operations
--a exit,always -F arch=b32 -S truncate -F exit=-EACCES -F auid>=500 -F auid!=4294967295 -k my_unsuccessful_file_operations
+-a always,exit -F arch=b64 -S truncate -F exit=-EPERM -F auid>=500 -F auid!=4294967295 -k my_unsuccessful_file_operations
+-a always,exit -F arch=b64 -S truncate -F exit=-EACCES -F auid>=500 -F auid!=4294967295 -k my_unsuccessful_file_operations
+-a always,exit -F arch=b32 -S truncate -F exit=-EPERM -F auid>=500 -F auid!=4294967295 -k my_unsuccessful_file_operations
+-a always,exit -F arch=b32 -S truncate -F exit=-EACCES -F auid>=500 -F auid!=4294967295 -k my_unsuccessful_file_operations
 
--a exit,always -F arch=b64 -S ftruncate -F exit=-EPERM -F auid>=500 -F auid!=4294967295 -k my_unsuccessful_file_operations
--a exit,always -F arch=b64 -S ftruncate -F exit=-EACCES -F auid>=500 -F auid!=4294967295 -k my_unsuccessful_file_operations
--a exit,always -F arch=b32 -S ftruncate -F exit=-EPERM -F auid>=500 -F auid!=4294967295 -k my_unsuccessful_file_operations
--a exit,always -F arch=b32 -S ftruncate -F exit=-EACCES -F auid>=500 -F auid!=4294967295 -k my_unsuccessful_file_operations
+-a always,exit -F arch=b64 -S ftruncate -F exit=-EPERM -F auid>=500 -F auid!=4294967295 -k my_unsuccessful_file_operations
+-a always,exit -F arch=b64 -S ftruncate -F exit=-EACCES -F auid>=500 -F auid!=4294967295 -k my_unsuccessful_file_operations
+-a always,exit -F arch=b32 -S ftruncate -F exit=-EPERM -F auid>=500 -F auid!=4294967295 -k my_unsuccessful_file_operations
+-a always,exit -F arch=b32 -S ftruncate -F exit=-EACCES -F auid>=500 -F auid!=4294967295 -k my_unsuccessful_file_operations
 
 ## Audit the execution of password commands
--a exit,always -F path=/usr/bin/passwd -F perm=x -F auid>=500 -F auid!=4294967295 -k my_passwd_cmds
+-a always,exit -F path=/usr/bin/passwd -F perm=x -F auid>=500 -F auid!=4294967295 -k my_passwd_cmds
 
--a exit,always -F path=/sbin/unix_chkpwd -F perm=x -F auid>=500 -F auid!=4294967295 -k my_passwd_cmds
+-a always,exit -F path=/sbin/unix_chkpwd -F perm=x -F auid>=500 -F auid!=4294967295 -k my_passwd_cmds
 
--a exit,always -F path=/usr/bin/gpasswd -F perm=x -F auid>=500 -F auid!=4294967295 -k my_passwd_cmds
+-a always,exit -F path=/usr/bin/gpasswd -F perm=x -F auid>=500 -F auid!=4294967295 -k my_passwd_cmds
 
--a exit,always -F path=/usr/bin/chage -F perm=x -F auid>=500 -F auid!=4294967295 -k my_passwd_cmds
+-a always,exit -F path=/usr/bin/chage -F perm=x -F auid>=500 -F auid!=4294967295 -k my_passwd_cmds
 
--a exit,always -F path=/usr/sbin/userhelper -F perm=x -F auid>=500 -F auid!=4294967295 -k my_passwd_cmds
+-a always,exit -F path=/usr/sbin/userhelper -F perm=x -F auid>=500 -F auid!=4294967295 -k my_passwd_cmds
 
 ## Audit the execution of privilege-related commands
--a exit,always -F path=/bin/su -F perm=x -F auid>=500 -F auid!=4294967295 -k my_priv_cmds
+-a always,exit -F path=/bin/su -F perm=x -F auid>=500 -F auid!=4294967295 -k my_priv_cmds
 
--a exit,always -F path=/usr/bin/sudo -F perm=x -F auid>=500 -F auid!=4294967295 -k my_priv_cmds
+-a always,exit -F path=/usr/bin/sudo -F perm=x -F auid>=500 -F auid!=4294967295 -k my_priv_cmds
 
--a exit,always -F path=/usr/bin/newgrp -F perm=x -F auid>=500 -F auid!=4294967295 -k my_priv_cmds
+-a always,exit -F path=/usr/bin/newgrp -F perm=x -F auid>=500 -F auid!=4294967295 -k my_priv_cmds
 
--a exit,always -F path=/usr/bin/chsh -F perm=x -F auid>=500 -F auid!=4294967295 -k my_priv_cmds
+-a always,exit -F path=/usr/bin/chsh -F perm=x -F auid>=500 -F auid!=4294967295 -k my_priv_cmds
 
--a exit,always -F path=/usr/bin/sudoedit -F perm=x -F auid>=500 -F auid!=4294967295 -k my_priv_cmds
+-a always,exit -F path=/usr/bin/sudoedit -F perm=x -F auid>=500 -F auid!=4294967295 -k my_priv_cmds
 
 ## Audit the execution of postfix-related commands
--a exit,always -F path=/usr/sbin/postdrop -F perm=x -F auid>=500 -F auid!=4294967295 -k my_postfix_cmds
+-a always,exit -F path=/usr/sbin/postdrop -F perm=x -F auid>=500 -F auid!=4294967295 -k my_postfix_cmds
 
--a exit,always -F path=/usr/sbin/postqueue -F perm=x -F auid>=500 -F auid!=4294967295 -k my_postfix_cmds
+-a always,exit -F path=/usr/sbin/postqueue -F perm=x -F auid>=500 -F auid!=4294967295 -k my_postfix_cmds
 
 ## Audit the execution of the ssh-keysign command
--a exit,always -F path=/usr/libexec/openssh/ssh-keysign -F perm=x -F auid>=500 -F auid!=4294967295 -k my_ssh_keysign_cmd
+-a always,exit -F path=/usr/libexec/openssh/ssh-keysign -F perm=x -F auid>=500 -F auid!=4294967295 -k my_ssh_keysign_cmd
 
 ## Audit the execution of the crontab command
--a exit,always -F path=/usr/bin/crontab -F perm=x -F auid>=500 -F auid!=4294967295 -k my_crontab
+-a always,exit -F path=/usr/bin/crontab -F perm=x -F auid>=500 -F auid!=4294967295 -k my_crontab
 
 ## Audit the execution of the pam_timestamp_check command
--a exit,always -F path=/sbin/pam_timestamp_check -F perm=x -F auid>=500 -F auid!=4294967295 -k my_pam_timestamp_check_cmd
+-a always,exit -F path=/sbin/pam_timestamp_check -F perm=x -F auid>=500 -F auid!=4294967295 -k my_pam_timestamp_check_cmd
 
 ## Audit selinux commands
--a exit,always -F path=/usr/sbin/semanage -F perm=x -F auid>=500 -F auid!=4294967295 -k my_selinux_cmds
+-a always,exit -F path=/usr/sbin/semanage -F perm=x -F auid>=500 -F auid!=4294967295 -k my_selinux_cmds
 
--a exit,always -F path=/usr/sbin/setsebool -F perm=x -F auid>=500 -F auid!=4294967295 -k my_selinux_cmds
+-a always,exit -F path=/usr/sbin/setsebool -F perm=x -F auid>=500 -F auid!=4294967295 -k my_selinux_cmds
 
--a exit,always -F path=/usr/bin/chcon -F perm=x -F auid>=500 -F auid!=4294967295 -k my_selinux_cmds
+-a always,exit -F path=/usr/bin/chcon -F perm=x -F auid>=500 -F auid!=4294967295 -k my_selinux_cmds
 
--a exit,always -F path=/sbin/setfiles -F perm=x -F auid>=500 -F auid!=4294967295 -k my_selinux_cmds
+-a always,exit -F path=/sbin/setfiles -F perm=x -F auid>=500 -F auid!=4294967295 -k my_selinux_cmds
 
--a exit,always -F path=/sbin/restorecon -F perm=x -F auid>=500 -F auid!=4294967295 -k my_selinux_cmds
+-a always,exit -F path=/sbin/restorecon -F perm=x -F auid>=500 -F auid!=4294967295 -k my_selinux_cmds
 
 ## Permissions auditing separated by chown, chmod, and attr
--a exit,always -F arch=b64 -S chown -F auid>=500 -F auid!=4294967295 -k my_chown
--a exit,always -F arch=b32 -S chown -F auid>=500 -F auid!=4294967295 -k my_chown
+-a always,exit -F arch=b64 -S chown -F auid>=500 -F auid!=4294967295 -k my_chown
+-a always,exit -F arch=b32 -S chown -F auid>=500 -F auid!=4294967295 -k my_chown
 
--a exit,always -F arch=b64 -S fchown -F auid>=500 -F auid!=4294967295 -k my_chown
--a exit,always -F arch=b32 -S fchown -F auid>=500 -F auid!=4294967295 -k my_chown
+-a always,exit -F arch=b64 -S fchown -F auid>=500 -F auid!=4294967295 -k my_chown
+-a always,exit -F arch=b32 -S fchown -F auid>=500 -F auid!=4294967295 -k my_chown
 
--a exit,always -F arch=b64 -S lchown -F auid>=500 -F auid!=4294967295 -k my_chown
--a exit,always -F arch=b32 -S lchown -F auid>=500 -F auid!=4294967295 -k my_chown
+-a always,exit -F arch=b64 -S lchown -F auid>=500 -F auid!=4294967295 -k my_chown
+-a always,exit -F arch=b32 -S lchown -F auid>=500 -F auid!=4294967295 -k my_chown
 
--a exit,always -F arch=b64 -S fchownat -F auid>=500 -F auid!=4294967295 -k my_chown
--a exit,always -F arch=b32 -S fchownat -F auid>=500 -F auid!=4294967295 -k my_chown
+-a always,exit -F arch=b64 -S fchownat -F auid>=500 -F auid!=4294967295 -k my_chown
+-a always,exit -F arch=b32 -S fchownat -F auid>=500 -F auid!=4294967295 -k my_chown
 
--a exit,always -F arch=b64 -S chmod -F auid>=500 -F auid!=4294967295 -k my_chmod
--a exit,always -F arch=b32 -S chmod -F auid>=500 -F auid!=4294967295 -k my_chmod
+-a always,exit -F arch=b64 -S chmod -F auid>=500 -F auid!=4294967295 -k my_chmod
+-a always,exit -F arch=b32 -S chmod -F auid>=500 -F auid!=4294967295 -k my_chmod
 
--a exit,always -F arch=b64 -S fchmod -F auid>=500 -F auid!=4294967295 -k my_chmod
--a exit,always -F arch=b32 -S fchmod -F auid>=500 -F auid!=4294967295 -k my_chmod
+-a always,exit -F arch=b64 -S fchmod -F auid>=500 -F auid!=4294967295 -k my_chmod
+-a always,exit -F arch=b32 -S fchmod -F auid>=500 -F auid!=4294967295 -k my_chmod
 
--a exit,always -F arch=b64 -S fchmodat -F auid>=500 -F auid!=4294967295 -k my_chmod
--a exit,always -F arch=b32 -S fchmodat -F auid>=500 -F auid!=4294967295 -k my_chmod
+-a always,exit -F arch=b64 -S fchmodat -F auid>=500 -F auid!=4294967295 -k my_chmod
+-a always,exit -F arch=b32 -S fchmodat -F auid>=500 -F auid!=4294967295 -k my_chmod
 
--a exit,always -F arch=b64 -S setxattr -F auid>=500 -F auid!=4294967295 -k my_attr
--a exit,always -F arch=b32 -S setxattr -F auid>=500 -F auid!=4294967295 -k my_attr
+-a always,exit -F arch=b64 -S setxattr -F auid>=500 -F auid!=4294967295 -k my_attr
+-a always,exit -F arch=b32 -S setxattr -F auid>=500 -F auid!=4294967295 -k my_attr
 
--a exit,always -F arch=b64 -S fsetxattr -F auid>=500 -F auid!=4294967295 -k my_attr
--a exit,always -F arch=b32 -S fsetxattr -F auid>=500 -F auid!=4294967295 -k my_attr
+-a always,exit -F arch=b64 -S fsetxattr -F auid>=500 -F auid!=4294967295 -k my_attr
+-a always,exit -F arch=b32 -S fsetxattr -F auid>=500 -F auid!=4294967295 -k my_attr
 
--a exit,always -F arch=b64 -S lsetxattr -F auid>=500 -F auid!=4294967295 -k my_attr
--a exit,always -F arch=b32 -S lsetxattr -F auid>=500 -F auid!=4294967295 -k my_attr
+-a always,exit -F arch=b64 -S lsetxattr -F auid>=500 -F auid!=4294967295 -k my_attr
+-a always,exit -F arch=b32 -S lsetxattr -F auid>=500 -F auid!=4294967295 -k my_attr
 
--a exit,always -F arch=b64 -S removexattr -F auid>=500 -F auid!=4294967295 -k my_attr
--a exit,always -F arch=b32 -S removexattr -F auid>=500 -F auid!=4294967295 -k my_attr
+-a always,exit -F arch=b64 -S removexattr -F auid>=500 -F auid!=4294967295 -k my_attr
+-a always,exit -F arch=b32 -S removexattr -F auid>=500 -F auid!=4294967295 -k my_attr
 
--a exit,always -F arch=b64 -S fremovexattr -F auid>=500 -F auid!=4294967295 -k my_attr
--a exit,always -F arch=b32 -S fremovexattr -F auid>=500 -F auid!=4294967295 -k my_attr
+-a always,exit -F arch=b64 -S fremovexattr -F auid>=500 -F auid!=4294967295 -k my_attr
+-a always,exit -F arch=b32 -S fremovexattr -F auid>=500 -F auid!=4294967295 -k my_attr
 
--a exit,always -F arch=b64 -S lremovexattr -F auid>=500 -F auid!=4294967295 -k my_attr
--a exit,always -F arch=b32 -S lremovexattr -F auid>=500 -F auid!=4294967295 -k my_attr
+-a always,exit -F arch=b64 -S lremovexattr -F auid>=500 -F auid!=4294967295 -k my_attr
+-a always,exit -F arch=b32 -S lremovexattr -F auid>=500 -F auid!=4294967295 -k my_attr
 
 ## Audit rename/removal operations
--a exit,always -F arch=b64 -S rename -F perm=x -F auid>=500 -F auid!=4294967295 -k my_rename_remove
--a exit,always -F arch=b32 -S rename -F perm=x -F auid>=500 -F auid!=4294967295 -k my_rename_remove
+-a always,exit -F arch=b64 -S rename -F perm=x -F auid>=500 -F auid!=4294967295 -k my_rename_remove
+-a always,exit -F arch=b32 -S rename -F perm=x -F auid>=500 -F auid!=4294967295 -k my_rename_remove
 
--a exit,always -F arch=b64 -S renameat -F perm=x -F auid>=500 -F auid!=4294967295 -k my_rename_remove
--a exit,always -F arch=b32 -S renameat -F perm=x -F auid>=500 -F auid!=4294967295 -k my_rename_remove
+-a always,exit -F arch=b64 -S renameat -F perm=x -F auid>=500 -F auid!=4294967295 -k my_rename_remove
+-a always,exit -F arch=b32 -S renameat -F perm=x -F auid>=500 -F auid!=4294967295 -k my_rename_remove
 
--a exit,always -F arch=b64 -S rmdir -F perm=x -F auid>=500 -F auid!=4294967295 -k my_rename_remove
--a exit,always -F arch=b32 -S rmdir -F perm=x -F auid>=500 -F auid!=4294967295 -k my_rename_remove
+-a always,exit -F arch=b64 -S rmdir -F perm=x -F auid>=500 -F auid!=4294967295 -k my_rename_remove
+-a always,exit -F arch=b32 -S rmdir -F perm=x -F auid>=500 -F auid!=4294967295 -k my_rename_remove
 
--a exit,always -F arch=b64 -S unlink -F perm=x -F auid>=500 -F auid!=4294967295 -k my_rename_remove
--a exit,always -F arch=b32 -S unlink -F perm=x -F auid>=500 -F auid!=4294967295 -k my_rename_remove
+-a always,exit -F arch=b64 -S unlink -F perm=x -F auid>=500 -F auid!=4294967295 -k my_rename_remove
+-a always,exit -F arch=b32 -S unlink -F perm=x -F auid>=500 -F auid!=4294967295 -k my_rename_remove
 
--a exit,always -F arch=b64 -S unlinkat -F perm=x -F auid>=500 -F auid!=4294967295 -k my_rename_remove
--a exit,always -F arch=b32 -S unlinkat -F perm=x -F auid>=500 -F auid!=4294967295 -k my_rename_remove
+-a always,exit -F arch=b64 -S unlinkat -F perm=x -F auid>=500 -F auid!=4294967295 -k my_rename_remove
+-a always,exit -F arch=b32 -S unlinkat -F perm=x -F auid>=500 -F auid!=4294967295 -k my_rename_remove
 
 ## Audit the execution of suid and sgid binaries.
--a exit,always -F path=/bin/cgclassify -F perm=x -F auid>=500 -F auid!=4294967295 -k my_suid_sgid
--a exit,always -F path=/bin/cgexec -F perm=x -F auid>=500 -F auid!=4294967295 -k my_suid_sgid
--a exit,always -F path=/bin/ping -F perm=x -F auid>=500 -F auid!=4294967295 -k my_suid_sgid
--a exit,always -F path=/bin/ping6 -F perm=x -F auid>=500 -F auid!=4294967295 -k my_suid_sgid
--a exit,always -F path=/sbin/mount.nfs -F perm=x -F auid>=500 -F auid!=4294967295 -k my_suid_sgid
--a exit,always -F path=/sbin/netreport -F perm=x -F auid>=500 -F auid!=4294967295 -k my_suid_sgid
--a exit,always -F path=/usr/bin/at -F perm=x -F auid>=500 -F auid!=4294967295 -k my_suid_sgid
--a exit,always -F path=/usr/bin/chage -F perm=x -F auid>=500 -F auid!=4294967295 -k my_suid_sgid
--a exit,always -F path=/usr/bin/chcon -F perm=x -F auid>=500 -F auid!=4294967295 -k my_suid_sgid
--a exit,always -F path=/usr/bin/chfn -F perm=x -F auid>=500 -F auid!=4294967295 -k my_suid_sgid
--a exit,always -F path=/usr/bin/chsh -F perm=x -F auid>=500 -F auid!=4294967295 -k my_suid_sgid
--a exit,always -F path=/usr/bin/crontab -F perm=x -F auid>=500 -F auid!=4294967295 -k my_suid_sgid
--a exit,always -F path=/usr/bin/fusermount -F perm=x -F auid>=500 -F auid!=4294967295 -k my_suid_sgid
--a exit,always -F path=/usr/bin/gpasswd -F perm=x -F auid>=500 -F auid!=4294967295 -k my_suid_sgid
--a exit,always -F path=/usr/bin/incrontab -F perm=x -F auid>=500 -F auid!=4294967295 -k my_suid_sgid
--a exit,always -F path=/usr/bin/ksu -F perm=x -F auid>=500 -F auid!=4294967295 -k my_suid_sgid
--a exit,always -F path=/usr/bin/locate -F perm=x -F auid>=500 -F auid!=4294967295 -k my_suid_sgid
--a exit,always -F path=/usr/bin/mount -F perm=x -F auid>=500 -F auid!=4294967295 -k my_suid_sgid
--a exit,always -F path=/usr/bin/newgidmap -F perm=x -F auid>=500 -F auid!=4294967295 -k my_suid_sgid
--a exit,always -F path=/usr/bin/newgrp -F perm=x -F auid>=500 -F auid!=4294967295 -k my_suid_sgid
--a exit,always -F path=/usr/bin/newuidmap -F perm=x -F auid>=500 -F auid!=4294967295 -k my_suid_sgid
--a exit,always -F path=/usr/bin/passwd -F perm=x -F auid>=500 -F auid!=4294967295 -k my_suid_sgid
--a exit,always -F path=/usr/bin/pkexec -F perm=x -F auid>=500 -F auid!=4294967295 -k my_suid_sgid
--a exit,always -F path=/usr/bin/screen -F perm=x -F auid>=500 -F auid!=4294967295 -k my_suid_sgid
--a exit,always -F path=/usr/bin/ssh-agent -F perm=x -F auid>=500 -F auid!=4294967295 -k my_suid_sgid
--a exit,always -F path=/usr/bin/su -F perm=x -F auid>=500 -F auid!=4294967295 -k my_suid_sgid
--a exit,always -F path=/usr/bin/sudo -F perm=x -F auid>=500 -F auid!=4294967295 -k my_suid_sgid
--a exit,always -F path=/usr/bin/sudoedit -F perm=x -F auid>=500 -F auid!=4294967295 -k my_suid_sgid
--a exit,always -F path=/usr/bin/umount -F perm=x -F auid>=500 -F auid!=4294967295 -k my_suid_sgid
--a exit,always -F path=/usr/bin/wall -F perm=x -F auid>=500 -F auid!=4294967295 -k my_suid_sgid
--a exit,always -F path=/usr/bin/write -F perm=x -F auid>=500 -F auid!=4294967295 -k my_suid_sgid
--a exit,always -F path=/usr/bin/Xorg -F perm=x -F auid>=500 -F auid!=4294967295 -k my_suid_sgid
--a exit,always -F path=/usr/libexec/dbus-1/dbus-daemon-launch-helper -F perm=x -F auid>=500 -F auid!=4294967295 -k my_suid_sgid
--a exit,always -F path=/usr/libexec/openssh/ssh-keysign -F perm=x -F auid>=500 -F auid!=4294967295 -k my_suid_sgid
--a exit,always -F path=/usr/libexec/polkit-1/polkit-agent-helper-1 -F perm=x -F auid>=500 -F auid!=4294967295 -k my_suid_sgid
--a exit,always -F path=/usr/libexec/pt_chown -F perm=x -F auid>=500 -F auid!=4294967295 -k my_suid_sgid
--a exit,always -F path=/usr/libexec/utempter/utempter -F perm=x -F auid>=500 -F auid!=4294967295 -k my_suid_sgid
--a exit,always -F path=/usr/sbin/pam_timestamp_check -F perm=x -F auid>=500 -F auid!=4294967295 -k my_suid_sgid
--a exit,always -F path=/usr/sbin/postdrop -F perm=x -F auid>=500 -F auid!=4294967295 -k my_suid_sgid
--a exit,always -F path=/usr/sbin/postqueue -F perm=x -F auid>=500 -F auid!=4294967295 -k my_suid_sgid
--a exit,always -F path=/usr/sbin/restorecon -F perm=x -F auid>=500 -F auid!=4294967295 -k my_suid_sgid
--a exit,always -F path=/usr/sbin/semanage -F perm=x -F auid>=500 -F auid!=4294967295 -k my_suid_sgid
--a exit,always -F path=/usr/sbin/setfiles -F perm=x -F auid>=500 -F auid!=4294967295 -k my_suid_sgid
--a exit,always -F path=/usr/sbin/setsebool -F perm=x -F auid>=500 -F auid!=4294967295 -k my_suid_sgid
--a exit,always -F path=/usr/sbin/seunshare -F perm=x -F auid>=500 -F auid!=4294967295 -k my_suid_sgid
--a exit,always -F path=/usr/sbin/suexec -F perm=x -F auid>=500 -F auid!=4294967295 -k my_suid_sgid
--a exit,always -F path=/usr/sbin/unix_chkpwd -F perm=x -F auid>=500 -F auid!=4294967295 -k my_suid_sgid
--a exit,always -F path=/usr/sbin/userhelper -F perm=x -F auid>=500 -F auid!=4294967295 -k my_suid_sgid
--a exit,always -F path=/usr/sbin/usernetctl -F perm=x -F auid>=500 -F auid!=4294967295 -k my_suid_sgid
+-a always,exit -F path=/bin/cgclassify -F perm=x -F auid>=500 -F auid!=4294967295 -k my_suid_sgid
+-a always,exit -F path=/bin/cgexec -F perm=x -F auid>=500 -F auid!=4294967295 -k my_suid_sgid
+-a always,exit -F path=/bin/ping -F perm=x -F auid>=500 -F auid!=4294967295 -k my_suid_sgid
+-a always,exit -F path=/bin/ping6 -F perm=x -F auid>=500 -F auid!=4294967295 -k my_suid_sgid
+-a always,exit -F path=/sbin/mount.nfs -F perm=x -F auid>=500 -F auid!=4294967295 -k my_suid_sgid
+-a always,exit -F path=/sbin/netreport -F perm=x -F auid>=500 -F auid!=4294967295 -k my_suid_sgid
+-a always,exit -F path=/usr/bin/at -F perm=x -F auid>=500 -F auid!=4294967295 -k my_suid_sgid
+-a always,exit -F path=/usr/bin/chage -F perm=x -F auid>=500 -F auid!=4294967295 -k my_suid_sgid
+-a always,exit -F path=/usr/bin/chcon -F perm=x -F auid>=500 -F auid!=4294967295 -k my_suid_sgid
+-a always,exit -F path=/usr/bin/chfn -F perm=x -F auid>=500 -F auid!=4294967295 -k my_suid_sgid
+-a always,exit -F path=/usr/bin/chsh -F perm=x -F auid>=500 -F auid!=4294967295 -k my_suid_sgid
+-a always,exit -F path=/usr/bin/crontab -F perm=x -F auid>=500 -F auid!=4294967295 -k my_suid_sgid
+-a always,exit -F path=/usr/bin/fusermount -F perm=x -F auid>=500 -F auid!=4294967295 -k my_suid_sgid
+-a always,exit -F path=/usr/bin/gpasswd -F perm=x -F auid>=500 -F auid!=4294967295 -k my_suid_sgid
+-a always,exit -F path=/usr/bin/incrontab -F perm=x -F auid>=500 -F auid!=4294967295 -k my_suid_sgid
+-a always,exit -F path=/usr/bin/ksu -F perm=x -F auid>=500 -F auid!=4294967295 -k my_suid_sgid
+-a always,exit -F path=/usr/bin/locate -F perm=x -F auid>=500 -F auid!=4294967295 -k my_suid_sgid
+-a always,exit -F path=/usr/bin/mount -F perm=x -F auid>=500 -F auid!=4294967295 -k my_suid_sgid
+-a always,exit -F path=/usr/bin/newgidmap -F perm=x -F auid>=500 -F auid!=4294967295 -k my_suid_sgid
+-a always,exit -F path=/usr/bin/newgrp -F perm=x -F auid>=500 -F auid!=4294967295 -k my_suid_sgid
+-a always,exit -F path=/usr/bin/newuidmap -F perm=x -F auid>=500 -F auid!=4294967295 -k my_suid_sgid
+-a always,exit -F path=/usr/bin/passwd -F perm=x -F auid>=500 -F auid!=4294967295 -k my_suid_sgid
+-a always,exit -F path=/usr/bin/pkexec -F perm=x -F auid>=500 -F auid!=4294967295 -k my_suid_sgid
+-a always,exit -F path=/usr/bin/screen -F perm=x -F auid>=500 -F auid!=4294967295 -k my_suid_sgid
+-a always,exit -F path=/usr/bin/ssh-agent -F perm=x -F auid>=500 -F auid!=4294967295 -k my_suid_sgid
+-a always,exit -F path=/usr/bin/su -F perm=x -F auid>=500 -F auid!=4294967295 -k my_suid_sgid
+-a always,exit -F path=/usr/bin/sudo -F perm=x -F auid>=500 -F auid!=4294967295 -k my_suid_sgid
+-a always,exit -F path=/usr/bin/sudoedit -F perm=x -F auid>=500 -F auid!=4294967295 -k my_suid_sgid
+-a always,exit -F path=/usr/bin/umount -F perm=x -F auid>=500 -F auid!=4294967295 -k my_suid_sgid
+-a always,exit -F path=/usr/bin/wall -F perm=x -F auid>=500 -F auid!=4294967295 -k my_suid_sgid
+-a always,exit -F path=/usr/bin/write -F perm=x -F auid>=500 -F auid!=4294967295 -k my_suid_sgid
+-a always,exit -F path=/usr/bin/Xorg -F perm=x -F auid>=500 -F auid!=4294967295 -k my_suid_sgid
+-a always,exit -F path=/usr/libexec/dbus-1/dbus-daemon-launch-helper -F perm=x -F auid>=500 -F auid!=4294967295 -k my_suid_sgid
+-a always,exit -F path=/usr/libexec/openssh/ssh-keysign -F perm=x -F auid>=500 -F auid!=4294967295 -k my_suid_sgid
+-a always,exit -F path=/usr/libexec/polkit-1/polkit-agent-helper-1 -F perm=x -F auid>=500 -F auid!=4294967295 -k my_suid_sgid
+-a always,exit -F path=/usr/libexec/pt_chown -F perm=x -F auid>=500 -F auid!=4294967295 -k my_suid_sgid
+-a always,exit -F path=/usr/libexec/utempter/utempter -F perm=x -F auid>=500 -F auid!=4294967295 -k my_suid_sgid
+-a always,exit -F path=/usr/sbin/pam_timestamp_check -F perm=x -F auid>=500 -F auid!=4294967295 -k my_suid_sgid
+-a always,exit -F path=/usr/sbin/postdrop -F perm=x -F auid>=500 -F auid!=4294967295 -k my_suid_sgid
+-a always,exit -F path=/usr/sbin/postqueue -F perm=x -F auid>=500 -F auid!=4294967295 -k my_suid_sgid
+-a always,exit -F path=/usr/sbin/restorecon -F perm=x -F auid>=500 -F auid!=4294967295 -k my_suid_sgid
+-a always,exit -F path=/usr/sbin/semanage -F perm=x -F auid>=500 -F auid!=4294967295 -k my_suid_sgid
+-a always,exit -F path=/usr/sbin/setfiles -F perm=x -F auid>=500 -F auid!=4294967295 -k my_suid_sgid
+-a always,exit -F path=/usr/sbin/setsebool -F perm=x -F auid>=500 -F auid!=4294967295 -k my_suid_sgid
+-a always,exit -F path=/usr/sbin/seunshare -F perm=x -F auid>=500 -F auid!=4294967295 -k my_suid_sgid
+-a always,exit -F path=/usr/sbin/suexec -F perm=x -F auid>=500 -F auid!=4294967295 -k my_suid_sgid
+-a always,exit -F path=/usr/sbin/unix_chkpwd -F perm=x -F auid>=500 -F auid!=4294967295 -k my_suid_sgid
+-a always,exit -F path=/usr/sbin/userhelper -F perm=x -F auid>=500 -F auid!=4294967295 -k my_suid_sgid
+-a always,exit -F path=/usr/sbin/usernetctl -F perm=x -F auid>=500 -F auid!=4294967295 -k my_suid_sgid
 
 ## Audit the loading and unloading of kernel modules.
 -w /sbin/insmod -p x -F auid!=4294967295 -k my_kernel_modules
@@ -192,25 +192,25 @@
 
 -w /sbin/modprobe -p x -F auid!=4294967295 -k my_kernel_modules
 
--a exit,always -F arch=b64 -S create_module -k my_kernel_modules
--a exit,always -F arch=b32 -S create_module -k my_kernel_modules
+-a always,exit -F arch=b64 -S create_module -k my_kernel_modules
+-a always,exit -F arch=b32 -S create_module -k my_kernel_modules
 
--a exit,always -F arch=b64 -S init_module -k my_kernel_modules
--a exit,always -F arch=b32 -S init_module -k my_kernel_modules
+-a always,exit -F arch=b64 -S init_module -k my_kernel_modules
+-a always,exit -F arch=b32 -S init_module -k my_kernel_modules
 
--a exit,always -F arch=b64 -S finit_module -k my_kernel_modules
--a exit,always -F arch=b32 -S finit_module -k my_kernel_modules
+-a always,exit -F arch=b64 -S finit_module -k my_kernel_modules
+-a always,exit -F arch=b32 -S finit_module -k my_kernel_modules
 
--a exit,always -F arch=b64 -S delete_module -k my_kernel_modules
--a exit,always -F arch=b32 -S delete_module -k my_kernel_modules
+-a always,exit -F arch=b64 -S delete_module -k my_kernel_modules
+-a always,exit -F arch=b32 -S delete_module -k my_kernel_modules
 
 ## Audit mount operations
--a exit,always -F arch=b64 -S mount -F auid>=500 -F auid!=4294967295 -k my_mount
--a exit,always -F arch=b64 -F path=/bin/mount -F auid>=500 -F auid!=4294967295 -k my_mount
--a exit,always -F arch=b32 -S mount -F auid>=500 -F auid!=4294967295 -k my_mount
--a exit,always -F arch=b32 -F path=/bin/mount -F auid>=500 -F auid!=4294967295 -k my_mount
+-a always,exit -F arch=b64 -S mount -F auid>=500 -F auid!=4294967295 -k my_mount
+-a always,exit -F arch=b64 -F path=/bin/mount -F auid>=500 -F auid!=4294967295 -k my_mount
+-a always,exit -F arch=b32 -S mount -F auid>=500 -F auid!=4294967295 -k my_mount
+-a always,exit -F arch=b32 -F path=/bin/mount -F auid>=500 -F auid!=4294967295 -k my_mount
 
--a exit,always -F path=/bin/umount -F perm=x -F auid>=500 -F auid!=4294967295 -k my_mount
+-a always,exit -F path=/bin/umount -F perm=x -F auid>=500 -F auid!=4294967295 -k my_mount
 
 ## Audit local accounts
 -w /etc/passwd -p wa -k my_local_account

--- a/spec/classes/config/audit_profiles/expected/stig_el6_base_rules.txt
+++ b/spec/classes/config/audit_profiles/expected/stig_el6_base_rules.txt
@@ -1,189 +1,189 @@
 #### auditd::config::audit_profiles::stig Audit Rules ####
 
 ## Audit unsuccessful file operations
--a exit,always -F arch=b64 -S creat -F exit=-EPERM -F auid>=500 -F auid!=4294967295 -k access
--a exit,always -F arch=b64 -S creat -F exit=-EACCES -F auid>=500 -F auid!=4294967295 -k access
--a exit,always -F arch=b32 -S creat -F exit=-EPERM -F auid>=500 -F auid!=4294967295 -k access
--a exit,always -F arch=b32 -S creat -F exit=-EACCES -F auid>=500 -F auid!=4294967295 -k access
+-a always,exit -F arch=b64 -S creat -F exit=-EPERM -F auid>=500 -F auid!=4294967295 -k access
+-a always,exit -F arch=b64 -S creat -F exit=-EACCES -F auid>=500 -F auid!=4294967295 -k access
+-a always,exit -F arch=b32 -S creat -F exit=-EPERM -F auid>=500 -F auid!=4294967295 -k access
+-a always,exit -F arch=b32 -S creat -F exit=-EACCES -F auid>=500 -F auid!=4294967295 -k access
 
--a exit,always -F arch=b64 -S open -F exit=-EPERM -F auid>=500 -F auid!=4294967295 -k access
--a exit,always -F arch=b64 -S open -F exit=-EACCES -F auid>=500 -F auid!=4294967295 -k access
--a exit,always -F arch=b32 -S open -F exit=-EPERM -F auid>=500 -F auid!=4294967295 -k access
--a exit,always -F arch=b32 -S open -F exit=-EACCES -F auid>=500 -F auid!=4294967295 -k access
+-a always,exit -F arch=b64 -S open -F exit=-EPERM -F auid>=500 -F auid!=4294967295 -k access
+-a always,exit -F arch=b64 -S open -F exit=-EACCES -F auid>=500 -F auid!=4294967295 -k access
+-a always,exit -F arch=b32 -S open -F exit=-EPERM -F auid>=500 -F auid!=4294967295 -k access
+-a always,exit -F arch=b32 -S open -F exit=-EACCES -F auid>=500 -F auid!=4294967295 -k access
 
--a exit,always -F arch=b64 -S openat -F exit=-EPERM -F auid>=500 -F auid!=4294967295 -k access
--a exit,always -F arch=b64 -S openat -F exit=-EACCES -F auid>=500 -F auid!=4294967295 -k access
--a exit,always -F arch=b32 -S openat -F exit=-EPERM -F auid>=500 -F auid!=4294967295 -k access
--a exit,always -F arch=b32 -S openat -F exit=-EACCES -F auid>=500 -F auid!=4294967295 -k access
+-a always,exit -F arch=b64 -S openat -F exit=-EPERM -F auid>=500 -F auid!=4294967295 -k access
+-a always,exit -F arch=b64 -S openat -F exit=-EACCES -F auid>=500 -F auid!=4294967295 -k access
+-a always,exit -F arch=b32 -S openat -F exit=-EPERM -F auid>=500 -F auid!=4294967295 -k access
+-a always,exit -F arch=b32 -S openat -F exit=-EACCES -F auid>=500 -F auid!=4294967295 -k access
 
--a exit,always -F arch=b64 -S open_by_handle_at -F exit=-EPERM -F auid>=500 -F auid!=4294967295 -k access
--a exit,always -F arch=b64 -S open_by_handle_at -F exit=-EACCES -F auid>=500 -F auid!=4294967295 -k access
--a exit,always -F arch=b32 -S open_by_handle_at -F exit=-EPERM -F auid>=500 -F auid!=4294967295 -k access
--a exit,always -F arch=b32 -S open_by_handle_at -F exit=-EACCES -F auid>=500 -F auid!=4294967295 -k access
+-a always,exit -F arch=b64 -S open_by_handle_at -F exit=-EPERM -F auid>=500 -F auid!=4294967295 -k access
+-a always,exit -F arch=b64 -S open_by_handle_at -F exit=-EACCES -F auid>=500 -F auid!=4294967295 -k access
+-a always,exit -F arch=b32 -S open_by_handle_at -F exit=-EPERM -F auid>=500 -F auid!=4294967295 -k access
+-a always,exit -F arch=b32 -S open_by_handle_at -F exit=-EACCES -F auid>=500 -F auid!=4294967295 -k access
 
--a exit,always -F arch=b64 -S truncate -F exit=-EPERM -F auid>=500 -F auid!=4294967295 -k access
--a exit,always -F arch=b64 -S truncate -F exit=-EACCES -F auid>=500 -F auid!=4294967295 -k access
--a exit,always -F arch=b32 -S truncate -F exit=-EPERM -F auid>=500 -F auid!=4294967295 -k access
--a exit,always -F arch=b32 -S truncate -F exit=-EACCES -F auid>=500 -F auid!=4294967295 -k access
+-a always,exit -F arch=b64 -S truncate -F exit=-EPERM -F auid>=500 -F auid!=4294967295 -k access
+-a always,exit -F arch=b64 -S truncate -F exit=-EACCES -F auid>=500 -F auid!=4294967295 -k access
+-a always,exit -F arch=b32 -S truncate -F exit=-EPERM -F auid>=500 -F auid!=4294967295 -k access
+-a always,exit -F arch=b32 -S truncate -F exit=-EACCES -F auid>=500 -F auid!=4294967295 -k access
 
--a exit,always -F arch=b64 -S ftruncate -F exit=-EPERM -F auid>=500 -F auid!=4294967295 -k access
--a exit,always -F arch=b64 -S ftruncate -F exit=-EACCES -F auid>=500 -F auid!=4294967295 -k access
--a exit,always -F arch=b32 -S ftruncate -F exit=-EPERM -F auid>=500 -F auid!=4294967295 -k access
--a exit,always -F arch=b32 -S ftruncate -F exit=-EACCES -F auid>=500 -F auid!=4294967295 -k access
+-a always,exit -F arch=b64 -S ftruncate -F exit=-EPERM -F auid>=500 -F auid!=4294967295 -k access
+-a always,exit -F arch=b64 -S ftruncate -F exit=-EACCES -F auid>=500 -F auid!=4294967295 -k access
+-a always,exit -F arch=b32 -S ftruncate -F exit=-EPERM -F auid>=500 -F auid!=4294967295 -k access
+-a always,exit -F arch=b32 -S ftruncate -F exit=-EACCES -F auid>=500 -F auid!=4294967295 -k access
 
 ## Audit the execution of password commands
--a exit,always -F path=/usr/bin/passwd -F perm=x -F auid>=500 -F auid!=4294967295 -k privileged-passwd
+-a always,exit -F path=/usr/bin/passwd -F perm=x -F auid>=500 -F auid!=4294967295 -k privileged-passwd
 
--a exit,always -F path=/sbin/unix_chkpwd -F perm=x -F auid>=500 -F auid!=4294967295 -k privileged-passwd
+-a always,exit -F path=/sbin/unix_chkpwd -F perm=x -F auid>=500 -F auid!=4294967295 -k privileged-passwd
 
--a exit,always -F path=/usr/bin/gpasswd -F perm=x -F auid>=500 -F auid!=4294967295 -k privileged-passwd
+-a always,exit -F path=/usr/bin/gpasswd -F perm=x -F auid>=500 -F auid!=4294967295 -k privileged-passwd
 
--a exit,always -F path=/usr/bin/chage -F perm=x -F auid>=500 -F auid!=4294967295 -k privileged-passwd
+-a always,exit -F path=/usr/bin/chage -F perm=x -F auid>=500 -F auid!=4294967295 -k privileged-passwd
 
--a exit,always -F path=/usr/sbin/userhelper -F perm=x -F auid>=500 -F auid!=4294967295 -k privileged-passwd
+-a always,exit -F path=/usr/sbin/userhelper -F perm=x -F auid>=500 -F auid!=4294967295 -k privileged-passwd
 
 ## Audit the execution of privilege-related commands
--a exit,always -F path=/bin/su -F perm=x -F auid>=500 -F auid!=4294967295 -k privileged-priv_change
+-a always,exit -F path=/bin/su -F perm=x -F auid>=500 -F auid!=4294967295 -k privileged-priv_change
 
--a exit,always -F path=/usr/bin/sudo -F perm=x -F auid>=500 -F auid!=4294967295 -k privileged-priv_change
+-a always,exit -F path=/usr/bin/sudo -F perm=x -F auid>=500 -F auid!=4294967295 -k privileged-priv_change
 
--a exit,always -F path=/usr/bin/newgrp -F perm=x -F auid>=500 -F auid!=4294967295 -k privileged-priv_change
+-a always,exit -F path=/usr/bin/newgrp -F perm=x -F auid>=500 -F auid!=4294967295 -k privileged-priv_change
 
--a exit,always -F path=/usr/bin/chsh -F perm=x -F auid>=500 -F auid!=4294967295 -k privileged-priv_change
+-a always,exit -F path=/usr/bin/chsh -F perm=x -F auid>=500 -F auid!=4294967295 -k privileged-priv_change
 
--a exit,always -F path=/usr/bin/sudoedit -F perm=x -F auid>=500 -F auid!=4294967295 -k privileged-priv_change
+-a always,exit -F path=/usr/bin/sudoedit -F perm=x -F auid>=500 -F auid!=4294967295 -k privileged-priv_change
 
 ## Audit the execution of postfix-related commands
--a exit,always -F path=/usr/sbin/postdrop -F perm=x -F auid>=500 -F auid!=4294967295 -k privileged-postfix
+-a always,exit -F path=/usr/sbin/postdrop -F perm=x -F auid>=500 -F auid!=4294967295 -k privileged-postfix
 
--a exit,always -F path=/usr/sbin/postqueue -F perm=x -F auid>=500 -F auid!=4294967295 -k privileged-postfix
+-a always,exit -F path=/usr/sbin/postqueue -F perm=x -F auid>=500 -F auid!=4294967295 -k privileged-postfix
 
 ## Audit the execution of the ssh-keysign command
--a exit,always -F path=/usr/libexec/openssh/ssh-keysign -F perm=x -F auid>=500 -F auid!=4294967295 -k privileged-ssh
+-a always,exit -F path=/usr/libexec/openssh/ssh-keysign -F perm=x -F auid>=500 -F auid!=4294967295 -k privileged-ssh
 
 ## Audit the execution of the crontab command
--a exit,always -F path=/usr/bin/crontab -F perm=x -F auid>=500 -F auid!=4294967295 -k privileged-cron
+-a always,exit -F path=/usr/bin/crontab -F perm=x -F auid>=500 -F auid!=4294967295 -k privileged-cron
 
 ## Audit the execution of the pam_timestamp_check command
--a exit,always -F path=/sbin/pam_timestamp_check -F perm=x -F auid>=500 -F auid!=4294967295 -k privileged-pam
+-a always,exit -F path=/sbin/pam_timestamp_check -F perm=x -F auid>=500 -F auid!=4294967295 -k privileged-pam
 
 ## Audit selinux commands
--a exit,always -F path=/usr/sbin/semanage -F perm=x -F auid>=500 -F auid!=4294967295 -k privileged-priv_change
+-a always,exit -F path=/usr/sbin/semanage -F perm=x -F auid>=500 -F auid!=4294967295 -k privileged-priv_change
 
--a exit,always -F path=/usr/sbin/setsebool -F perm=x -F auid>=500 -F auid!=4294967295 -k privileged-priv_change
+-a always,exit -F path=/usr/sbin/setsebool -F perm=x -F auid>=500 -F auid!=4294967295 -k privileged-priv_change
 
--a exit,always -F path=/usr/bin/chcon -F perm=x -F auid>=500 -F auid!=4294967295 -k privileged-priv_change
+-a always,exit -F path=/usr/bin/chcon -F perm=x -F auid>=500 -F auid!=4294967295 -k privileged-priv_change
 
--a exit,always -F path=/sbin/setfiles -F perm=x -F auid>=500 -F auid!=4294967295 -k privileged-priv_change
+-a always,exit -F path=/sbin/setfiles -F perm=x -F auid>=500 -F auid!=4294967295 -k privileged-priv_change
 
--a exit,always -F path=/sbin/restorecon -F perm=x -F auid>=500 -F auid!=4294967295 -k privileged-priv_change
+-a always,exit -F path=/sbin/restorecon -F perm=x -F auid>=500 -F auid!=4294967295 -k privileged-priv_change
 
 ## Permissions auditing separated by chown, chmod, and attr
--a exit,always -F arch=b64 -S chown -F auid>=500 -F auid!=4294967295 -k perm_mod
--a exit,always -F arch=b32 -S chown -F auid>=500 -F auid!=4294967295 -k perm_mod
+-a always,exit -F arch=b64 -S chown -F auid>=500 -F auid!=4294967295 -k perm_mod
+-a always,exit -F arch=b32 -S chown -F auid>=500 -F auid!=4294967295 -k perm_mod
 
--a exit,always -F arch=b64 -S fchown -F auid>=500 -F auid!=4294967295 -k perm_mod
--a exit,always -F arch=b32 -S fchown -F auid>=500 -F auid!=4294967295 -k perm_mod
+-a always,exit -F arch=b64 -S fchown -F auid>=500 -F auid!=4294967295 -k perm_mod
+-a always,exit -F arch=b32 -S fchown -F auid>=500 -F auid!=4294967295 -k perm_mod
 
--a exit,always -F arch=b64 -S lchown -F auid>=500 -F auid!=4294967295 -k perm_mod
--a exit,always -F arch=b32 -S lchown -F auid>=500 -F auid!=4294967295 -k perm_mod
+-a always,exit -F arch=b64 -S lchown -F auid>=500 -F auid!=4294967295 -k perm_mod
+-a always,exit -F arch=b32 -S lchown -F auid>=500 -F auid!=4294967295 -k perm_mod
 
--a exit,always -F arch=b64 -S fchownat -F auid>=500 -F auid!=4294967295 -k perm_mod
--a exit,always -F arch=b32 -S fchownat -F auid>=500 -F auid!=4294967295 -k perm_mod
+-a always,exit -F arch=b64 -S fchownat -F auid>=500 -F auid!=4294967295 -k perm_mod
+-a always,exit -F arch=b32 -S fchownat -F auid>=500 -F auid!=4294967295 -k perm_mod
 
--a exit,always -F arch=b64 -S chmod -F auid>=500 -F auid!=4294967295 -k perm_mod
--a exit,always -F arch=b32 -S chmod -F auid>=500 -F auid!=4294967295 -k perm_mod
+-a always,exit -F arch=b64 -S chmod -F auid>=500 -F auid!=4294967295 -k perm_mod
+-a always,exit -F arch=b32 -S chmod -F auid>=500 -F auid!=4294967295 -k perm_mod
 
--a exit,always -F arch=b64 -S fchmod -F auid>=500 -F auid!=4294967295 -k perm_mod
--a exit,always -F arch=b32 -S fchmod -F auid>=500 -F auid!=4294967295 -k perm_mod
+-a always,exit -F arch=b64 -S fchmod -F auid>=500 -F auid!=4294967295 -k perm_mod
+-a always,exit -F arch=b32 -S fchmod -F auid>=500 -F auid!=4294967295 -k perm_mod
 
--a exit,always -F arch=b64 -S fchmodat -F auid>=500 -F auid!=4294967295 -k perm_mod
--a exit,always -F arch=b32 -S fchmodat -F auid>=500 -F auid!=4294967295 -k perm_mod
+-a always,exit -F arch=b64 -S fchmodat -F auid>=500 -F auid!=4294967295 -k perm_mod
+-a always,exit -F arch=b32 -S fchmodat -F auid>=500 -F auid!=4294967295 -k perm_mod
 
--a exit,always -F arch=b64 -S setxattr -F auid>=500 -F auid!=4294967295 -k perm_mod
--a exit,always -F arch=b32 -S setxattr -F auid>=500 -F auid!=4294967295 -k perm_mod
+-a always,exit -F arch=b64 -S setxattr -F auid>=500 -F auid!=4294967295 -k perm_mod
+-a always,exit -F arch=b32 -S setxattr -F auid>=500 -F auid!=4294967295 -k perm_mod
 
--a exit,always -F arch=b64 -S fsetxattr -F auid>=500 -F auid!=4294967295 -k perm_mod
--a exit,always -F arch=b32 -S fsetxattr -F auid>=500 -F auid!=4294967295 -k perm_mod
+-a always,exit -F arch=b64 -S fsetxattr -F auid>=500 -F auid!=4294967295 -k perm_mod
+-a always,exit -F arch=b32 -S fsetxattr -F auid>=500 -F auid!=4294967295 -k perm_mod
 
--a exit,always -F arch=b64 -S lsetxattr -F auid>=500 -F auid!=4294967295 -k perm_mod
--a exit,always -F arch=b32 -S lsetxattr -F auid>=500 -F auid!=4294967295 -k perm_mod
+-a always,exit -F arch=b64 -S lsetxattr -F auid>=500 -F auid!=4294967295 -k perm_mod
+-a always,exit -F arch=b32 -S lsetxattr -F auid>=500 -F auid!=4294967295 -k perm_mod
 
--a exit,always -F arch=b64 -S removexattr -F auid>=500 -F auid!=4294967295 -k perm_mod
--a exit,always -F arch=b32 -S removexattr -F auid>=500 -F auid!=4294967295 -k perm_mod
+-a always,exit -F arch=b64 -S removexattr -F auid>=500 -F auid!=4294967295 -k perm_mod
+-a always,exit -F arch=b32 -S removexattr -F auid>=500 -F auid!=4294967295 -k perm_mod
 
--a exit,always -F arch=b64 -S fremovexattr -F auid>=500 -F auid!=4294967295 -k perm_mod
--a exit,always -F arch=b32 -S fremovexattr -F auid>=500 -F auid!=4294967295 -k perm_mod
+-a always,exit -F arch=b64 -S fremovexattr -F auid>=500 -F auid!=4294967295 -k perm_mod
+-a always,exit -F arch=b32 -S fremovexattr -F auid>=500 -F auid!=4294967295 -k perm_mod
 
--a exit,always -F arch=b64 -S lremovexattr -F auid>=500 -F auid!=4294967295 -k perm_mod
--a exit,always -F arch=b32 -S lremovexattr -F auid>=500 -F auid!=4294967295 -k perm_mod
+-a always,exit -F arch=b64 -S lremovexattr -F auid>=500 -F auid!=4294967295 -k perm_mod
+-a always,exit -F arch=b32 -S lremovexattr -F auid>=500 -F auid!=4294967295 -k perm_mod
 
 ## Audit rename/removal operations
--a exit,always -F arch=b64 -S rename -F perm=x -F auid>=500 -F auid!=4294967295 -k delete
--a exit,always -F arch=b32 -S rename -F perm=x -F auid>=500 -F auid!=4294967295 -k delete
+-a always,exit -F arch=b64 -S rename -F perm=x -F auid>=500 -F auid!=4294967295 -k delete
+-a always,exit -F arch=b32 -S rename -F perm=x -F auid>=500 -F auid!=4294967295 -k delete
 
--a exit,always -F arch=b64 -S renameat -F perm=x -F auid>=500 -F auid!=4294967295 -k delete
--a exit,always -F arch=b32 -S renameat -F perm=x -F auid>=500 -F auid!=4294967295 -k delete
+-a always,exit -F arch=b64 -S renameat -F perm=x -F auid>=500 -F auid!=4294967295 -k delete
+-a always,exit -F arch=b32 -S renameat -F perm=x -F auid>=500 -F auid!=4294967295 -k delete
 
--a exit,always -F arch=b64 -S rmdir -F perm=x -F auid>=500 -F auid!=4294967295 -k delete
--a exit,always -F arch=b32 -S rmdir -F perm=x -F auid>=500 -F auid!=4294967295 -k delete
+-a always,exit -F arch=b64 -S rmdir -F perm=x -F auid>=500 -F auid!=4294967295 -k delete
+-a always,exit -F arch=b32 -S rmdir -F perm=x -F auid>=500 -F auid!=4294967295 -k delete
 
--a exit,always -F arch=b64 -S unlink -F perm=x -F auid>=500 -F auid!=4294967295 -k delete
--a exit,always -F arch=b32 -S unlink -F perm=x -F auid>=500 -F auid!=4294967295 -k delete
+-a always,exit -F arch=b64 -S unlink -F perm=x -F auid>=500 -F auid!=4294967295 -k delete
+-a always,exit -F arch=b32 -S unlink -F perm=x -F auid>=500 -F auid!=4294967295 -k delete
 
--a exit,always -F arch=b64 -S unlinkat -F perm=x -F auid>=500 -F auid!=4294967295 -k delete
--a exit,always -F arch=b32 -S unlinkat -F perm=x -F auid>=500 -F auid!=4294967295 -k delete
+-a always,exit -F arch=b64 -S unlinkat -F perm=x -F auid>=500 -F auid!=4294967295 -k delete
+-a always,exit -F arch=b32 -S unlinkat -F perm=x -F auid>=500 -F auid!=4294967295 -k delete
 
 ## Audit the execution of suid and sgid binaries.
--a exit,always -F path=/bin/cgclassify -F perm=x -F auid>=500 -F auid!=4294967295 -k setuid/setgid
--a exit,always -F path=/bin/cgexec -F perm=x -F auid>=500 -F auid!=4294967295 -k setuid/setgid
--a exit,always -F path=/bin/ping -F perm=x -F auid>=500 -F auid!=4294967295 -k setuid/setgid
--a exit,always -F path=/bin/ping6 -F perm=x -F auid>=500 -F auid!=4294967295 -k setuid/setgid
--a exit,always -F path=/sbin/mount.nfs -F perm=x -F auid>=500 -F auid!=4294967295 -k setuid/setgid
--a exit,always -F path=/sbin/netreport -F perm=x -F auid>=500 -F auid!=4294967295 -k setuid/setgid
--a exit,always -F path=/usr/bin/at -F perm=x -F auid>=500 -F auid!=4294967295 -k setuid/setgid
--a exit,always -F path=/usr/bin/chage -F perm=x -F auid>=500 -F auid!=4294967295 -k setuid/setgid
--a exit,always -F path=/usr/bin/chcon -F perm=x -F auid>=500 -F auid!=4294967295 -k setuid/setgid
--a exit,always -F path=/usr/bin/chfn -F perm=x -F auid>=500 -F auid!=4294967295 -k setuid/setgid
--a exit,always -F path=/usr/bin/chsh -F perm=x -F auid>=500 -F auid!=4294967295 -k setuid/setgid
--a exit,always -F path=/usr/bin/crontab -F perm=x -F auid>=500 -F auid!=4294967295 -k setuid/setgid
--a exit,always -F path=/usr/bin/fusermount -F perm=x -F auid>=500 -F auid!=4294967295 -k setuid/setgid
--a exit,always -F path=/usr/bin/gpasswd -F perm=x -F auid>=500 -F auid!=4294967295 -k setuid/setgid
--a exit,always -F path=/usr/bin/incrontab -F perm=x -F auid>=500 -F auid!=4294967295 -k setuid/setgid
--a exit,always -F path=/usr/bin/ksu -F perm=x -F auid>=500 -F auid!=4294967295 -k setuid/setgid
--a exit,always -F path=/usr/bin/locate -F perm=x -F auid>=500 -F auid!=4294967295 -k setuid/setgid
--a exit,always -F path=/usr/bin/mount -F perm=x -F auid>=500 -F auid!=4294967295 -k setuid/setgid
--a exit,always -F path=/usr/bin/newgidmap -F perm=x -F auid>=500 -F auid!=4294967295 -k setuid/setgid
--a exit,always -F path=/usr/bin/newgrp -F perm=x -F auid>=500 -F auid!=4294967295 -k setuid/setgid
--a exit,always -F path=/usr/bin/newuidmap -F perm=x -F auid>=500 -F auid!=4294967295 -k setuid/setgid
--a exit,always -F path=/usr/bin/passwd -F perm=x -F auid>=500 -F auid!=4294967295 -k setuid/setgid
--a exit,always -F path=/usr/bin/pkexec -F perm=x -F auid>=500 -F auid!=4294967295 -k setuid/setgid
--a exit,always -F path=/usr/bin/screen -F perm=x -F auid>=500 -F auid!=4294967295 -k setuid/setgid
--a exit,always -F path=/usr/bin/ssh-agent -F perm=x -F auid>=500 -F auid!=4294967295 -k setuid/setgid
--a exit,always -F path=/usr/bin/su -F perm=x -F auid>=500 -F auid!=4294967295 -k setuid/setgid
--a exit,always -F path=/usr/bin/sudo -F perm=x -F auid>=500 -F auid!=4294967295 -k setuid/setgid
--a exit,always -F path=/usr/bin/sudoedit -F perm=x -F auid>=500 -F auid!=4294967295 -k setuid/setgid
--a exit,always -F path=/usr/bin/umount -F perm=x -F auid>=500 -F auid!=4294967295 -k setuid/setgid
--a exit,always -F path=/usr/bin/wall -F perm=x -F auid>=500 -F auid!=4294967295 -k setuid/setgid
--a exit,always -F path=/usr/bin/write -F perm=x -F auid>=500 -F auid!=4294967295 -k setuid/setgid
--a exit,always -F path=/usr/bin/Xorg -F perm=x -F auid>=500 -F auid!=4294967295 -k setuid/setgid
--a exit,always -F path=/usr/libexec/dbus-1/dbus-daemon-launch-helper -F perm=x -F auid>=500 -F auid!=4294967295 -k setuid/setgid
--a exit,always -F path=/usr/libexec/openssh/ssh-keysign -F perm=x -F auid>=500 -F auid!=4294967295 -k setuid/setgid
--a exit,always -F path=/usr/libexec/polkit-1/polkit-agent-helper-1 -F perm=x -F auid>=500 -F auid!=4294967295 -k setuid/setgid
--a exit,always -F path=/usr/libexec/pt_chown -F perm=x -F auid>=500 -F auid!=4294967295 -k setuid/setgid
--a exit,always -F path=/usr/libexec/utempter/utempter -F perm=x -F auid>=500 -F auid!=4294967295 -k setuid/setgid
--a exit,always -F path=/usr/sbin/pam_timestamp_check -F perm=x -F auid>=500 -F auid!=4294967295 -k setuid/setgid
--a exit,always -F path=/usr/sbin/postdrop -F perm=x -F auid>=500 -F auid!=4294967295 -k setuid/setgid
--a exit,always -F path=/usr/sbin/postqueue -F perm=x -F auid>=500 -F auid!=4294967295 -k setuid/setgid
--a exit,always -F path=/usr/sbin/restorecon -F perm=x -F auid>=500 -F auid!=4294967295 -k setuid/setgid
--a exit,always -F path=/usr/sbin/semanage -F perm=x -F auid>=500 -F auid!=4294967295 -k setuid/setgid
--a exit,always -F path=/usr/sbin/setfiles -F perm=x -F auid>=500 -F auid!=4294967295 -k setuid/setgid
--a exit,always -F path=/usr/sbin/setsebool -F perm=x -F auid>=500 -F auid!=4294967295 -k setuid/setgid
--a exit,always -F path=/usr/sbin/seunshare -F perm=x -F auid>=500 -F auid!=4294967295 -k setuid/setgid
--a exit,always -F path=/usr/sbin/suexec -F perm=x -F auid>=500 -F auid!=4294967295 -k setuid/setgid
--a exit,always -F path=/usr/sbin/unix_chkpwd -F perm=x -F auid>=500 -F auid!=4294967295 -k setuid/setgid
--a exit,always -F path=/usr/sbin/userhelper -F perm=x -F auid>=500 -F auid!=4294967295 -k setuid/setgid
--a exit,always -F path=/usr/sbin/usernetctl -F perm=x -F auid>=500 -F auid!=4294967295 -k setuid/setgid
+-a always,exit -F path=/bin/cgclassify -F perm=x -F auid>=500 -F auid!=4294967295 -k setuid/setgid
+-a always,exit -F path=/bin/cgexec -F perm=x -F auid>=500 -F auid!=4294967295 -k setuid/setgid
+-a always,exit -F path=/bin/ping -F perm=x -F auid>=500 -F auid!=4294967295 -k setuid/setgid
+-a always,exit -F path=/bin/ping6 -F perm=x -F auid>=500 -F auid!=4294967295 -k setuid/setgid
+-a always,exit -F path=/sbin/mount.nfs -F perm=x -F auid>=500 -F auid!=4294967295 -k setuid/setgid
+-a always,exit -F path=/sbin/netreport -F perm=x -F auid>=500 -F auid!=4294967295 -k setuid/setgid
+-a always,exit -F path=/usr/bin/at -F perm=x -F auid>=500 -F auid!=4294967295 -k setuid/setgid
+-a always,exit -F path=/usr/bin/chage -F perm=x -F auid>=500 -F auid!=4294967295 -k setuid/setgid
+-a always,exit -F path=/usr/bin/chcon -F perm=x -F auid>=500 -F auid!=4294967295 -k setuid/setgid
+-a always,exit -F path=/usr/bin/chfn -F perm=x -F auid>=500 -F auid!=4294967295 -k setuid/setgid
+-a always,exit -F path=/usr/bin/chsh -F perm=x -F auid>=500 -F auid!=4294967295 -k setuid/setgid
+-a always,exit -F path=/usr/bin/crontab -F perm=x -F auid>=500 -F auid!=4294967295 -k setuid/setgid
+-a always,exit -F path=/usr/bin/fusermount -F perm=x -F auid>=500 -F auid!=4294967295 -k setuid/setgid
+-a always,exit -F path=/usr/bin/gpasswd -F perm=x -F auid>=500 -F auid!=4294967295 -k setuid/setgid
+-a always,exit -F path=/usr/bin/incrontab -F perm=x -F auid>=500 -F auid!=4294967295 -k setuid/setgid
+-a always,exit -F path=/usr/bin/ksu -F perm=x -F auid>=500 -F auid!=4294967295 -k setuid/setgid
+-a always,exit -F path=/usr/bin/locate -F perm=x -F auid>=500 -F auid!=4294967295 -k setuid/setgid
+-a always,exit -F path=/usr/bin/mount -F perm=x -F auid>=500 -F auid!=4294967295 -k setuid/setgid
+-a always,exit -F path=/usr/bin/newgidmap -F perm=x -F auid>=500 -F auid!=4294967295 -k setuid/setgid
+-a always,exit -F path=/usr/bin/newgrp -F perm=x -F auid>=500 -F auid!=4294967295 -k setuid/setgid
+-a always,exit -F path=/usr/bin/newuidmap -F perm=x -F auid>=500 -F auid!=4294967295 -k setuid/setgid
+-a always,exit -F path=/usr/bin/passwd -F perm=x -F auid>=500 -F auid!=4294967295 -k setuid/setgid
+-a always,exit -F path=/usr/bin/pkexec -F perm=x -F auid>=500 -F auid!=4294967295 -k setuid/setgid
+-a always,exit -F path=/usr/bin/screen -F perm=x -F auid>=500 -F auid!=4294967295 -k setuid/setgid
+-a always,exit -F path=/usr/bin/ssh-agent -F perm=x -F auid>=500 -F auid!=4294967295 -k setuid/setgid
+-a always,exit -F path=/usr/bin/su -F perm=x -F auid>=500 -F auid!=4294967295 -k setuid/setgid
+-a always,exit -F path=/usr/bin/sudo -F perm=x -F auid>=500 -F auid!=4294967295 -k setuid/setgid
+-a always,exit -F path=/usr/bin/sudoedit -F perm=x -F auid>=500 -F auid!=4294967295 -k setuid/setgid
+-a always,exit -F path=/usr/bin/umount -F perm=x -F auid>=500 -F auid!=4294967295 -k setuid/setgid
+-a always,exit -F path=/usr/bin/wall -F perm=x -F auid>=500 -F auid!=4294967295 -k setuid/setgid
+-a always,exit -F path=/usr/bin/write -F perm=x -F auid>=500 -F auid!=4294967295 -k setuid/setgid
+-a always,exit -F path=/usr/bin/Xorg -F perm=x -F auid>=500 -F auid!=4294967295 -k setuid/setgid
+-a always,exit -F path=/usr/libexec/dbus-1/dbus-daemon-launch-helper -F perm=x -F auid>=500 -F auid!=4294967295 -k setuid/setgid
+-a always,exit -F path=/usr/libexec/openssh/ssh-keysign -F perm=x -F auid>=500 -F auid!=4294967295 -k setuid/setgid
+-a always,exit -F path=/usr/libexec/polkit-1/polkit-agent-helper-1 -F perm=x -F auid>=500 -F auid!=4294967295 -k setuid/setgid
+-a always,exit -F path=/usr/libexec/pt_chown -F perm=x -F auid>=500 -F auid!=4294967295 -k setuid/setgid
+-a always,exit -F path=/usr/libexec/utempter/utempter -F perm=x -F auid>=500 -F auid!=4294967295 -k setuid/setgid
+-a always,exit -F path=/usr/sbin/pam_timestamp_check -F perm=x -F auid>=500 -F auid!=4294967295 -k setuid/setgid
+-a always,exit -F path=/usr/sbin/postdrop -F perm=x -F auid>=500 -F auid!=4294967295 -k setuid/setgid
+-a always,exit -F path=/usr/sbin/postqueue -F perm=x -F auid>=500 -F auid!=4294967295 -k setuid/setgid
+-a always,exit -F path=/usr/sbin/restorecon -F perm=x -F auid>=500 -F auid!=4294967295 -k setuid/setgid
+-a always,exit -F path=/usr/sbin/semanage -F perm=x -F auid>=500 -F auid!=4294967295 -k setuid/setgid
+-a always,exit -F path=/usr/sbin/setfiles -F perm=x -F auid>=500 -F auid!=4294967295 -k setuid/setgid
+-a always,exit -F path=/usr/sbin/setsebool -F perm=x -F auid>=500 -F auid!=4294967295 -k setuid/setgid
+-a always,exit -F path=/usr/sbin/seunshare -F perm=x -F auid>=500 -F auid!=4294967295 -k setuid/setgid
+-a always,exit -F path=/usr/sbin/suexec -F perm=x -F auid>=500 -F auid!=4294967295 -k setuid/setgid
+-a always,exit -F path=/usr/sbin/unix_chkpwd -F perm=x -F auid>=500 -F auid!=4294967295 -k setuid/setgid
+-a always,exit -F path=/usr/sbin/userhelper -F perm=x -F auid>=500 -F auid!=4294967295 -k setuid/setgid
+-a always,exit -F path=/usr/sbin/usernetctl -F perm=x -F auid>=500 -F auid!=4294967295 -k setuid/setgid
 
 ## Audit the loading and unloading of kernel modules.
 -w /sbin/insmod -p x -F auid!=4294967295 -k module-change
@@ -192,25 +192,25 @@
 
 -w /sbin/modprobe -p x -F auid!=4294967295 -k module-change
 
--a exit,always -F arch=b64 -S create_module -k module-change
--a exit,always -F arch=b32 -S create_module -k module-change
+-a always,exit -F arch=b64 -S create_module -k module-change
+-a always,exit -F arch=b32 -S create_module -k module-change
 
--a exit,always -F arch=b64 -S init_module -k module-change
--a exit,always -F arch=b32 -S init_module -k module-change
+-a always,exit -F arch=b64 -S init_module -k module-change
+-a always,exit -F arch=b32 -S init_module -k module-change
 
--a exit,always -F arch=b64 -S finit_module -k module-change
--a exit,always -F arch=b32 -S finit_module -k module-change
+-a always,exit -F arch=b64 -S finit_module -k module-change
+-a always,exit -F arch=b32 -S finit_module -k module-change
 
--a exit,always -F arch=b64 -S delete_module -k module-change
--a exit,always -F arch=b32 -S delete_module -k module-change
+-a always,exit -F arch=b64 -S delete_module -k module-change
+-a always,exit -F arch=b32 -S delete_module -k module-change
 
 ## Audit mount operations
--a exit,always -F arch=b64 -S mount -F auid>=500 -F auid!=4294967295 -k privileged-mount
--a exit,always -F arch=b64 -F path=/bin/mount -F auid>=500 -F auid!=4294967295 -k privileged-mount
--a exit,always -F arch=b32 -S mount -F auid>=500 -F auid!=4294967295 -k privileged-mount
--a exit,always -F arch=b32 -F path=/bin/mount -F auid>=500 -F auid!=4294967295 -k privileged-mount
+-a always,exit -F arch=b64 -S mount -F auid>=500 -F auid!=4294967295 -k privileged-mount
+-a always,exit -F arch=b64 -F path=/bin/mount -F auid>=500 -F auid!=4294967295 -k privileged-mount
+-a always,exit -F arch=b32 -S mount -F auid>=500 -F auid!=4294967295 -k privileged-mount
+-a always,exit -F arch=b32 -F path=/bin/mount -F auid>=500 -F auid!=4294967295 -k privileged-mount
 
--a exit,always -F path=/bin/umount -F perm=x -F auid>=500 -F auid!=4294967295 -k privileged-mount
+-a always,exit -F path=/bin/umount -F perm=x -F auid>=500 -F auid!=4294967295 -k privileged-mount
 
 ## Audit local accounts
 -w /etc/passwd -p wa -k identity

--- a/spec/classes/config/audit_profiles/expected/stig_el7_all_custom_tags.txt
+++ b/spec/classes/config/audit_profiles/expected/stig_el7_all_custom_tags.txt
@@ -1,208 +1,208 @@
 #### auditd::config::audit_profiles::stig Audit Rules ####
 
 ## Audit unsuccessful file operations
--a exit,always -F arch=b64 -S creat -F exit=-EPERM -F auid>=1000 -F auid!=4294967295 -k my_unsuccessful_file_operations
--a exit,always -F arch=b64 -S creat -F exit=-EACCES -F auid>=1000 -F auid!=4294967295 -k my_unsuccessful_file_operations
--a exit,always -F arch=b32 -S creat -F exit=-EPERM -F auid>=1000 -F auid!=4294967295 -k my_unsuccessful_file_operations
--a exit,always -F arch=b32 -S creat -F exit=-EACCES -F auid>=1000 -F auid!=4294967295 -k my_unsuccessful_file_operations
+-a always,exit -F arch=b64 -S creat -F exit=-EPERM -F auid>=1000 -F auid!=4294967295 -k my_unsuccessful_file_operations
+-a always,exit -F arch=b64 -S creat -F exit=-EACCES -F auid>=1000 -F auid!=4294967295 -k my_unsuccessful_file_operations
+-a always,exit -F arch=b32 -S creat -F exit=-EPERM -F auid>=1000 -F auid!=4294967295 -k my_unsuccessful_file_operations
+-a always,exit -F arch=b32 -S creat -F exit=-EACCES -F auid>=1000 -F auid!=4294967295 -k my_unsuccessful_file_operations
 
--a exit,always -F arch=b64 -S open -F exit=-EPERM -F auid>=1000 -F auid!=4294967295 -k my_unsuccessful_file_operations
--a exit,always -F arch=b64 -S open -F exit=-EACCES -F auid>=1000 -F auid!=4294967295 -k my_unsuccessful_file_operations
--a exit,always -F arch=b32 -S open -F exit=-EPERM -F auid>=1000 -F auid!=4294967295 -k my_unsuccessful_file_operations
--a exit,always -F arch=b32 -S open -F exit=-EACCES -F auid>=1000 -F auid!=4294967295 -k my_unsuccessful_file_operations
+-a always,exit -F arch=b64 -S open -F exit=-EPERM -F auid>=1000 -F auid!=4294967295 -k my_unsuccessful_file_operations
+-a always,exit -F arch=b64 -S open -F exit=-EACCES -F auid>=1000 -F auid!=4294967295 -k my_unsuccessful_file_operations
+-a always,exit -F arch=b32 -S open -F exit=-EPERM -F auid>=1000 -F auid!=4294967295 -k my_unsuccessful_file_operations
+-a always,exit -F arch=b32 -S open -F exit=-EACCES -F auid>=1000 -F auid!=4294967295 -k my_unsuccessful_file_operations
 
--a exit,always -F arch=b64 -S openat -F exit=-EPERM -F auid>=1000 -F auid!=4294967295 -k my_unsuccessful_file_operations
--a exit,always -F arch=b64 -S openat -F exit=-EACCES -F auid>=1000 -F auid!=4294967295 -k my_unsuccessful_file_operations
--a exit,always -F arch=b32 -S openat -F exit=-EPERM -F auid>=1000 -F auid!=4294967295 -k my_unsuccessful_file_operations
--a exit,always -F arch=b32 -S openat -F exit=-EACCES -F auid>=1000 -F auid!=4294967295 -k my_unsuccessful_file_operations
+-a always,exit -F arch=b64 -S openat -F exit=-EPERM -F auid>=1000 -F auid!=4294967295 -k my_unsuccessful_file_operations
+-a always,exit -F arch=b64 -S openat -F exit=-EACCES -F auid>=1000 -F auid!=4294967295 -k my_unsuccessful_file_operations
+-a always,exit -F arch=b32 -S openat -F exit=-EPERM -F auid>=1000 -F auid!=4294967295 -k my_unsuccessful_file_operations
+-a always,exit -F arch=b32 -S openat -F exit=-EACCES -F auid>=1000 -F auid!=4294967295 -k my_unsuccessful_file_operations
 
--a exit,always -F arch=b64 -S open_by_handle_at -F exit=-EPERM -F auid>=1000 -F auid!=4294967295 -k my_unsuccessful_file_operations
--a exit,always -F arch=b64 -S open_by_handle_at -F exit=-EACCES -F auid>=1000 -F auid!=4294967295 -k my_unsuccessful_file_operations
--a exit,always -F arch=b32 -S open_by_handle_at -F exit=-EPERM -F auid>=1000 -F auid!=4294967295 -k my_unsuccessful_file_operations
--a exit,always -F arch=b32 -S open_by_handle_at -F exit=-EACCES -F auid>=1000 -F auid!=4294967295 -k my_unsuccessful_file_operations
+-a always,exit -F arch=b64 -S open_by_handle_at -F exit=-EPERM -F auid>=1000 -F auid!=4294967295 -k my_unsuccessful_file_operations
+-a always,exit -F arch=b64 -S open_by_handle_at -F exit=-EACCES -F auid>=1000 -F auid!=4294967295 -k my_unsuccessful_file_operations
+-a always,exit -F arch=b32 -S open_by_handle_at -F exit=-EPERM -F auid>=1000 -F auid!=4294967295 -k my_unsuccessful_file_operations
+-a always,exit -F arch=b32 -S open_by_handle_at -F exit=-EACCES -F auid>=1000 -F auid!=4294967295 -k my_unsuccessful_file_operations
 
--a exit,always -F arch=b64 -S truncate -F exit=-EPERM -F auid>=1000 -F auid!=4294967295 -k my_unsuccessful_file_operations
--a exit,always -F arch=b64 -S truncate -F exit=-EACCES -F auid>=1000 -F auid!=4294967295 -k my_unsuccessful_file_operations
--a exit,always -F arch=b32 -S truncate -F exit=-EPERM -F auid>=1000 -F auid!=4294967295 -k my_unsuccessful_file_operations
--a exit,always -F arch=b32 -S truncate -F exit=-EACCES -F auid>=1000 -F auid!=4294967295 -k my_unsuccessful_file_operations
+-a always,exit -F arch=b64 -S truncate -F exit=-EPERM -F auid>=1000 -F auid!=4294967295 -k my_unsuccessful_file_operations
+-a always,exit -F arch=b64 -S truncate -F exit=-EACCES -F auid>=1000 -F auid!=4294967295 -k my_unsuccessful_file_operations
+-a always,exit -F arch=b32 -S truncate -F exit=-EPERM -F auid>=1000 -F auid!=4294967295 -k my_unsuccessful_file_operations
+-a always,exit -F arch=b32 -S truncate -F exit=-EACCES -F auid>=1000 -F auid!=4294967295 -k my_unsuccessful_file_operations
 
--a exit,always -F arch=b64 -S ftruncate -F exit=-EPERM -F auid>=1000 -F auid!=4294967295 -k my_unsuccessful_file_operations
--a exit,always -F arch=b64 -S ftruncate -F exit=-EACCES -F auid>=1000 -F auid!=4294967295 -k my_unsuccessful_file_operations
--a exit,always -F arch=b32 -S ftruncate -F exit=-EPERM -F auid>=1000 -F auid!=4294967295 -k my_unsuccessful_file_operations
--a exit,always -F arch=b32 -S ftruncate -F exit=-EACCES -F auid>=1000 -F auid!=4294967295 -k my_unsuccessful_file_operations
+-a always,exit -F arch=b64 -S ftruncate -F exit=-EPERM -F auid>=1000 -F auid!=4294967295 -k my_unsuccessful_file_operations
+-a always,exit -F arch=b64 -S ftruncate -F exit=-EACCES -F auid>=1000 -F auid!=4294967295 -k my_unsuccessful_file_operations
+-a always,exit -F arch=b32 -S ftruncate -F exit=-EPERM -F auid>=1000 -F auid!=4294967295 -k my_unsuccessful_file_operations
+-a always,exit -F arch=b32 -S ftruncate -F exit=-EACCES -F auid>=1000 -F auid!=4294967295 -k my_unsuccessful_file_operations
 
 ## Audit the execution of password commands
--a exit,always -F path=/usr/bin/passwd -F perm=x -F auid>=1000 -F auid!=4294967295 -k my_passwd_cmds
--a exit,always -F path=/bin/passwd -F perm=x -F auid>=1000 -F auid!=4294967295 -k my_passwd_cmds
+-a always,exit -F path=/usr/bin/passwd -F perm=x -F auid>=1000 -F auid!=4294967295 -k my_passwd_cmds
+-a always,exit -F path=/bin/passwd -F perm=x -F auid>=1000 -F auid!=4294967295 -k my_passwd_cmds
 
--a exit,always -F path=/usr/sbin/unix_chkpwd -F perm=x -F auid>=1000 -F auid!=4294967295 -k my_passwd_cmds
--a exit,always -F path=/sbin/unix_chkpwd -F perm=x -F auid>=1000 -F auid!=4294967295 -k my_passwd_cmds
+-a always,exit -F path=/usr/sbin/unix_chkpwd -F perm=x -F auid>=1000 -F auid!=4294967295 -k my_passwd_cmds
+-a always,exit -F path=/sbin/unix_chkpwd -F perm=x -F auid>=1000 -F auid!=4294967295 -k my_passwd_cmds
 
--a exit,always -F path=/usr/bin/gpasswd -F perm=x -F auid>=1000 -F auid!=4294967295 -k my_passwd_cmds
--a exit,always -F path=/bin/gpasswd -F perm=x -F auid>=1000 -F auid!=4294967295 -k my_passwd_cmds
+-a always,exit -F path=/usr/bin/gpasswd -F perm=x -F auid>=1000 -F auid!=4294967295 -k my_passwd_cmds
+-a always,exit -F path=/bin/gpasswd -F perm=x -F auid>=1000 -F auid!=4294967295 -k my_passwd_cmds
 
--a exit,always -F path=/usr/bin/chage -F perm=x -F auid>=1000 -F auid!=4294967295 -k my_passwd_cmds
--a exit,always -F path=/bin/chage -F perm=x -F auid>=1000 -F auid!=4294967295 -k my_passwd_cmds
+-a always,exit -F path=/usr/bin/chage -F perm=x -F auid>=1000 -F auid!=4294967295 -k my_passwd_cmds
+-a always,exit -F path=/bin/chage -F perm=x -F auid>=1000 -F auid!=4294967295 -k my_passwd_cmds
 
--a exit,always -F path=/usr/sbin/userhelper -F perm=x -F auid>=1000 -F auid!=4294967295 -k my_passwd_cmds
--a exit,always -F path=/sbin/userhelper -F perm=x -F auid>=1000 -F auid!=4294967295 -k my_passwd_cmds
+-a always,exit -F path=/usr/sbin/userhelper -F perm=x -F auid>=1000 -F auid!=4294967295 -k my_passwd_cmds
+-a always,exit -F path=/sbin/userhelper -F perm=x -F auid>=1000 -F auid!=4294967295 -k my_passwd_cmds
 
 ## Audit the execution of privilege-related commands
--a exit,always -F path=/usr/bin/su -F perm=x -F auid>=1000 -F auid!=4294967295 -k my_priv_cmds
--a exit,always -F path=/bin/su -F perm=x -F auid>=1000 -F auid!=4294967295 -k my_priv_cmds
+-a always,exit -F path=/usr/bin/su -F perm=x -F auid>=1000 -F auid!=4294967295 -k my_priv_cmds
+-a always,exit -F path=/bin/su -F perm=x -F auid>=1000 -F auid!=4294967295 -k my_priv_cmds
 
--a exit,always -F path=/usr/bin/sudo -F perm=x -F auid>=1000 -F auid!=4294967295 -k my_priv_cmds
--a exit,always -F path=/bin/sudo -F perm=x -F auid>=1000 -F auid!=4294967295 -k my_priv_cmds
+-a always,exit -F path=/usr/bin/sudo -F perm=x -F auid>=1000 -F auid!=4294967295 -k my_priv_cmds
+-a always,exit -F path=/bin/sudo -F perm=x -F auid>=1000 -F auid!=4294967295 -k my_priv_cmds
 
--a exit,always -F path=/usr/bin/newgrp -F perm=x -F auid>=1000 -F auid!=4294967295 -k my_priv_cmds
--a exit,always -F path=/bin/newgrp -F perm=x -F auid>=1000 -F auid!=4294967295 -k my_priv_cmds
+-a always,exit -F path=/usr/bin/newgrp -F perm=x -F auid>=1000 -F auid!=4294967295 -k my_priv_cmds
+-a always,exit -F path=/bin/newgrp -F perm=x -F auid>=1000 -F auid!=4294967295 -k my_priv_cmds
 
--a exit,always -F path=/usr/bin/chsh -F perm=x -F auid>=1000 -F auid!=4294967295 -k my_priv_cmds
--a exit,always -F path=/bin/chsh -F perm=x -F auid>=1000 -F auid!=4294967295 -k my_priv_cmds
+-a always,exit -F path=/usr/bin/chsh -F perm=x -F auid>=1000 -F auid!=4294967295 -k my_priv_cmds
+-a always,exit -F path=/bin/chsh -F perm=x -F auid>=1000 -F auid!=4294967295 -k my_priv_cmds
 
--a exit,always -F path=/usr/bin/sudoedit -F perm=x -F auid>=1000 -F auid!=4294967295 -k my_priv_cmds
--a exit,always -F path=/bin/sudoedit -F perm=x -F auid>=1000 -F auid!=4294967295 -k my_priv_cmds
+-a always,exit -F path=/usr/bin/sudoedit -F perm=x -F auid>=1000 -F auid!=4294967295 -k my_priv_cmds
+-a always,exit -F path=/bin/sudoedit -F perm=x -F auid>=1000 -F auid!=4294967295 -k my_priv_cmds
 
 ## Audit the execution of postfix-related commands
--a exit,always -F path=/usr/sbin/postdrop -F perm=x -F auid>=1000 -F auid!=4294967295 -k my_postfix_cmds
--a exit,always -F path=/sbin/postdrop -F perm=x -F auid>=1000 -F auid!=4294967295 -k my_postfix_cmds
+-a always,exit -F path=/usr/sbin/postdrop -F perm=x -F auid>=1000 -F auid!=4294967295 -k my_postfix_cmds
+-a always,exit -F path=/sbin/postdrop -F perm=x -F auid>=1000 -F auid!=4294967295 -k my_postfix_cmds
 
--a exit,always -F path=/usr/sbin/postqueue -F perm=x -F auid>=1000 -F auid!=4294967295 -k my_postfix_cmds
--a exit,always -F path=/sbin/postqueue -F perm=x -F auid>=1000 -F auid!=4294967295 -k my_postfix_cmds
+-a always,exit -F path=/usr/sbin/postqueue -F perm=x -F auid>=1000 -F auid!=4294967295 -k my_postfix_cmds
+-a always,exit -F path=/sbin/postqueue -F perm=x -F auid>=1000 -F auid!=4294967295 -k my_postfix_cmds
 
 ## Audit the execution of the ssh-keysign command
--a exit,always -F path=/usr/libexec/openssh/ssh-keysign -F perm=x -F auid>=1000 -F auid!=4294967295 -k my_ssh_keysign_cmd
+-a always,exit -F path=/usr/libexec/openssh/ssh-keysign -F perm=x -F auid>=1000 -F auid!=4294967295 -k my_ssh_keysign_cmd
 
 ## Audit the execution of the crontab command
--a exit,always -F path=/usr/bin/crontab -F perm=x -F auid>=1000 -F auid!=4294967295 -k my_crontab
--a exit,always -F path=/bin/crontab -F perm=x -F auid>=1000 -F auid!=4294967295 -k my_crontab
+-a always,exit -F path=/usr/bin/crontab -F perm=x -F auid>=1000 -F auid!=4294967295 -k my_crontab
+-a always,exit -F path=/bin/crontab -F perm=x -F auid>=1000 -F auid!=4294967295 -k my_crontab
 
 ## Audit the execution of the pam_timestamp_check command
--a exit,always -F path=/usr/sbin/pam_timestamp_check -F perm=x -F auid>=1000 -F auid!=4294967295 -k my_pam_timestamp_check_cmd
--a exit,always -F path=/sbin/pam_timestamp_check -F perm=x -F auid>=1000 -F auid!=4294967295 -k my_pam_timestamp_check_cmd
+-a always,exit -F path=/usr/sbin/pam_timestamp_check -F perm=x -F auid>=1000 -F auid!=4294967295 -k my_pam_timestamp_check_cmd
+-a always,exit -F path=/sbin/pam_timestamp_check -F perm=x -F auid>=1000 -F auid!=4294967295 -k my_pam_timestamp_check_cmd
 
 ## Audit selinux commands
--a exit,always -F path=/usr/sbin/semanage -F perm=x -F auid>=1000 -F auid!=4294967295 -k my_selinux_cmds
--a exit,always -F path=/sbin/semanage -F perm=x -F auid>=1000 -F auid!=4294967295 -k my_selinux_cmds
+-a always,exit -F path=/usr/sbin/semanage -F perm=x -F auid>=1000 -F auid!=4294967295 -k my_selinux_cmds
+-a always,exit -F path=/sbin/semanage -F perm=x -F auid>=1000 -F auid!=4294967295 -k my_selinux_cmds
 
--a exit,always -F path=/usr/sbin/setsebool -F perm=x -F auid>=1000 -F auid!=4294967295 -k my_selinux_cmds
--a exit,always -F path=/sbin/setsebool -F perm=x -F auid>=1000 -F auid!=4294967295 -k my_selinux_cmds
+-a always,exit -F path=/usr/sbin/setsebool -F perm=x -F auid>=1000 -F auid!=4294967295 -k my_selinux_cmds
+-a always,exit -F path=/sbin/setsebool -F perm=x -F auid>=1000 -F auid!=4294967295 -k my_selinux_cmds
 
--a exit,always -F path=/usr/bin/chcon -F perm=x -F auid>=1000 -F auid!=4294967295 -k my_selinux_cmds
--a exit,always -F path=/bin/chcon -F perm=x -F auid>=1000 -F auid!=4294967295 -k my_selinux_cmds
+-a always,exit -F path=/usr/bin/chcon -F perm=x -F auid>=1000 -F auid!=4294967295 -k my_selinux_cmds
+-a always,exit -F path=/bin/chcon -F perm=x -F auid>=1000 -F auid!=4294967295 -k my_selinux_cmds
 
--a exit,always -F path=/usr/sbin/setfiles -F perm=x -F auid>=1000 -F auid!=4294967295 -k my_selinux_cmds
--a exit,always -F path=/sbin/setfiles -F perm=x -F auid>=1000 -F auid!=4294967295 -k my_selinux_cmds
+-a always,exit -F path=/usr/sbin/setfiles -F perm=x -F auid>=1000 -F auid!=4294967295 -k my_selinux_cmds
+-a always,exit -F path=/sbin/setfiles -F perm=x -F auid>=1000 -F auid!=4294967295 -k my_selinux_cmds
 
--a exit,always -F path=/sbin/restorecon -F perm=x -F auid>=1000 -F auid!=4294967295 -k my_selinux_cmds
--a exit,always -F path=/usr/sbin/restorecon -F perm=x -F auid>=1000 -F auid!=4294967295 -k my_selinux_cmds
+-a always,exit -F path=/sbin/restorecon -F perm=x -F auid>=1000 -F auid!=4294967295 -k my_selinux_cmds
+-a always,exit -F path=/usr/sbin/restorecon -F perm=x -F auid>=1000 -F auid!=4294967295 -k my_selinux_cmds
 
 ## Permissions auditing separated by chown, chmod, and attr
--a exit,always -F arch=b64 -S chown -F auid>=1000 -F auid!=4294967295 -k my_chown
--a exit,always -F arch=b32 -S chown -F auid>=1000 -F auid!=4294967295 -k my_chown
+-a always,exit -F arch=b64 -S chown -F auid>=1000 -F auid!=4294967295 -k my_chown
+-a always,exit -F arch=b32 -S chown -F auid>=1000 -F auid!=4294967295 -k my_chown
 
--a exit,always -F arch=b64 -S fchown -F auid>=1000 -F auid!=4294967295 -k my_chown
--a exit,always -F arch=b32 -S fchown -F auid>=1000 -F auid!=4294967295 -k my_chown
+-a always,exit -F arch=b64 -S fchown -F auid>=1000 -F auid!=4294967295 -k my_chown
+-a always,exit -F arch=b32 -S fchown -F auid>=1000 -F auid!=4294967295 -k my_chown
 
--a exit,always -F arch=b64 -S lchown -F auid>=1000 -F auid!=4294967295 -k my_chown
--a exit,always -F arch=b32 -S lchown -F auid>=1000 -F auid!=4294967295 -k my_chown
+-a always,exit -F arch=b64 -S lchown -F auid>=1000 -F auid!=4294967295 -k my_chown
+-a always,exit -F arch=b32 -S lchown -F auid>=1000 -F auid!=4294967295 -k my_chown
 
--a exit,always -F arch=b64 -S fchownat -F auid>=1000 -F auid!=4294967295 -k my_chown
--a exit,always -F arch=b32 -S fchownat -F auid>=1000 -F auid!=4294967295 -k my_chown
+-a always,exit -F arch=b64 -S fchownat -F auid>=1000 -F auid!=4294967295 -k my_chown
+-a always,exit -F arch=b32 -S fchownat -F auid>=1000 -F auid!=4294967295 -k my_chown
 
--a exit,always -F arch=b64 -S chmod -F auid>=1000 -F auid!=4294967295 -k my_chmod
--a exit,always -F arch=b32 -S chmod -F auid>=1000 -F auid!=4294967295 -k my_chmod
+-a always,exit -F arch=b64 -S chmod -F auid>=1000 -F auid!=4294967295 -k my_chmod
+-a always,exit -F arch=b32 -S chmod -F auid>=1000 -F auid!=4294967295 -k my_chmod
 
--a exit,always -F arch=b64 -S fchmod -F auid>=1000 -F auid!=4294967295 -k my_chmod
--a exit,always -F arch=b32 -S fchmod -F auid>=1000 -F auid!=4294967295 -k my_chmod
+-a always,exit -F arch=b64 -S fchmod -F auid>=1000 -F auid!=4294967295 -k my_chmod
+-a always,exit -F arch=b32 -S fchmod -F auid>=1000 -F auid!=4294967295 -k my_chmod
 
--a exit,always -F arch=b64 -S fchmodat -F auid>=1000 -F auid!=4294967295 -k my_chmod
--a exit,always -F arch=b32 -S fchmodat -F auid>=1000 -F auid!=4294967295 -k my_chmod
+-a always,exit -F arch=b64 -S fchmodat -F auid>=1000 -F auid!=4294967295 -k my_chmod
+-a always,exit -F arch=b32 -S fchmodat -F auid>=1000 -F auid!=4294967295 -k my_chmod
 
--a exit,always -F arch=b64 -S setxattr -F auid>=1000 -F auid!=4294967295 -k my_attr
--a exit,always -F arch=b32 -S setxattr -F auid>=1000 -F auid!=4294967295 -k my_attr
+-a always,exit -F arch=b64 -S setxattr -F auid>=1000 -F auid!=4294967295 -k my_attr
+-a always,exit -F arch=b32 -S setxattr -F auid>=1000 -F auid!=4294967295 -k my_attr
 
--a exit,always -F arch=b64 -S fsetxattr -F auid>=1000 -F auid!=4294967295 -k my_attr
--a exit,always -F arch=b32 -S fsetxattr -F auid>=1000 -F auid!=4294967295 -k my_attr
+-a always,exit -F arch=b64 -S fsetxattr -F auid>=1000 -F auid!=4294967295 -k my_attr
+-a always,exit -F arch=b32 -S fsetxattr -F auid>=1000 -F auid!=4294967295 -k my_attr
 
--a exit,always -F arch=b64 -S lsetxattr -F auid>=1000 -F auid!=4294967295 -k my_attr
--a exit,always -F arch=b32 -S lsetxattr -F auid>=1000 -F auid!=4294967295 -k my_attr
+-a always,exit -F arch=b64 -S lsetxattr -F auid>=1000 -F auid!=4294967295 -k my_attr
+-a always,exit -F arch=b32 -S lsetxattr -F auid>=1000 -F auid!=4294967295 -k my_attr
 
--a exit,always -F arch=b64 -S removexattr -F auid>=1000 -F auid!=4294967295 -k my_attr
--a exit,always -F arch=b32 -S removexattr -F auid>=1000 -F auid!=4294967295 -k my_attr
+-a always,exit -F arch=b64 -S removexattr -F auid>=1000 -F auid!=4294967295 -k my_attr
+-a always,exit -F arch=b32 -S removexattr -F auid>=1000 -F auid!=4294967295 -k my_attr
 
--a exit,always -F arch=b64 -S fremovexattr -F auid>=1000 -F auid!=4294967295 -k my_attr
--a exit,always -F arch=b32 -S fremovexattr -F auid>=1000 -F auid!=4294967295 -k my_attr
+-a always,exit -F arch=b64 -S fremovexattr -F auid>=1000 -F auid!=4294967295 -k my_attr
+-a always,exit -F arch=b32 -S fremovexattr -F auid>=1000 -F auid!=4294967295 -k my_attr
 
--a exit,always -F arch=b64 -S lremovexattr -F auid>=1000 -F auid!=4294967295 -k my_attr
--a exit,always -F arch=b32 -S lremovexattr -F auid>=1000 -F auid!=4294967295 -k my_attr
+-a always,exit -F arch=b64 -S lremovexattr -F auid>=1000 -F auid!=4294967295 -k my_attr
+-a always,exit -F arch=b32 -S lremovexattr -F auid>=1000 -F auid!=4294967295 -k my_attr
 
 ## Audit rename/removal operations
--a exit,always -F arch=b64 -S rename -F perm=x -F auid>=1000 -F auid!=4294967295 -k my_rename_remove
--a exit,always -F arch=b32 -S rename -F perm=x -F auid>=1000 -F auid!=4294967295 -k my_rename_remove
+-a always,exit -F arch=b64 -S rename -F perm=x -F auid>=1000 -F auid!=4294967295 -k my_rename_remove
+-a always,exit -F arch=b32 -S rename -F perm=x -F auid>=1000 -F auid!=4294967295 -k my_rename_remove
 
--a exit,always -F arch=b64 -S renameat -F perm=x -F auid>=1000 -F auid!=4294967295 -k my_rename_remove
--a exit,always -F arch=b32 -S renameat -F perm=x -F auid>=1000 -F auid!=4294967295 -k my_rename_remove
+-a always,exit -F arch=b64 -S renameat -F perm=x -F auid>=1000 -F auid!=4294967295 -k my_rename_remove
+-a always,exit -F arch=b32 -S renameat -F perm=x -F auid>=1000 -F auid!=4294967295 -k my_rename_remove
 
--a exit,always -F arch=b64 -S rmdir -F perm=x -F auid>=1000 -F auid!=4294967295 -k my_rename_remove
--a exit,always -F arch=b32 -S rmdir -F perm=x -F auid>=1000 -F auid!=4294967295 -k my_rename_remove
+-a always,exit -F arch=b64 -S rmdir -F perm=x -F auid>=1000 -F auid!=4294967295 -k my_rename_remove
+-a always,exit -F arch=b32 -S rmdir -F perm=x -F auid>=1000 -F auid!=4294967295 -k my_rename_remove
 
--a exit,always -F arch=b64 -S unlink -F perm=x -F auid>=1000 -F auid!=4294967295 -k my_rename_remove
--a exit,always -F arch=b32 -S unlink -F perm=x -F auid>=1000 -F auid!=4294967295 -k my_rename_remove
+-a always,exit -F arch=b64 -S unlink -F perm=x -F auid>=1000 -F auid!=4294967295 -k my_rename_remove
+-a always,exit -F arch=b32 -S unlink -F perm=x -F auid>=1000 -F auid!=4294967295 -k my_rename_remove
 
--a exit,always -F arch=b64 -S unlinkat -F perm=x -F auid>=1000 -F auid!=4294967295 -k my_rename_remove
--a exit,always -F arch=b32 -S unlinkat -F perm=x -F auid>=1000 -F auid!=4294967295 -k my_rename_remove
+-a always,exit -F arch=b64 -S unlinkat -F perm=x -F auid>=1000 -F auid!=4294967295 -k my_rename_remove
+-a always,exit -F arch=b32 -S unlinkat -F perm=x -F auid>=1000 -F auid!=4294967295 -k my_rename_remove
 
 ## Audit the execution of suid and sgid binaries.
--a exit,always -F path=/usr/bin/at -F perm=x -F auid>=1000 -F auid!=4294967295 -k my_suid_sgid
--a exit,always -F path=/usr/bin/chage -F perm=x -F auid>=1000 -F auid!=4294967295 -k my_suid_sgid
--a exit,always -F path=/usr/bin/chcon -F perm=x -F auid>=1000 -F auid!=4294967295 -k my_suid_sgid
--a exit,always -F path=/usr/bin/chfn -F perm=x -F auid>=1000 -F auid!=4294967295 -k my_suid_sgid
--a exit,always -F path=/usr/bin/chsh -F perm=x -F auid>=1000 -F auid!=4294967295 -k my_suid_sgid
--a exit,always -F path=/usr/bin/crontab -F perm=x -F auid>=1000 -F auid!=4294967295 -k my_suid_sgid
--a exit,always -F path=/usr/bin/fusermount -F perm=x -F auid>=1000 -F auid!=4294967295 -k my_suid_sgid
--a exit,always -F path=/usr/bin/gpasswd -F perm=x -F auid>=1000 -F auid!=4294967295 -k my_suid_sgid
--a exit,always -F path=/usr/bin/incrontab -F perm=x -F auid>=1000 -F auid!=4294967295 -k my_suid_sgid
--a exit,always -F path=/usr/bin/ksu -F perm=x -F auid>=1000 -F auid!=4294967295 -k my_suid_sgid
--a exit,always -F path=/usr/bin/locate -F perm=x -F auid>=1000 -F auid!=4294967295 -k my_suid_sgid
--a exit,always -F path=/usr/bin/mount -F perm=x -F auid>=1000 -F auid!=4294967295 -k my_suid_sgid
--a exit,always -F path=/usr/bin/newgidmap -F perm=x -F auid>=1000 -F auid!=4294967295 -k my_suid_sgid
--a exit,always -F path=/usr/bin/newgrp -F perm=x -F auid>=1000 -F auid!=4294967295 -k my_suid_sgid
--a exit,always -F path=/usr/bin/newuidmap -F perm=x -F auid>=1000 -F auid!=4294967295 -k my_suid_sgid
--a exit,always -F path=/usr/bin/passwd -F perm=x -F auid>=1000 -F auid!=4294967295 -k my_suid_sgid
--a exit,always -F path=/usr/bin/pkexec -F perm=x -F auid>=1000 -F auid!=4294967295 -k my_suid_sgid
--a exit,always -F path=/usr/bin/screen -F perm=x -F auid>=1000 -F auid!=4294967295 -k my_suid_sgid
--a exit,always -F path=/usr/bin/ssh-agent -F perm=x -F auid>=1000 -F auid!=4294967295 -k my_suid_sgid
--a exit,always -F path=/usr/bin/su -F perm=x -F auid>=1000 -F auid!=4294967295 -k my_suid_sgid
--a exit,always -F path=/usr/bin/sudo -F perm=x -F auid>=1000 -F auid!=4294967295 -k my_suid_sgid
--a exit,always -F path=/usr/bin/sudoedit -F perm=x -F auid>=1000 -F auid!=4294967295 -k my_suid_sgid
--a exit,always -F path=/usr/bin/umount -F perm=x -F auid>=1000 -F auid!=4294967295 -k my_suid_sgid
--a exit,always -F path=/usr/bin/wall -F perm=x -F auid>=1000 -F auid!=4294967295 -k my_suid_sgid
--a exit,always -F path=/usr/bin/write -F perm=x -F auid>=1000 -F auid!=4294967295 -k my_suid_sgid
--a exit,always -F path=/usr/bin/Xorg -F perm=x -F auid>=1000 -F auid!=4294967295 -k my_suid_sgid
--a exit,always -F path=/usr/lib64/dbus-1/dbus-daemon-launch-helper -F perm=x -F auid>=1000 -F auid!=4294967295 -k my_suid_sgid
--a exit,always -F path=/usr/libexec/dbus-1/dbus-daemon-launch-helper -F perm=x -F auid>=1000 -F auid!=4294967295 -k my_suid_sgid
--a exit,always -F path=/usr/libexec/openssh/ssh-keysign -F perm=x -F auid>=1000 -F auid!=4294967295 -k my_suid_sgid
--a exit,always -F path=/usr/libexec/pt_chown -F perm=x -F auid>=1000 -F auid!=4294967295 -k my_suid_sgid
--a exit,always -F path=/usr/libexec/sssd/krb5_child -F perm=x -F auid>=1000 -F auid!=4294967295 -k my_suid_sgid
--a exit,always -F path=/usr/libexec/sssd/ldap_child -F perm=x -F auid>=1000 -F auid!=4294967295 -k my_suid_sgid
--a exit,always -F path=/usr/libexec/sssd/proxy_child -F perm=x -F auid>=1000 -F auid!=4294967295 -k my_suid_sgid
--a exit,always -F path=/usr/libexec/sssd/selinux_child -F perm=x -F auid>=1000 -F auid!=4294967295 -k my_suid_sgid
--a exit,always -F path=/usr/libexec/utempter/utempter -F perm=x -F auid>=1000 -F auid!=4294967295 -k my_suid_sgid
--a exit,always -F path=/usr/lib/polkit-1/polkit-agent-helper-1 -F perm=x -F auid>=1000 -F auid!=4294967295 -k my_suid_sgid
--a exit,always -F path=/usr/sbin/mount.nfs -F perm=x -F auid>=1000 -F auid!=4294967295 -k my_suid_sgid
--a exit,always -F path=/usr/sbin/netreport -F perm=x -F auid>=1000 -F auid!=4294967295 -k my_suid_sgid
--a exit,always -F path=/usr/sbin/pam_timestamp_check -F perm=x -F auid>=1000 -F auid!=4294967295 -k my_suid_sgid
--a exit,always -F path=/usr/sbin/postdrop -F perm=x -F auid>=1000 -F auid!=4294967295 -k my_suid_sgid
--a exit,always -F path=/usr/sbin/postqueue -F perm=x -F auid>=1000 -F auid!=4294967295 -k my_suid_sgid
--a exit,always -F path=/usr/sbin/restorecon -F perm=x -F auid>=1000 -F auid!=4294967295 -k my_suid_sgid
--a exit,always -F path=/usr/sbin/semanage -F perm=x -F auid>=1000 -F auid!=4294967295 -k my_suid_sgid
--a exit,always -F path=/usr/sbin/setfiles -F perm=x -F auid>=1000 -F auid!=4294967295 -k my_suid_sgid
--a exit,always -F path=/usr/sbin/setsebool -F perm=x -F auid>=1000 -F auid!=4294967295 -k my_suid_sgid
--a exit,always -F path=/usr/sbin/seunshare -F perm=x -F auid>=1000 -F auid!=4294967295 -k my_suid_sgid
--a exit,always -F path=/usr/sbin/unix_chkpwd -F perm=x -F auid>=1000 -F auid!=4294967295 -k my_suid_sgid
--a exit,always -F path=/usr/sbin/userhelper -F perm=x -F auid>=1000 -F auid!=4294967295 -k my_suid_sgid
--a exit,always -F path=/usr/sbin/usernetctl -F perm=x -F auid>=1000 -F auid!=4294967295 -k my_suid_sgid
+-a always,exit -F path=/usr/bin/at -F perm=x -F auid>=1000 -F auid!=4294967295 -k my_suid_sgid
+-a always,exit -F path=/usr/bin/chage -F perm=x -F auid>=1000 -F auid!=4294967295 -k my_suid_sgid
+-a always,exit -F path=/usr/bin/chcon -F perm=x -F auid>=1000 -F auid!=4294967295 -k my_suid_sgid
+-a always,exit -F path=/usr/bin/chfn -F perm=x -F auid>=1000 -F auid!=4294967295 -k my_suid_sgid
+-a always,exit -F path=/usr/bin/chsh -F perm=x -F auid>=1000 -F auid!=4294967295 -k my_suid_sgid
+-a always,exit -F path=/usr/bin/crontab -F perm=x -F auid>=1000 -F auid!=4294967295 -k my_suid_sgid
+-a always,exit -F path=/usr/bin/fusermount -F perm=x -F auid>=1000 -F auid!=4294967295 -k my_suid_sgid
+-a always,exit -F path=/usr/bin/gpasswd -F perm=x -F auid>=1000 -F auid!=4294967295 -k my_suid_sgid
+-a always,exit -F path=/usr/bin/incrontab -F perm=x -F auid>=1000 -F auid!=4294967295 -k my_suid_sgid
+-a always,exit -F path=/usr/bin/ksu -F perm=x -F auid>=1000 -F auid!=4294967295 -k my_suid_sgid
+-a always,exit -F path=/usr/bin/locate -F perm=x -F auid>=1000 -F auid!=4294967295 -k my_suid_sgid
+-a always,exit -F path=/usr/bin/mount -F perm=x -F auid>=1000 -F auid!=4294967295 -k my_suid_sgid
+-a always,exit -F path=/usr/bin/newgidmap -F perm=x -F auid>=1000 -F auid!=4294967295 -k my_suid_sgid
+-a always,exit -F path=/usr/bin/newgrp -F perm=x -F auid>=1000 -F auid!=4294967295 -k my_suid_sgid
+-a always,exit -F path=/usr/bin/newuidmap -F perm=x -F auid>=1000 -F auid!=4294967295 -k my_suid_sgid
+-a always,exit -F path=/usr/bin/passwd -F perm=x -F auid>=1000 -F auid!=4294967295 -k my_suid_sgid
+-a always,exit -F path=/usr/bin/pkexec -F perm=x -F auid>=1000 -F auid!=4294967295 -k my_suid_sgid
+-a always,exit -F path=/usr/bin/screen -F perm=x -F auid>=1000 -F auid!=4294967295 -k my_suid_sgid
+-a always,exit -F path=/usr/bin/ssh-agent -F perm=x -F auid>=1000 -F auid!=4294967295 -k my_suid_sgid
+-a always,exit -F path=/usr/bin/su -F perm=x -F auid>=1000 -F auid!=4294967295 -k my_suid_sgid
+-a always,exit -F path=/usr/bin/sudo -F perm=x -F auid>=1000 -F auid!=4294967295 -k my_suid_sgid
+-a always,exit -F path=/usr/bin/sudoedit -F perm=x -F auid>=1000 -F auid!=4294967295 -k my_suid_sgid
+-a always,exit -F path=/usr/bin/umount -F perm=x -F auid>=1000 -F auid!=4294967295 -k my_suid_sgid
+-a always,exit -F path=/usr/bin/wall -F perm=x -F auid>=1000 -F auid!=4294967295 -k my_suid_sgid
+-a always,exit -F path=/usr/bin/write -F perm=x -F auid>=1000 -F auid!=4294967295 -k my_suid_sgid
+-a always,exit -F path=/usr/bin/Xorg -F perm=x -F auid>=1000 -F auid!=4294967295 -k my_suid_sgid
+-a always,exit -F path=/usr/lib64/dbus-1/dbus-daemon-launch-helper -F perm=x -F auid>=1000 -F auid!=4294967295 -k my_suid_sgid
+-a always,exit -F path=/usr/libexec/dbus-1/dbus-daemon-launch-helper -F perm=x -F auid>=1000 -F auid!=4294967295 -k my_suid_sgid
+-a always,exit -F path=/usr/libexec/openssh/ssh-keysign -F perm=x -F auid>=1000 -F auid!=4294967295 -k my_suid_sgid
+-a always,exit -F path=/usr/libexec/pt_chown -F perm=x -F auid>=1000 -F auid!=4294967295 -k my_suid_sgid
+-a always,exit -F path=/usr/libexec/sssd/krb5_child -F perm=x -F auid>=1000 -F auid!=4294967295 -k my_suid_sgid
+-a always,exit -F path=/usr/libexec/sssd/ldap_child -F perm=x -F auid>=1000 -F auid!=4294967295 -k my_suid_sgid
+-a always,exit -F path=/usr/libexec/sssd/proxy_child -F perm=x -F auid>=1000 -F auid!=4294967295 -k my_suid_sgid
+-a always,exit -F path=/usr/libexec/sssd/selinux_child -F perm=x -F auid>=1000 -F auid!=4294967295 -k my_suid_sgid
+-a always,exit -F path=/usr/libexec/utempter/utempter -F perm=x -F auid>=1000 -F auid!=4294967295 -k my_suid_sgid
+-a always,exit -F path=/usr/lib/polkit-1/polkit-agent-helper-1 -F perm=x -F auid>=1000 -F auid!=4294967295 -k my_suid_sgid
+-a always,exit -F path=/usr/sbin/mount.nfs -F perm=x -F auid>=1000 -F auid!=4294967295 -k my_suid_sgid
+-a always,exit -F path=/usr/sbin/netreport -F perm=x -F auid>=1000 -F auid!=4294967295 -k my_suid_sgid
+-a always,exit -F path=/usr/sbin/pam_timestamp_check -F perm=x -F auid>=1000 -F auid!=4294967295 -k my_suid_sgid
+-a always,exit -F path=/usr/sbin/postdrop -F perm=x -F auid>=1000 -F auid!=4294967295 -k my_suid_sgid
+-a always,exit -F path=/usr/sbin/postqueue -F perm=x -F auid>=1000 -F auid!=4294967295 -k my_suid_sgid
+-a always,exit -F path=/usr/sbin/restorecon -F perm=x -F auid>=1000 -F auid!=4294967295 -k my_suid_sgid
+-a always,exit -F path=/usr/sbin/semanage -F perm=x -F auid>=1000 -F auid!=4294967295 -k my_suid_sgid
+-a always,exit -F path=/usr/sbin/setfiles -F perm=x -F auid>=1000 -F auid!=4294967295 -k my_suid_sgid
+-a always,exit -F path=/usr/sbin/setsebool -F perm=x -F auid>=1000 -F auid!=4294967295 -k my_suid_sgid
+-a always,exit -F path=/usr/sbin/seunshare -F perm=x -F auid>=1000 -F auid!=4294967295 -k my_suid_sgid
+-a always,exit -F path=/usr/sbin/unix_chkpwd -F perm=x -F auid>=1000 -F auid!=4294967295 -k my_suid_sgid
+-a always,exit -F path=/usr/sbin/userhelper -F perm=x -F auid>=1000 -F auid!=4294967295 -k my_suid_sgid
+-a always,exit -F path=/usr/sbin/usernetctl -F perm=x -F auid>=1000 -F auid!=4294967295 -k my_suid_sgid
 
 ## Audit the loading and unloading of kernel modules.
 -w /usr/bin/kmod -p x -F auid!=4294967295 -k my_kernel_modules
@@ -216,28 +216,28 @@
 -w /usr/sbin/modprobe -p x -F auid!=4294967295 -k my_kernel_modules
 -w /sbin/modprobe -p x -F auid!=4294967295 -k my_kernel_modules
 
--a exit,always -F arch=b64 -S create_module -k my_kernel_modules
--a exit,always -F arch=b32 -S create_module -k my_kernel_modules
+-a always,exit -F arch=b64 -S create_module -k my_kernel_modules
+-a always,exit -F arch=b32 -S create_module -k my_kernel_modules
 
--a exit,always -F arch=b64 -S init_module -k my_kernel_modules
--a exit,always -F arch=b32 -S init_module -k my_kernel_modules
+-a always,exit -F arch=b64 -S init_module -k my_kernel_modules
+-a always,exit -F arch=b32 -S init_module -k my_kernel_modules
 
--a exit,always -F arch=b64 -S finit_module -k my_kernel_modules
--a exit,always -F arch=b32 -S finit_module -k my_kernel_modules
+-a always,exit -F arch=b64 -S finit_module -k my_kernel_modules
+-a always,exit -F arch=b32 -S finit_module -k my_kernel_modules
 
--a exit,always -F arch=b64 -S delete_module -k my_kernel_modules
--a exit,always -F arch=b32 -S delete_module -k my_kernel_modules
+-a always,exit -F arch=b64 -S delete_module -k my_kernel_modules
+-a always,exit -F arch=b32 -S delete_module -k my_kernel_modules
 
 ## Audit mount operations
--a exit,always -F arch=b64 -S mount -F auid>=1000 -F auid!=4294967295 -k my_mount
--a exit,always -F arch=b64 -F path=/usr/bin/mount -F auid>=1000 -F auid!=4294967295 -k my_mount
--a exit,always -F arch=b64 -F path=/bin/mount -F auid>=1000 -F auid!=4294967295 -k my_mount
--a exit,always -F arch=b32 -S mount -F auid>=1000 -F auid!=4294967295 -k my_mount
--a exit,always -F arch=b32 -F path=/usr/bin/mount -F auid>=1000 -F auid!=4294967295 -k my_mount
--a exit,always -F arch=b32 -F path=/bin/mount -F auid>=1000 -F auid!=4294967295 -k my_mount
+-a always,exit -F arch=b64 -S mount -F auid>=1000 -F auid!=4294967295 -k my_mount
+-a always,exit -F arch=b64 -F path=/usr/bin/mount -F auid>=1000 -F auid!=4294967295 -k my_mount
+-a always,exit -F arch=b64 -F path=/bin/mount -F auid>=1000 -F auid!=4294967295 -k my_mount
+-a always,exit -F arch=b32 -S mount -F auid>=1000 -F auid!=4294967295 -k my_mount
+-a always,exit -F arch=b32 -F path=/usr/bin/mount -F auid>=1000 -F auid!=4294967295 -k my_mount
+-a always,exit -F arch=b32 -F path=/bin/mount -F auid>=1000 -F auid!=4294967295 -k my_mount
 
--a exit,always -F path=/usr/bin/umount -F perm=x -F auid>=1000 -F auid!=4294967295 -k my_mount
--a exit,always -F path=/bin/umount -F perm=x -F auid>=1000 -F auid!=4294967295 -k my_mount
+-a always,exit -F path=/usr/bin/umount -F perm=x -F auid>=1000 -F auid!=4294967295 -k my_mount
+-a always,exit -F path=/bin/umount -F perm=x -F auid>=1000 -F auid!=4294967295 -k my_mount
 
 ## Audit local accounts
 -w /etc/passwd -p wa -k my_local_account

--- a/spec/classes/config/audit_profiles/expected/stig_el7_base_rules.txt
+++ b/spec/classes/config/audit_profiles/expected/stig_el7_base_rules.txt
@@ -1,208 +1,208 @@
 #### auditd::config::audit_profiles::stig Audit Rules ####
 
 ## Audit unsuccessful file operations
--a exit,always -F arch=b64 -S creat -F exit=-EPERM -F auid>=1000 -F auid!=4294967295 -k access
--a exit,always -F arch=b64 -S creat -F exit=-EACCES -F auid>=1000 -F auid!=4294967295 -k access
--a exit,always -F arch=b32 -S creat -F exit=-EPERM -F auid>=1000 -F auid!=4294967295 -k access
--a exit,always -F arch=b32 -S creat -F exit=-EACCES -F auid>=1000 -F auid!=4294967295 -k access
+-a always,exit -F arch=b64 -S creat -F exit=-EPERM -F auid>=1000 -F auid!=4294967295 -k access
+-a always,exit -F arch=b64 -S creat -F exit=-EACCES -F auid>=1000 -F auid!=4294967295 -k access
+-a always,exit -F arch=b32 -S creat -F exit=-EPERM -F auid>=1000 -F auid!=4294967295 -k access
+-a always,exit -F arch=b32 -S creat -F exit=-EACCES -F auid>=1000 -F auid!=4294967295 -k access
 
--a exit,always -F arch=b64 -S open -F exit=-EPERM -F auid>=1000 -F auid!=4294967295 -k access
--a exit,always -F arch=b64 -S open -F exit=-EACCES -F auid>=1000 -F auid!=4294967295 -k access
--a exit,always -F arch=b32 -S open -F exit=-EPERM -F auid>=1000 -F auid!=4294967295 -k access
--a exit,always -F arch=b32 -S open -F exit=-EACCES -F auid>=1000 -F auid!=4294967295 -k access
+-a always,exit -F arch=b64 -S open -F exit=-EPERM -F auid>=1000 -F auid!=4294967295 -k access
+-a always,exit -F arch=b64 -S open -F exit=-EACCES -F auid>=1000 -F auid!=4294967295 -k access
+-a always,exit -F arch=b32 -S open -F exit=-EPERM -F auid>=1000 -F auid!=4294967295 -k access
+-a always,exit -F arch=b32 -S open -F exit=-EACCES -F auid>=1000 -F auid!=4294967295 -k access
 
--a exit,always -F arch=b64 -S openat -F exit=-EPERM -F auid>=1000 -F auid!=4294967295 -k access
--a exit,always -F arch=b64 -S openat -F exit=-EACCES -F auid>=1000 -F auid!=4294967295 -k access
--a exit,always -F arch=b32 -S openat -F exit=-EPERM -F auid>=1000 -F auid!=4294967295 -k access
--a exit,always -F arch=b32 -S openat -F exit=-EACCES -F auid>=1000 -F auid!=4294967295 -k access
+-a always,exit -F arch=b64 -S openat -F exit=-EPERM -F auid>=1000 -F auid!=4294967295 -k access
+-a always,exit -F arch=b64 -S openat -F exit=-EACCES -F auid>=1000 -F auid!=4294967295 -k access
+-a always,exit -F arch=b32 -S openat -F exit=-EPERM -F auid>=1000 -F auid!=4294967295 -k access
+-a always,exit -F arch=b32 -S openat -F exit=-EACCES -F auid>=1000 -F auid!=4294967295 -k access
 
--a exit,always -F arch=b64 -S open_by_handle_at -F exit=-EPERM -F auid>=1000 -F auid!=4294967295 -k access
--a exit,always -F arch=b64 -S open_by_handle_at -F exit=-EACCES -F auid>=1000 -F auid!=4294967295 -k access
--a exit,always -F arch=b32 -S open_by_handle_at -F exit=-EPERM -F auid>=1000 -F auid!=4294967295 -k access
--a exit,always -F arch=b32 -S open_by_handle_at -F exit=-EACCES -F auid>=1000 -F auid!=4294967295 -k access
+-a always,exit -F arch=b64 -S open_by_handle_at -F exit=-EPERM -F auid>=1000 -F auid!=4294967295 -k access
+-a always,exit -F arch=b64 -S open_by_handle_at -F exit=-EACCES -F auid>=1000 -F auid!=4294967295 -k access
+-a always,exit -F arch=b32 -S open_by_handle_at -F exit=-EPERM -F auid>=1000 -F auid!=4294967295 -k access
+-a always,exit -F arch=b32 -S open_by_handle_at -F exit=-EACCES -F auid>=1000 -F auid!=4294967295 -k access
 
--a exit,always -F arch=b64 -S truncate -F exit=-EPERM -F auid>=1000 -F auid!=4294967295 -k access
--a exit,always -F arch=b64 -S truncate -F exit=-EACCES -F auid>=1000 -F auid!=4294967295 -k access
--a exit,always -F arch=b32 -S truncate -F exit=-EPERM -F auid>=1000 -F auid!=4294967295 -k access
--a exit,always -F arch=b32 -S truncate -F exit=-EACCES -F auid>=1000 -F auid!=4294967295 -k access
+-a always,exit -F arch=b64 -S truncate -F exit=-EPERM -F auid>=1000 -F auid!=4294967295 -k access
+-a always,exit -F arch=b64 -S truncate -F exit=-EACCES -F auid>=1000 -F auid!=4294967295 -k access
+-a always,exit -F arch=b32 -S truncate -F exit=-EPERM -F auid>=1000 -F auid!=4294967295 -k access
+-a always,exit -F arch=b32 -S truncate -F exit=-EACCES -F auid>=1000 -F auid!=4294967295 -k access
 
--a exit,always -F arch=b64 -S ftruncate -F exit=-EPERM -F auid>=1000 -F auid!=4294967295 -k access
--a exit,always -F arch=b64 -S ftruncate -F exit=-EACCES -F auid>=1000 -F auid!=4294967295 -k access
--a exit,always -F arch=b32 -S ftruncate -F exit=-EPERM -F auid>=1000 -F auid!=4294967295 -k access
--a exit,always -F arch=b32 -S ftruncate -F exit=-EACCES -F auid>=1000 -F auid!=4294967295 -k access
+-a always,exit -F arch=b64 -S ftruncate -F exit=-EPERM -F auid>=1000 -F auid!=4294967295 -k access
+-a always,exit -F arch=b64 -S ftruncate -F exit=-EACCES -F auid>=1000 -F auid!=4294967295 -k access
+-a always,exit -F arch=b32 -S ftruncate -F exit=-EPERM -F auid>=1000 -F auid!=4294967295 -k access
+-a always,exit -F arch=b32 -S ftruncate -F exit=-EACCES -F auid>=1000 -F auid!=4294967295 -k access
 
 ## Audit the execution of password commands
--a exit,always -F path=/usr/bin/passwd -F perm=x -F auid>=1000 -F auid!=4294967295 -k privileged-passwd
--a exit,always -F path=/bin/passwd -F perm=x -F auid>=1000 -F auid!=4294967295 -k privileged-passwd
+-a always,exit -F path=/usr/bin/passwd -F perm=x -F auid>=1000 -F auid!=4294967295 -k privileged-passwd
+-a always,exit -F path=/bin/passwd -F perm=x -F auid>=1000 -F auid!=4294967295 -k privileged-passwd
 
--a exit,always -F path=/usr/sbin/unix_chkpwd -F perm=x -F auid>=1000 -F auid!=4294967295 -k privileged-passwd
--a exit,always -F path=/sbin/unix_chkpwd -F perm=x -F auid>=1000 -F auid!=4294967295 -k privileged-passwd
+-a always,exit -F path=/usr/sbin/unix_chkpwd -F perm=x -F auid>=1000 -F auid!=4294967295 -k privileged-passwd
+-a always,exit -F path=/sbin/unix_chkpwd -F perm=x -F auid>=1000 -F auid!=4294967295 -k privileged-passwd
 
--a exit,always -F path=/usr/bin/gpasswd -F perm=x -F auid>=1000 -F auid!=4294967295 -k privileged-passwd
--a exit,always -F path=/bin/gpasswd -F perm=x -F auid>=1000 -F auid!=4294967295 -k privileged-passwd
+-a always,exit -F path=/usr/bin/gpasswd -F perm=x -F auid>=1000 -F auid!=4294967295 -k privileged-passwd
+-a always,exit -F path=/bin/gpasswd -F perm=x -F auid>=1000 -F auid!=4294967295 -k privileged-passwd
 
--a exit,always -F path=/usr/bin/chage -F perm=x -F auid>=1000 -F auid!=4294967295 -k privileged-passwd
--a exit,always -F path=/bin/chage -F perm=x -F auid>=1000 -F auid!=4294967295 -k privileged-passwd
+-a always,exit -F path=/usr/bin/chage -F perm=x -F auid>=1000 -F auid!=4294967295 -k privileged-passwd
+-a always,exit -F path=/bin/chage -F perm=x -F auid>=1000 -F auid!=4294967295 -k privileged-passwd
 
--a exit,always -F path=/usr/sbin/userhelper -F perm=x -F auid>=1000 -F auid!=4294967295 -k privileged-passwd
--a exit,always -F path=/sbin/userhelper -F perm=x -F auid>=1000 -F auid!=4294967295 -k privileged-passwd
+-a always,exit -F path=/usr/sbin/userhelper -F perm=x -F auid>=1000 -F auid!=4294967295 -k privileged-passwd
+-a always,exit -F path=/sbin/userhelper -F perm=x -F auid>=1000 -F auid!=4294967295 -k privileged-passwd
 
 ## Audit the execution of privilege-related commands
--a exit,always -F path=/usr/bin/su -F perm=x -F auid>=1000 -F auid!=4294967295 -k privileged-priv_change
--a exit,always -F path=/bin/su -F perm=x -F auid>=1000 -F auid!=4294967295 -k privileged-priv_change
+-a always,exit -F path=/usr/bin/su -F perm=x -F auid>=1000 -F auid!=4294967295 -k privileged-priv_change
+-a always,exit -F path=/bin/su -F perm=x -F auid>=1000 -F auid!=4294967295 -k privileged-priv_change
 
--a exit,always -F path=/usr/bin/sudo -F perm=x -F auid>=1000 -F auid!=4294967295 -k privileged-priv_change
--a exit,always -F path=/bin/sudo -F perm=x -F auid>=1000 -F auid!=4294967295 -k privileged-priv_change
+-a always,exit -F path=/usr/bin/sudo -F perm=x -F auid>=1000 -F auid!=4294967295 -k privileged-priv_change
+-a always,exit -F path=/bin/sudo -F perm=x -F auid>=1000 -F auid!=4294967295 -k privileged-priv_change
 
--a exit,always -F path=/usr/bin/newgrp -F perm=x -F auid>=1000 -F auid!=4294967295 -k privileged-priv_change
--a exit,always -F path=/bin/newgrp -F perm=x -F auid>=1000 -F auid!=4294967295 -k privileged-priv_change
+-a always,exit -F path=/usr/bin/newgrp -F perm=x -F auid>=1000 -F auid!=4294967295 -k privileged-priv_change
+-a always,exit -F path=/bin/newgrp -F perm=x -F auid>=1000 -F auid!=4294967295 -k privileged-priv_change
 
--a exit,always -F path=/usr/bin/chsh -F perm=x -F auid>=1000 -F auid!=4294967295 -k privileged-priv_change
--a exit,always -F path=/bin/chsh -F perm=x -F auid>=1000 -F auid!=4294967295 -k privileged-priv_change
+-a always,exit -F path=/usr/bin/chsh -F perm=x -F auid>=1000 -F auid!=4294967295 -k privileged-priv_change
+-a always,exit -F path=/bin/chsh -F perm=x -F auid>=1000 -F auid!=4294967295 -k privileged-priv_change
 
--a exit,always -F path=/usr/bin/sudoedit -F perm=x -F auid>=1000 -F auid!=4294967295 -k privileged-priv_change
--a exit,always -F path=/bin/sudoedit -F perm=x -F auid>=1000 -F auid!=4294967295 -k privileged-priv_change
+-a always,exit -F path=/usr/bin/sudoedit -F perm=x -F auid>=1000 -F auid!=4294967295 -k privileged-priv_change
+-a always,exit -F path=/bin/sudoedit -F perm=x -F auid>=1000 -F auid!=4294967295 -k privileged-priv_change
 
 ## Audit the execution of postfix-related commands
--a exit,always -F path=/usr/sbin/postdrop -F perm=x -F auid>=1000 -F auid!=4294967295 -k privileged-postfix
--a exit,always -F path=/sbin/postdrop -F perm=x -F auid>=1000 -F auid!=4294967295 -k privileged-postfix
+-a always,exit -F path=/usr/sbin/postdrop -F perm=x -F auid>=1000 -F auid!=4294967295 -k privileged-postfix
+-a always,exit -F path=/sbin/postdrop -F perm=x -F auid>=1000 -F auid!=4294967295 -k privileged-postfix
 
--a exit,always -F path=/usr/sbin/postqueue -F perm=x -F auid>=1000 -F auid!=4294967295 -k privileged-postfix
--a exit,always -F path=/sbin/postqueue -F perm=x -F auid>=1000 -F auid!=4294967295 -k privileged-postfix
+-a always,exit -F path=/usr/sbin/postqueue -F perm=x -F auid>=1000 -F auid!=4294967295 -k privileged-postfix
+-a always,exit -F path=/sbin/postqueue -F perm=x -F auid>=1000 -F auid!=4294967295 -k privileged-postfix
 
 ## Audit the execution of the ssh-keysign command
--a exit,always -F path=/usr/libexec/openssh/ssh-keysign -F perm=x -F auid>=1000 -F auid!=4294967295 -k privileged-ssh
+-a always,exit -F path=/usr/libexec/openssh/ssh-keysign -F perm=x -F auid>=1000 -F auid!=4294967295 -k privileged-ssh
 
 ## Audit the execution of the crontab command
--a exit,always -F path=/usr/bin/crontab -F perm=x -F auid>=1000 -F auid!=4294967295 -k privileged-cron
--a exit,always -F path=/bin/crontab -F perm=x -F auid>=1000 -F auid!=4294967295 -k privileged-cron
+-a always,exit -F path=/usr/bin/crontab -F perm=x -F auid>=1000 -F auid!=4294967295 -k privileged-cron
+-a always,exit -F path=/bin/crontab -F perm=x -F auid>=1000 -F auid!=4294967295 -k privileged-cron
 
 ## Audit the execution of the pam_timestamp_check command
--a exit,always -F path=/usr/sbin/pam_timestamp_check -F perm=x -F auid>=1000 -F auid!=4294967295 -k privileged-pam
--a exit,always -F path=/sbin/pam_timestamp_check -F perm=x -F auid>=1000 -F auid!=4294967295 -k privileged-pam
+-a always,exit -F path=/usr/sbin/pam_timestamp_check -F perm=x -F auid>=1000 -F auid!=4294967295 -k privileged-pam
+-a always,exit -F path=/sbin/pam_timestamp_check -F perm=x -F auid>=1000 -F auid!=4294967295 -k privileged-pam
 
 ## Audit selinux commands
--a exit,always -F path=/usr/sbin/semanage -F perm=x -F auid>=1000 -F auid!=4294967295 -k privileged-priv_change
--a exit,always -F path=/sbin/semanage -F perm=x -F auid>=1000 -F auid!=4294967295 -k privileged-priv_change
+-a always,exit -F path=/usr/sbin/semanage -F perm=x -F auid>=1000 -F auid!=4294967295 -k privileged-priv_change
+-a always,exit -F path=/sbin/semanage -F perm=x -F auid>=1000 -F auid!=4294967295 -k privileged-priv_change
 
--a exit,always -F path=/usr/sbin/setsebool -F perm=x -F auid>=1000 -F auid!=4294967295 -k privileged-priv_change
--a exit,always -F path=/sbin/setsebool -F perm=x -F auid>=1000 -F auid!=4294967295 -k privileged-priv_change
+-a always,exit -F path=/usr/sbin/setsebool -F perm=x -F auid>=1000 -F auid!=4294967295 -k privileged-priv_change
+-a always,exit -F path=/sbin/setsebool -F perm=x -F auid>=1000 -F auid!=4294967295 -k privileged-priv_change
 
--a exit,always -F path=/usr/bin/chcon -F perm=x -F auid>=1000 -F auid!=4294967295 -k privileged-priv_change
--a exit,always -F path=/bin/chcon -F perm=x -F auid>=1000 -F auid!=4294967295 -k privileged-priv_change
+-a always,exit -F path=/usr/bin/chcon -F perm=x -F auid>=1000 -F auid!=4294967295 -k privileged-priv_change
+-a always,exit -F path=/bin/chcon -F perm=x -F auid>=1000 -F auid!=4294967295 -k privileged-priv_change
 
--a exit,always -F path=/usr/sbin/setfiles -F perm=x -F auid>=1000 -F auid!=4294967295 -k privileged-priv_change
--a exit,always -F path=/sbin/setfiles -F perm=x -F auid>=1000 -F auid!=4294967295 -k privileged-priv_change
+-a always,exit -F path=/usr/sbin/setfiles -F perm=x -F auid>=1000 -F auid!=4294967295 -k privileged-priv_change
+-a always,exit -F path=/sbin/setfiles -F perm=x -F auid>=1000 -F auid!=4294967295 -k privileged-priv_change
 
--a exit,always -F path=/sbin/restorecon -F perm=x -F auid>=1000 -F auid!=4294967295 -k privileged-priv_change
--a exit,always -F path=/usr/sbin/restorecon -F perm=x -F auid>=1000 -F auid!=4294967295 -k privileged-priv_change
+-a always,exit -F path=/sbin/restorecon -F perm=x -F auid>=1000 -F auid!=4294967295 -k privileged-priv_change
+-a always,exit -F path=/usr/sbin/restorecon -F perm=x -F auid>=1000 -F auid!=4294967295 -k privileged-priv_change
 
 ## Permissions auditing separated by chown, chmod, and attr
--a exit,always -F arch=b64 -S chown -F auid>=1000 -F auid!=4294967295 -k perm_mod
--a exit,always -F arch=b32 -S chown -F auid>=1000 -F auid!=4294967295 -k perm_mod
+-a always,exit -F arch=b64 -S chown -F auid>=1000 -F auid!=4294967295 -k perm_mod
+-a always,exit -F arch=b32 -S chown -F auid>=1000 -F auid!=4294967295 -k perm_mod
 
--a exit,always -F arch=b64 -S fchown -F auid>=1000 -F auid!=4294967295 -k perm_mod
--a exit,always -F arch=b32 -S fchown -F auid>=1000 -F auid!=4294967295 -k perm_mod
+-a always,exit -F arch=b64 -S fchown -F auid>=1000 -F auid!=4294967295 -k perm_mod
+-a always,exit -F arch=b32 -S fchown -F auid>=1000 -F auid!=4294967295 -k perm_mod
 
--a exit,always -F arch=b64 -S lchown -F auid>=1000 -F auid!=4294967295 -k perm_mod
--a exit,always -F arch=b32 -S lchown -F auid>=1000 -F auid!=4294967295 -k perm_mod
+-a always,exit -F arch=b64 -S lchown -F auid>=1000 -F auid!=4294967295 -k perm_mod
+-a always,exit -F arch=b32 -S lchown -F auid>=1000 -F auid!=4294967295 -k perm_mod
 
--a exit,always -F arch=b64 -S fchownat -F auid>=1000 -F auid!=4294967295 -k perm_mod
--a exit,always -F arch=b32 -S fchownat -F auid>=1000 -F auid!=4294967295 -k perm_mod
+-a always,exit -F arch=b64 -S fchownat -F auid>=1000 -F auid!=4294967295 -k perm_mod
+-a always,exit -F arch=b32 -S fchownat -F auid>=1000 -F auid!=4294967295 -k perm_mod
 
--a exit,always -F arch=b64 -S chmod -F auid>=1000 -F auid!=4294967295 -k perm_mod
--a exit,always -F arch=b32 -S chmod -F auid>=1000 -F auid!=4294967295 -k perm_mod
+-a always,exit -F arch=b64 -S chmod -F auid>=1000 -F auid!=4294967295 -k perm_mod
+-a always,exit -F arch=b32 -S chmod -F auid>=1000 -F auid!=4294967295 -k perm_mod
 
--a exit,always -F arch=b64 -S fchmod -F auid>=1000 -F auid!=4294967295 -k perm_mod
--a exit,always -F arch=b32 -S fchmod -F auid>=1000 -F auid!=4294967295 -k perm_mod
+-a always,exit -F arch=b64 -S fchmod -F auid>=1000 -F auid!=4294967295 -k perm_mod
+-a always,exit -F arch=b32 -S fchmod -F auid>=1000 -F auid!=4294967295 -k perm_mod
 
--a exit,always -F arch=b64 -S fchmodat -F auid>=1000 -F auid!=4294967295 -k perm_mod
--a exit,always -F arch=b32 -S fchmodat -F auid>=1000 -F auid!=4294967295 -k perm_mod
+-a always,exit -F arch=b64 -S fchmodat -F auid>=1000 -F auid!=4294967295 -k perm_mod
+-a always,exit -F arch=b32 -S fchmodat -F auid>=1000 -F auid!=4294967295 -k perm_mod
 
--a exit,always -F arch=b64 -S setxattr -F auid>=1000 -F auid!=4294967295 -k perm_mod
--a exit,always -F arch=b32 -S setxattr -F auid>=1000 -F auid!=4294967295 -k perm_mod
+-a always,exit -F arch=b64 -S setxattr -F auid>=1000 -F auid!=4294967295 -k perm_mod
+-a always,exit -F arch=b32 -S setxattr -F auid>=1000 -F auid!=4294967295 -k perm_mod
 
--a exit,always -F arch=b64 -S fsetxattr -F auid>=1000 -F auid!=4294967295 -k perm_mod
--a exit,always -F arch=b32 -S fsetxattr -F auid>=1000 -F auid!=4294967295 -k perm_mod
+-a always,exit -F arch=b64 -S fsetxattr -F auid>=1000 -F auid!=4294967295 -k perm_mod
+-a always,exit -F arch=b32 -S fsetxattr -F auid>=1000 -F auid!=4294967295 -k perm_mod
 
--a exit,always -F arch=b64 -S lsetxattr -F auid>=1000 -F auid!=4294967295 -k perm_mod
--a exit,always -F arch=b32 -S lsetxattr -F auid>=1000 -F auid!=4294967295 -k perm_mod
+-a always,exit -F arch=b64 -S lsetxattr -F auid>=1000 -F auid!=4294967295 -k perm_mod
+-a always,exit -F arch=b32 -S lsetxattr -F auid>=1000 -F auid!=4294967295 -k perm_mod
 
--a exit,always -F arch=b64 -S removexattr -F auid>=1000 -F auid!=4294967295 -k perm_mod
--a exit,always -F arch=b32 -S removexattr -F auid>=1000 -F auid!=4294967295 -k perm_mod
+-a always,exit -F arch=b64 -S removexattr -F auid>=1000 -F auid!=4294967295 -k perm_mod
+-a always,exit -F arch=b32 -S removexattr -F auid>=1000 -F auid!=4294967295 -k perm_mod
 
--a exit,always -F arch=b64 -S fremovexattr -F auid>=1000 -F auid!=4294967295 -k perm_mod
--a exit,always -F arch=b32 -S fremovexattr -F auid>=1000 -F auid!=4294967295 -k perm_mod
+-a always,exit -F arch=b64 -S fremovexattr -F auid>=1000 -F auid!=4294967295 -k perm_mod
+-a always,exit -F arch=b32 -S fremovexattr -F auid>=1000 -F auid!=4294967295 -k perm_mod
 
--a exit,always -F arch=b64 -S lremovexattr -F auid>=1000 -F auid!=4294967295 -k perm_mod
--a exit,always -F arch=b32 -S lremovexattr -F auid>=1000 -F auid!=4294967295 -k perm_mod
+-a always,exit -F arch=b64 -S lremovexattr -F auid>=1000 -F auid!=4294967295 -k perm_mod
+-a always,exit -F arch=b32 -S lremovexattr -F auid>=1000 -F auid!=4294967295 -k perm_mod
 
 ## Audit rename/removal operations
--a exit,always -F arch=b64 -S rename -F perm=x -F auid>=1000 -F auid!=4294967295 -k delete
--a exit,always -F arch=b32 -S rename -F perm=x -F auid>=1000 -F auid!=4294967295 -k delete
+-a always,exit -F arch=b64 -S rename -F perm=x -F auid>=1000 -F auid!=4294967295 -k delete
+-a always,exit -F arch=b32 -S rename -F perm=x -F auid>=1000 -F auid!=4294967295 -k delete
 
--a exit,always -F arch=b64 -S renameat -F perm=x -F auid>=1000 -F auid!=4294967295 -k delete
--a exit,always -F arch=b32 -S renameat -F perm=x -F auid>=1000 -F auid!=4294967295 -k delete
+-a always,exit -F arch=b64 -S renameat -F perm=x -F auid>=1000 -F auid!=4294967295 -k delete
+-a always,exit -F arch=b32 -S renameat -F perm=x -F auid>=1000 -F auid!=4294967295 -k delete
 
--a exit,always -F arch=b64 -S rmdir -F perm=x -F auid>=1000 -F auid!=4294967295 -k delete
--a exit,always -F arch=b32 -S rmdir -F perm=x -F auid>=1000 -F auid!=4294967295 -k delete
+-a always,exit -F arch=b64 -S rmdir -F perm=x -F auid>=1000 -F auid!=4294967295 -k delete
+-a always,exit -F arch=b32 -S rmdir -F perm=x -F auid>=1000 -F auid!=4294967295 -k delete
 
--a exit,always -F arch=b64 -S unlink -F perm=x -F auid>=1000 -F auid!=4294967295 -k delete
--a exit,always -F arch=b32 -S unlink -F perm=x -F auid>=1000 -F auid!=4294967295 -k delete
+-a always,exit -F arch=b64 -S unlink -F perm=x -F auid>=1000 -F auid!=4294967295 -k delete
+-a always,exit -F arch=b32 -S unlink -F perm=x -F auid>=1000 -F auid!=4294967295 -k delete
 
--a exit,always -F arch=b64 -S unlinkat -F perm=x -F auid>=1000 -F auid!=4294967295 -k delete
--a exit,always -F arch=b32 -S unlinkat -F perm=x -F auid>=1000 -F auid!=4294967295 -k delete
+-a always,exit -F arch=b64 -S unlinkat -F perm=x -F auid>=1000 -F auid!=4294967295 -k delete
+-a always,exit -F arch=b32 -S unlinkat -F perm=x -F auid>=1000 -F auid!=4294967295 -k delete
 
 ## Audit the execution of suid and sgid binaries.
--a exit,always -F path=/usr/bin/at -F perm=x -F auid>=1000 -F auid!=4294967295 -k setuid/setgid
--a exit,always -F path=/usr/bin/chage -F perm=x -F auid>=1000 -F auid!=4294967295 -k setuid/setgid
--a exit,always -F path=/usr/bin/chcon -F perm=x -F auid>=1000 -F auid!=4294967295 -k setuid/setgid
--a exit,always -F path=/usr/bin/chfn -F perm=x -F auid>=1000 -F auid!=4294967295 -k setuid/setgid
--a exit,always -F path=/usr/bin/chsh -F perm=x -F auid>=1000 -F auid!=4294967295 -k setuid/setgid
--a exit,always -F path=/usr/bin/crontab -F perm=x -F auid>=1000 -F auid!=4294967295 -k setuid/setgid
--a exit,always -F path=/usr/bin/fusermount -F perm=x -F auid>=1000 -F auid!=4294967295 -k setuid/setgid
--a exit,always -F path=/usr/bin/gpasswd -F perm=x -F auid>=1000 -F auid!=4294967295 -k setuid/setgid
--a exit,always -F path=/usr/bin/incrontab -F perm=x -F auid>=1000 -F auid!=4294967295 -k setuid/setgid
--a exit,always -F path=/usr/bin/ksu -F perm=x -F auid>=1000 -F auid!=4294967295 -k setuid/setgid
--a exit,always -F path=/usr/bin/locate -F perm=x -F auid>=1000 -F auid!=4294967295 -k setuid/setgid
--a exit,always -F path=/usr/bin/mount -F perm=x -F auid>=1000 -F auid!=4294967295 -k setuid/setgid
--a exit,always -F path=/usr/bin/newgidmap -F perm=x -F auid>=1000 -F auid!=4294967295 -k setuid/setgid
--a exit,always -F path=/usr/bin/newgrp -F perm=x -F auid>=1000 -F auid!=4294967295 -k setuid/setgid
--a exit,always -F path=/usr/bin/newuidmap -F perm=x -F auid>=1000 -F auid!=4294967295 -k setuid/setgid
--a exit,always -F path=/usr/bin/passwd -F perm=x -F auid>=1000 -F auid!=4294967295 -k setuid/setgid
--a exit,always -F path=/usr/bin/pkexec -F perm=x -F auid>=1000 -F auid!=4294967295 -k setuid/setgid
--a exit,always -F path=/usr/bin/screen -F perm=x -F auid>=1000 -F auid!=4294967295 -k setuid/setgid
--a exit,always -F path=/usr/bin/ssh-agent -F perm=x -F auid>=1000 -F auid!=4294967295 -k setuid/setgid
--a exit,always -F path=/usr/bin/su -F perm=x -F auid>=1000 -F auid!=4294967295 -k setuid/setgid
--a exit,always -F path=/usr/bin/sudo -F perm=x -F auid>=1000 -F auid!=4294967295 -k setuid/setgid
--a exit,always -F path=/usr/bin/sudoedit -F perm=x -F auid>=1000 -F auid!=4294967295 -k setuid/setgid
--a exit,always -F path=/usr/bin/umount -F perm=x -F auid>=1000 -F auid!=4294967295 -k setuid/setgid
--a exit,always -F path=/usr/bin/wall -F perm=x -F auid>=1000 -F auid!=4294967295 -k setuid/setgid
--a exit,always -F path=/usr/bin/write -F perm=x -F auid>=1000 -F auid!=4294967295 -k setuid/setgid
--a exit,always -F path=/usr/bin/Xorg -F perm=x -F auid>=1000 -F auid!=4294967295 -k setuid/setgid
--a exit,always -F path=/usr/lib64/dbus-1/dbus-daemon-launch-helper -F perm=x -F auid>=1000 -F auid!=4294967295 -k setuid/setgid
--a exit,always -F path=/usr/libexec/dbus-1/dbus-daemon-launch-helper -F perm=x -F auid>=1000 -F auid!=4294967295 -k setuid/setgid
--a exit,always -F path=/usr/libexec/openssh/ssh-keysign -F perm=x -F auid>=1000 -F auid!=4294967295 -k setuid/setgid
--a exit,always -F path=/usr/libexec/pt_chown -F perm=x -F auid>=1000 -F auid!=4294967295 -k setuid/setgid
--a exit,always -F path=/usr/libexec/sssd/krb5_child -F perm=x -F auid>=1000 -F auid!=4294967295 -k setuid/setgid
--a exit,always -F path=/usr/libexec/sssd/ldap_child -F perm=x -F auid>=1000 -F auid!=4294967295 -k setuid/setgid
--a exit,always -F path=/usr/libexec/sssd/proxy_child -F perm=x -F auid>=1000 -F auid!=4294967295 -k setuid/setgid
--a exit,always -F path=/usr/libexec/sssd/selinux_child -F perm=x -F auid>=1000 -F auid!=4294967295 -k setuid/setgid
--a exit,always -F path=/usr/libexec/utempter/utempter -F perm=x -F auid>=1000 -F auid!=4294967295 -k setuid/setgid
--a exit,always -F path=/usr/lib/polkit-1/polkit-agent-helper-1 -F perm=x -F auid>=1000 -F auid!=4294967295 -k setuid/setgid
--a exit,always -F path=/usr/sbin/mount.nfs -F perm=x -F auid>=1000 -F auid!=4294967295 -k setuid/setgid
--a exit,always -F path=/usr/sbin/netreport -F perm=x -F auid>=1000 -F auid!=4294967295 -k setuid/setgid
--a exit,always -F path=/usr/sbin/pam_timestamp_check -F perm=x -F auid>=1000 -F auid!=4294967295 -k setuid/setgid
--a exit,always -F path=/usr/sbin/postdrop -F perm=x -F auid>=1000 -F auid!=4294967295 -k setuid/setgid
--a exit,always -F path=/usr/sbin/postqueue -F perm=x -F auid>=1000 -F auid!=4294967295 -k setuid/setgid
--a exit,always -F path=/usr/sbin/restorecon -F perm=x -F auid>=1000 -F auid!=4294967295 -k setuid/setgid
--a exit,always -F path=/usr/sbin/semanage -F perm=x -F auid>=1000 -F auid!=4294967295 -k setuid/setgid
--a exit,always -F path=/usr/sbin/setfiles -F perm=x -F auid>=1000 -F auid!=4294967295 -k setuid/setgid
--a exit,always -F path=/usr/sbin/setsebool -F perm=x -F auid>=1000 -F auid!=4294967295 -k setuid/setgid
--a exit,always -F path=/usr/sbin/seunshare -F perm=x -F auid>=1000 -F auid!=4294967295 -k setuid/setgid
--a exit,always -F path=/usr/sbin/unix_chkpwd -F perm=x -F auid>=1000 -F auid!=4294967295 -k setuid/setgid
--a exit,always -F path=/usr/sbin/userhelper -F perm=x -F auid>=1000 -F auid!=4294967295 -k setuid/setgid
--a exit,always -F path=/usr/sbin/usernetctl -F perm=x -F auid>=1000 -F auid!=4294967295 -k setuid/setgid
+-a always,exit -F path=/usr/bin/at -F perm=x -F auid>=1000 -F auid!=4294967295 -k setuid/setgid
+-a always,exit -F path=/usr/bin/chage -F perm=x -F auid>=1000 -F auid!=4294967295 -k setuid/setgid
+-a always,exit -F path=/usr/bin/chcon -F perm=x -F auid>=1000 -F auid!=4294967295 -k setuid/setgid
+-a always,exit -F path=/usr/bin/chfn -F perm=x -F auid>=1000 -F auid!=4294967295 -k setuid/setgid
+-a always,exit -F path=/usr/bin/chsh -F perm=x -F auid>=1000 -F auid!=4294967295 -k setuid/setgid
+-a always,exit -F path=/usr/bin/crontab -F perm=x -F auid>=1000 -F auid!=4294967295 -k setuid/setgid
+-a always,exit -F path=/usr/bin/fusermount -F perm=x -F auid>=1000 -F auid!=4294967295 -k setuid/setgid
+-a always,exit -F path=/usr/bin/gpasswd -F perm=x -F auid>=1000 -F auid!=4294967295 -k setuid/setgid
+-a always,exit -F path=/usr/bin/incrontab -F perm=x -F auid>=1000 -F auid!=4294967295 -k setuid/setgid
+-a always,exit -F path=/usr/bin/ksu -F perm=x -F auid>=1000 -F auid!=4294967295 -k setuid/setgid
+-a always,exit -F path=/usr/bin/locate -F perm=x -F auid>=1000 -F auid!=4294967295 -k setuid/setgid
+-a always,exit -F path=/usr/bin/mount -F perm=x -F auid>=1000 -F auid!=4294967295 -k setuid/setgid
+-a always,exit -F path=/usr/bin/newgidmap -F perm=x -F auid>=1000 -F auid!=4294967295 -k setuid/setgid
+-a always,exit -F path=/usr/bin/newgrp -F perm=x -F auid>=1000 -F auid!=4294967295 -k setuid/setgid
+-a always,exit -F path=/usr/bin/newuidmap -F perm=x -F auid>=1000 -F auid!=4294967295 -k setuid/setgid
+-a always,exit -F path=/usr/bin/passwd -F perm=x -F auid>=1000 -F auid!=4294967295 -k setuid/setgid
+-a always,exit -F path=/usr/bin/pkexec -F perm=x -F auid>=1000 -F auid!=4294967295 -k setuid/setgid
+-a always,exit -F path=/usr/bin/screen -F perm=x -F auid>=1000 -F auid!=4294967295 -k setuid/setgid
+-a always,exit -F path=/usr/bin/ssh-agent -F perm=x -F auid>=1000 -F auid!=4294967295 -k setuid/setgid
+-a always,exit -F path=/usr/bin/su -F perm=x -F auid>=1000 -F auid!=4294967295 -k setuid/setgid
+-a always,exit -F path=/usr/bin/sudo -F perm=x -F auid>=1000 -F auid!=4294967295 -k setuid/setgid
+-a always,exit -F path=/usr/bin/sudoedit -F perm=x -F auid>=1000 -F auid!=4294967295 -k setuid/setgid
+-a always,exit -F path=/usr/bin/umount -F perm=x -F auid>=1000 -F auid!=4294967295 -k setuid/setgid
+-a always,exit -F path=/usr/bin/wall -F perm=x -F auid>=1000 -F auid!=4294967295 -k setuid/setgid
+-a always,exit -F path=/usr/bin/write -F perm=x -F auid>=1000 -F auid!=4294967295 -k setuid/setgid
+-a always,exit -F path=/usr/bin/Xorg -F perm=x -F auid>=1000 -F auid!=4294967295 -k setuid/setgid
+-a always,exit -F path=/usr/lib64/dbus-1/dbus-daemon-launch-helper -F perm=x -F auid>=1000 -F auid!=4294967295 -k setuid/setgid
+-a always,exit -F path=/usr/libexec/dbus-1/dbus-daemon-launch-helper -F perm=x -F auid>=1000 -F auid!=4294967295 -k setuid/setgid
+-a always,exit -F path=/usr/libexec/openssh/ssh-keysign -F perm=x -F auid>=1000 -F auid!=4294967295 -k setuid/setgid
+-a always,exit -F path=/usr/libexec/pt_chown -F perm=x -F auid>=1000 -F auid!=4294967295 -k setuid/setgid
+-a always,exit -F path=/usr/libexec/sssd/krb5_child -F perm=x -F auid>=1000 -F auid!=4294967295 -k setuid/setgid
+-a always,exit -F path=/usr/libexec/sssd/ldap_child -F perm=x -F auid>=1000 -F auid!=4294967295 -k setuid/setgid
+-a always,exit -F path=/usr/libexec/sssd/proxy_child -F perm=x -F auid>=1000 -F auid!=4294967295 -k setuid/setgid
+-a always,exit -F path=/usr/libexec/sssd/selinux_child -F perm=x -F auid>=1000 -F auid!=4294967295 -k setuid/setgid
+-a always,exit -F path=/usr/libexec/utempter/utempter -F perm=x -F auid>=1000 -F auid!=4294967295 -k setuid/setgid
+-a always,exit -F path=/usr/lib/polkit-1/polkit-agent-helper-1 -F perm=x -F auid>=1000 -F auid!=4294967295 -k setuid/setgid
+-a always,exit -F path=/usr/sbin/mount.nfs -F perm=x -F auid>=1000 -F auid!=4294967295 -k setuid/setgid
+-a always,exit -F path=/usr/sbin/netreport -F perm=x -F auid>=1000 -F auid!=4294967295 -k setuid/setgid
+-a always,exit -F path=/usr/sbin/pam_timestamp_check -F perm=x -F auid>=1000 -F auid!=4294967295 -k setuid/setgid
+-a always,exit -F path=/usr/sbin/postdrop -F perm=x -F auid>=1000 -F auid!=4294967295 -k setuid/setgid
+-a always,exit -F path=/usr/sbin/postqueue -F perm=x -F auid>=1000 -F auid!=4294967295 -k setuid/setgid
+-a always,exit -F path=/usr/sbin/restorecon -F perm=x -F auid>=1000 -F auid!=4294967295 -k setuid/setgid
+-a always,exit -F path=/usr/sbin/semanage -F perm=x -F auid>=1000 -F auid!=4294967295 -k setuid/setgid
+-a always,exit -F path=/usr/sbin/setfiles -F perm=x -F auid>=1000 -F auid!=4294967295 -k setuid/setgid
+-a always,exit -F path=/usr/sbin/setsebool -F perm=x -F auid>=1000 -F auid!=4294967295 -k setuid/setgid
+-a always,exit -F path=/usr/sbin/seunshare -F perm=x -F auid>=1000 -F auid!=4294967295 -k setuid/setgid
+-a always,exit -F path=/usr/sbin/unix_chkpwd -F perm=x -F auid>=1000 -F auid!=4294967295 -k setuid/setgid
+-a always,exit -F path=/usr/sbin/userhelper -F perm=x -F auid>=1000 -F auid!=4294967295 -k setuid/setgid
+-a always,exit -F path=/usr/sbin/usernetctl -F perm=x -F auid>=1000 -F auid!=4294967295 -k setuid/setgid
 
 ## Audit the loading and unloading of kernel modules.
 -w /usr/bin/kmod -p x -F auid!=4294967295 -k module-change
@@ -216,28 +216,28 @@
 -w /usr/sbin/modprobe -p x -F auid!=4294967295 -k module-change
 -w /sbin/modprobe -p x -F auid!=4294967295 -k module-change
 
--a exit,always -F arch=b64 -S create_module -k module-change
--a exit,always -F arch=b32 -S create_module -k module-change
+-a always,exit -F arch=b64 -S create_module -k module-change
+-a always,exit -F arch=b32 -S create_module -k module-change
 
--a exit,always -F arch=b64 -S init_module -k module-change
--a exit,always -F arch=b32 -S init_module -k module-change
+-a always,exit -F arch=b64 -S init_module -k module-change
+-a always,exit -F arch=b32 -S init_module -k module-change
 
--a exit,always -F arch=b64 -S finit_module -k module-change
--a exit,always -F arch=b32 -S finit_module -k module-change
+-a always,exit -F arch=b64 -S finit_module -k module-change
+-a always,exit -F arch=b32 -S finit_module -k module-change
 
--a exit,always -F arch=b64 -S delete_module -k module-change
--a exit,always -F arch=b32 -S delete_module -k module-change
+-a always,exit -F arch=b64 -S delete_module -k module-change
+-a always,exit -F arch=b32 -S delete_module -k module-change
 
 ## Audit mount operations
--a exit,always -F arch=b64 -S mount -F auid>=1000 -F auid!=4294967295 -k privileged-mount
--a exit,always -F arch=b64 -F path=/usr/bin/mount -F auid>=1000 -F auid!=4294967295 -k privileged-mount
--a exit,always -F arch=b64 -F path=/bin/mount -F auid>=1000 -F auid!=4294967295 -k privileged-mount
--a exit,always -F arch=b32 -S mount -F auid>=1000 -F auid!=4294967295 -k privileged-mount
--a exit,always -F arch=b32 -F path=/usr/bin/mount -F auid>=1000 -F auid!=4294967295 -k privileged-mount
--a exit,always -F arch=b32 -F path=/bin/mount -F auid>=1000 -F auid!=4294967295 -k privileged-mount
+-a always,exit -F arch=b64 -S mount -F auid>=1000 -F auid!=4294967295 -k privileged-mount
+-a always,exit -F arch=b64 -F path=/usr/bin/mount -F auid>=1000 -F auid!=4294967295 -k privileged-mount
+-a always,exit -F arch=b64 -F path=/bin/mount -F auid>=1000 -F auid!=4294967295 -k privileged-mount
+-a always,exit -F arch=b32 -S mount -F auid>=1000 -F auid!=4294967295 -k privileged-mount
+-a always,exit -F arch=b32 -F path=/usr/bin/mount -F auid>=1000 -F auid!=4294967295 -k privileged-mount
+-a always,exit -F arch=b32 -F path=/bin/mount -F auid>=1000 -F auid!=4294967295 -k privileged-mount
 
--a exit,always -F path=/usr/bin/umount -F perm=x -F auid>=1000 -F auid!=4294967295 -k privileged-mount
--a exit,always -F path=/bin/umount -F perm=x -F auid>=1000 -F auid!=4294967295 -k privileged-mount
+-a always,exit -F path=/usr/bin/umount -F perm=x -F auid>=1000 -F auid!=4294967295 -k privileged-mount
+-a always,exit -F path=/bin/umount -F perm=x -F auid>=1000 -F auid!=4294967295 -k privileged-mount
 
 ## Audit local accounts
 -w /etc/passwd -p wa -k identity

--- a/spec/classes/config/audit_profiles/simp_spec.rb
+++ b/spec/classes/config/audit_profiles/simp_spec.rb
@@ -34,19 +34,19 @@ describe 'auditd' do
         it 'disables chmod auditing by default' do
           # chmod is disabled by default (SIMP-2250)
           is_expected.not_to contain_file('/etc/audit/rules.d/50_00_simp_base.rules').with_content(
-            %r(^-a exit,always -F arch=b\d\d -S chmod,fchmod,fchmodat -k chmod$)
+            %r(^-a always,exit -F arch=b\d\d -S chmod,fchmod,fchmodat -k chmod$)
           )
         end
 
         it 'disables rename/remove auditing by default' do
           is_expected.not_to contain_file('/etc/audit/rules.d/50_00_simp_base.rules').with_content(
-            %r(^-a exit,always -F arch=b\d\d -S rename,renameat,rmdir,unlink,unlinkat -F perm=x -k delete)
+            %r(^-a always,exit -F arch=b\d\d -S rename,renameat,rmdir,unlink,unlinkat -F perm=x -k delete)
           )
         end
 
         it 'disables umask auditing by default' do
           is_expected.not_to contain_file('/etc/audit/rules.d/50_00_simp_base.rules').with_content(
-            %r(^-a exit,always -F arch=b\d\d -S umask -k umask)
+            %r(^-a always,exit -F arch=b\d\d -S umask -k umask)
           )
         end
 
@@ -59,11 +59,11 @@ describe 'auditd' do
 
         it 'disables selinux commands auditing by default' do
           is_expected.not_to contain_file('/etc/audit/rules.d/50_00_simp_base.rules').with_content(
-            %r{^-a exit,always -F path=/usr/bin/(chcon|semanage|setsebool) -F perm=x -k privileged-priv_change}
+            %r{^-a always,exit -F path=/usr/bin/(chcon|semanage|setsebool) -F perm=x -k privileged-priv_change}
           )
 
           is_expected.not_to contain_file('/etc/audit/rules.d/50_00_simp_base.rules').with_content(
-            %r(^-a exit,always -F path=/(usr/)?sbin/setfiles -F perm=x -k privileged-priv_change)
+            %r(^-a always,exit -F path=/(usr/)?sbin/setfiles -F perm=x -k privileged-priv_change)
           )
         end
       end
@@ -128,11 +128,11 @@ describe 'auditd' do
       context 'with privilege-related command auditing disabled' do
         let(:hieradata) { 'simp_audit_profile/disable__audit_priv_cmds' }
         [
-          %r{^-a exit,always -F path=/(usr/)?bin/su -F perm=x -k privileged-priv_change$},
-          %r{^-a exit,always -F path=/usr/bin/sudo -F perm=x -k privileged-priv_change$},
-          %r{^-a exit,always -F path=/usr/bin/newgrp -F perm=x -k privileged-priv_change$},
-          %r{^-a exit,always -F path=/usr/bin/chsh -F perm=x -k privileged-priv_change$},
-          %r{^-a exit,always -F path=/(usr/)?bin/sudoedit -F perm=x -k privileged-priv_change$}
+          %r{^-a always,exit -F path=/(usr/)?bin/su -F perm=x -k privileged-priv_change$},
+          %r{^-a always,exit -F path=/usr/bin/sudo -F perm=x -k privileged-priv_change$},
+          %r{^-a always,exit -F path=/usr/bin/newgrp -F perm=x -k privileged-priv_change$},
+          %r{^-a always,exit -F path=/usr/bin/chsh -F perm=x -k privileged-priv_change$},
+          %r{^-a always,exit -F path=/(usr/)?bin/sudoedit -F perm=x -k privileged-priv_change$}
         ].each do |command_regex|
           it {
             is_expected.not_to contain_file('/etc/audit/rules.d/50_00_simp_base.rules').
@@ -201,7 +201,7 @@ describe 'auditd' do
 
         it {
           is_expected.not_to contain_file('/etc/audit/rules.d/50_00_simp_base.rules'). with_content(
-            %r{^-a exit,always -F arch=b\d\d -S ptrace -k paranoid$}
+            %r{^-a always,exit -F arch=b\d\d -S ptrace -k paranoid$}
           )
         }
       end
@@ -211,7 +211,7 @@ describe 'auditd' do
 
         it {
           is_expected.not_to contain_file('/etc/audit/rules.d/50_00_simp_base.rules').with_content(
-            %r{^-a exit,always -F arch=b\d\d -S personality -k paranoid$}
+            %r{^-a always,exit -F arch=b\d\d -S personality -k paranoid$}
           )
         }
       end
@@ -221,7 +221,7 @@ describe 'auditd' do
 
         it {
           is_expected.to contain_file('/etc/audit/rules.d/50_00_simp_base.rules').with_content(
-            %r(^-a exit,always -F arch=b\d\d -S chmod,fchmod,fchmodat -k chmod$)
+            %r(^-a always,exit -F arch=b\d\d -S chmod,fchmod,fchmodat -k chmod$)
           )
         }
       end
@@ -231,13 +231,13 @@ describe 'auditd' do
 
         it {
           is_expected.to contain_file('/etc/audit/rules.d/50_00_simp_base.rules').with_content(
-            %r(^-a exit,always -F arch=b64 -S rename,renameat,rmdir,unlink,unlinkat -F perm=x -k delete)
+            %r(^-a always,exit -F arch=b64 -S rename,renameat,rmdir,unlink,unlinkat -F perm=x -k delete)
           )
         }
 
         it {
           is_expected.to contain_file('/etc/audit/rules.d/50_00_simp_base.rules').with_content(
-            %r(^-a exit,always -F arch=b32 -S rename,renameat,rmdir,unlink,unlinkat -F perm=x -k delete)
+            %r(^-a always,exit -F arch=b32 -S rename,renameat,rmdir,unlink,unlinkat -F perm=x -k delete)
           )
         }
       end
@@ -247,7 +247,7 @@ describe 'auditd' do
 
         it {
           is_expected.to contain_file('/etc/audit/rules.d/50_00_simp_base.rules').with_content(
-            %r(^-a exit,always -F arch=b\d\d -S umask -k umask)
+            %r(^-a always,exit -F arch=b\d\d -S umask -k umask)
           )
         }
       end
@@ -257,25 +257,25 @@ describe 'auditd' do
 
         it {
           is_expected.to contain_file('/etc/audit/rules.d/50_00_simp_base.rules').with_content(
-            %r(^-a exit,always -F path=/usr/bin/chcon -F perm=x -k privileged-priv_change)
+            %r(^-a always,exit -F path=/usr/bin/chcon -F perm=x -k privileged-priv_change)
           )
         }
 
         it {
           is_expected.to contain_file('/etc/audit/rules.d/50_00_simp_base.rules').with_content(
-            %r(^-a exit,always -F path=/usr/sbin/semanage -F perm=x -k privileged-priv_change)
+            %r(^-a always,exit -F path=/usr/sbin/semanage -F perm=x -k privileged-priv_change)
           )
         }
 
         it {
           is_expected.to contain_file('/etc/audit/rules.d/50_00_simp_base.rules').with_content(
-            %r(^-a exit,always -F path=/usr/sbin/setsebool -F perm=x -k privileged-priv_change)
+            %r(^-a always,exit -F path=/usr/sbin/setsebool -F perm=x -k privileged-priv_change)
           )
         }
 
         it {
           is_expected.to contain_file('/etc/audit/rules.d/50_00_simp_base.rules').with_content(
-            %r(^-a exit,always -F path=/(usr/)?sbin/setfiles -F perm=x -k privileged-priv_change)
+            %r(^-a always,exit -F path=/(usr/)?sbin/setfiles -F perm=x -k privileged-priv_change)
           )
         }
       end

--- a/spec/classes/config/audit_profiles/stig_spec.rb
+++ b/spec/classes/config/audit_profiles/stig_spec.rb
@@ -55,7 +55,7 @@ describe 'auditd' do
 
         it {
           is_expected.not_to contain_file('/etc/audit/rules.d/50_00_stig_base.rules').with_content(
-            %r(^-a exit,always -F arch=b\d\d -S \w*chown\w* -F auid>=\d+ -F auid!=4294967295 -k perm_mod$)
+            %r(^-a always,exit -F arch=b\d\d -S \w*chown\w* -F auid>=\d+ -F auid!=4294967295 -k perm_mod$)
           )
         }
       end
@@ -66,7 +66,7 @@ describe 'auditd' do
 
         it {
           is_expected.not_to contain_file('/etc/audit/rules.d/50_00_stig_base.rules').with_content(
-            %r(^-a exit,always -F arch=b\d\d -S \w*chmod\w* -F auid>=\d+ -F auid!=4294967295 -k perm_mod$)
+            %r(^-a always,exit -F arch=b\d\d -S \w*chmod\w* -F auid>=\d+ -F auid!=4294967295 -k perm_mod$)
           )
         }
       end
@@ -77,7 +77,7 @@ describe 'auditd' do
 
         it {
           is_expected.not_to contain_file('/etc/audit/rules.d/50_00_stig_base.rules').with_content(
-            %r(^-a exit,always -F arch=b\d\d -S \w*attr -F auid>=\d+ -F auid!=4294967295 -k perm_mod$)
+            %r(^-a always,exit -F arch=b\d\d -S \w*attr -F auid>=\d+ -F auid!=4294967295 -k perm_mod$)
           )
         }
       end
@@ -88,11 +88,11 @@ describe 'auditd' do
 
         it {
           is_expected.not_to contain_file('/etc/audit/rules.d/50_00_stig_base.rules').with_content(
-            %r{^-a exit,always -F path=/usr/bin/(chcon|semanage|setsebool) -F perm=x -F auid>=\d+ -F auid!=4294967295 -k privileged-priv_change}
+            %r{^-a always,exit -F path=/usr/bin/(chcon|semanage|setsebool) -F perm=x -F auid>=\d+ -F auid!=4294967295 -k privileged-priv_change}
           )
 
           is_expected.not_to contain_file('/etc/audit/rules.d/50_00_stig_base.rules').with_content(
-            %r(^-a exit,always -F path=/(usr/)?sbin/setfiles -F perm=x -F auid>=\d+ -F auid!=4294967295 -k privileged-priv_change)
+            %r(^-a always,exit -F path=/(usr/)?sbin/setfiles -F perm=x -F auid>=\d+ -F auid!=4294967295 -k privileged-priv_change)
           )
         }
       end
@@ -101,11 +101,11 @@ describe 'auditd' do
         let(:params) {{ :default_audit_profiles => ['stig'] }}
         let(:hieradata) { 'stig_audit_profile/disable__audit_priv_cmds' }
         [
-          %r{^-a exit,always -F path=/(usr/)?bin/su -F perm=x -F auid>=\d+ -F auid!=4294967295 -k privileged-priv_change$},
-          %r{^-a exit,always -F path=/usr/bin/sudo -F perm=x -F auid>=\d+ -F auid!=4294967295 -k privileged-priv_change$},
-          %r{^-a exit,always -F path=/usr/bin/newgrp -F perm=x -F auid>=\d+ -F auid!=4294967295 -k privileged-priv_change$},
-          %r{^-a exit,always -F path=/usr/bin/chsh -F perm=x -F auid>=\d+ -F auid!=4294967295 -k privileged-priv_change$},
-          %r{^-a exit,always -F path=/(usr/)?bin/sudoedit -F perm=x -F auid>=\d+ -F auid!=4294967295 -k privileged-priv_change$}
+          %r{^-a always,exit -F path=/(usr/)?bin/su -F perm=x -F auid>=\d+ -F auid!=4294967295 -k privileged-priv_change$},
+          %r{^-a always,exit -F path=/usr/bin/sudo -F perm=x -F auid>=\d+ -F auid!=4294967295 -k privileged-priv_change$},
+          %r{^-a always,exit -F path=/usr/bin/newgrp -F perm=x -F auid>=\d+ -F auid!=4294967295 -k privileged-priv_change$},
+          %r{^-a always,exit -F path=/usr/bin/chsh -F perm=x -F auid>=\d+ -F auid!=4294967295 -k privileged-priv_change$},
+          %r{^-a always,exit -F path=/(usr/)?bin/sudoedit -F perm=x -F auid>=\d+ -F auid!=4294967295 -k privileged-priv_change$}
         ].each do |command_regex|
           it {
             is_expected.not_to contain_file('/etc/audit/rules.d/50_00_stig_base.rules').

--- a/spec/defines/rule_spec.rb
+++ b/spec/defines/rule_spec.rb
@@ -31,16 +31,16 @@ describe 'auditd::rule' do
         context 'when :content is an Array' do
           let(:params) {{
             :content => [
-              '-a exit,always -F dir=${confdir} -F uid!=puppet -p wa -k Puppet_Config',
-              '-a exit,always -F dir=${logdir} -F uid!=puppet -p wa -k Puppet_Log',
-              '-a exit,always -F dir=${rundir} -F uid!=puppet -p wa -k Puppet_Run',
-              '-a exit,always -F dir=${ssldir} -F uid!=puppet -p wa -k Puppet_SSL'
+              '-a always,exit -F dir=${confdir} -F uid!=puppet -p wa -k Puppet_Config',
+              '-a always,exit -F dir=${logdir} -F uid!=puppet -p wa -k Puppet_Log',
+              '-a always,exit -F dir=${rundir} -F uid!=puppet -p wa -k Puppet_Run',
+              '-a always,exit -F dir=${ssldir} -F uid!=puppet -p wa -k Puppet_SSL'
             ]
           }}
 
           it {
            is_expected.to compile.with_all_deps
-           is_expected.to create_file("/etc/audit/rules.d/75.#{title}.rules").with_content(%r(^-a exit,always -F dir=))
+           is_expected.to create_file("/etc/audit/rules.d/75.#{title}.rules").with_content(%r(^-a always,exit -F dir=))
            is_expected.to create_file("/etc/audit/rules.d/75.#{title}.rules").without_content(%r(^[^-]))
           }
         end
@@ -49,16 +49,16 @@ describe 'auditd::rule' do
           # :content string mocks a common pattern of declaring readable auditd rules.
           let(:params) {{
             :content => '
-              -a exit,always -F dir=${confdir} -F uid!=puppet -p wa -k Puppet_Config
-              -a exit,always -F dir=${logdir} -F uid!=puppet -p wa -k Puppet_Log
-              -a exit,always -F dir=${rundir} -F uid!=puppet -p wa -k Puppet_Run
-              -a exit,always -F dir=${ssldir} -F uid!=puppet -p wa -k Puppet_SSL
+              -a always,exit -F dir=${confdir} -F uid!=puppet -p wa -k Puppet_Config
+              -a always,exit -F dir=${logdir} -F uid!=puppet -p wa -k Puppet_Log
+              -a always,exit -F dir=${rundir} -F uid!=puppet -p wa -k Puppet_Run
+              -a always,exit -F dir=${ssldir} -F uid!=puppet -p wa -k Puppet_SSL
             '
           }}
 
           it {
            is_expected.to compile.with_all_deps
-           is_expected.to create_file("/etc/audit/rules.d/75.#{title}.rules").with_content(%r(^-a exit,always -F dir=))
+           is_expected.to create_file("/etc/audit/rules.d/75.#{title}.rules").with_content(%r(^-a always,exit -F dir=))
            is_expected.to create_file("/etc/audit/rules.d/75.#{title}.rules").without_content(%r(^[^-]))
           }
         end
@@ -66,7 +66,7 @@ describe 'auditd::rule' do
         context 'with :order specified' do
           let(:params) {{
             :order   => '10',
-            :content => '-a exit,always -F dir=${confdir} -F uid!=puppet -p wa -k Puppet_Config'
+            :content => '-a always,exit -F dir=${confdir} -F uid!=puppet -p wa -k Puppet_Config'
           }}
 
           it {

--- a/templates/rule_profiles/simp/base.epp
+++ b/templates/rule_profiles/simp/base.epp
@@ -2,133 +2,133 @@
 <% if $auditd::config::audit_profiles::simp::audit_32bit_operations { -%>
 # 64-bit systems should generally never call the 32-bit API. 32-bit syscalls
 # may be a sign of someone exploiting a hole in the API.
--a exit,always -F arch=b32 -S all -F key=<%= $auditd::config::audit_profiles::simp::audit_32bit_operations_tag -%>
+-a always,exit -F arch=b32 -S all -F key=<%= $auditd::config::audit_profiles::simp::audit_32bit_operations_tag -%>
 <% } -%>
 
 <% if $auditd::config::audit_profiles::simp::audit_network_ipv4_accept { -%>
 <%   if $facts['hardwaremodel'] == "x86_64"  { -%>
--a exit,always -F arch=b64 -S accept -F a0=2 -F key=<%= $auditd::config::audit_profiles::simp::audit_network_ipv4_accept_tag %>
+-a always,exit -F arch=b64 -S accept -F a0=2 -F key=<%= $auditd::config::audit_profiles::simp::audit_network_ipv4_accept_tag %>
 <%   } -%>
 <% } -%>
 <% if $auditd::config::audit_profiles::simp::audit_network_ipv6_accept { -%>
 <%   if $facts['hardwaremodel'] == "x86_64"  { -%>
--a exit,always -F arch=b64 -S accept -F a0=10 -F key=<%= $auditd::config::audit_profiles::simp::audit_network_ipv6_accept_tag %>
+-a always,exit -F arch=b64 -S accept -F a0=10 -F key=<%= $auditd::config::audit_profiles::simp::audit_network_ipv6_accept_tag %>
 <%   } -%>
 <% } -%>
 <% if $auditd::config::audit_profiles::simp::audit_network_ipv4_connect { -%>
 <%   if $facts['hardwaremodel'] == "x86_64"  { -%>
--a exit,always -F arch=b64 -S connect -F a0=2 -F key=<%= $auditd::config::audit_profiles::simp::audit_network_ipv4_connect_tag %>
+-a always,exit -F arch=b64 -S connect -F a0=2 -F key=<%= $auditd::config::audit_profiles::simp::audit_network_ipv4_connect_tag %>
 <%   } -%>
--a exit,always -F arch=b32 -S connect -F a0=2 -F key=<%= $auditd::config::audit_profiles::simp::audit_network_ipv4_connect_tag %>
+-a always,exit -F arch=b32 -S connect -F a0=2 -F key=<%= $auditd::config::audit_profiles::simp::audit_network_ipv4_connect_tag %>
 <% } -%>
 <% if $auditd::config::audit_profiles::simp::audit_network_ipv6_connect { -%>
 <%   if $facts['hardwaremodel'] == "x86_64"  { -%>
--a exit,always -F arch=b64 -S connect -F a0=10 -F key=<%= $auditd::config::audit_profiles::simp::audit_network_ipv6_connect_tag %>
+-a always,exit -F arch=b64 -S connect -F a0=10 -F key=<%= $auditd::config::audit_profiles::simp::audit_network_ipv6_connect_tag %>
 <%   } -%>
--a exit,always -F arch=b32 -S connect -F a0=10 -F key=<%= $auditd::config::audit_profiles::simp::audit_network_ipv6_connect_tag %>
+-a always,exit -F arch=b32 -S connect -F a0=10 -F key=<%= $auditd::config::audit_profiles::simp::audit_network_ipv6_connect_tag %>
 <% } -%>
 
 <% if $auditd::config::audit_profiles::simp::audit_unsuccessful_file_operations  { -%>
 ## Audit unsuccessful file operations
 <%   if $facts['hardwaremodel'] == "x86_64"  { -%>
--a exit,always -F arch=b64 -S creat,mkdir,mknod,link,symlink,mkdirat,mknodat,linkat,symlinkat,openat,open_by_handle_at,open,close,rename,renameat,truncate,ftruncate,rmdir,unlink,unlinkat -F exit=-EACCES -k <%= $auditd::config::audit_profiles::simp::audit_unsuccessful_file_operations_tag %>
--a exit,always -F arch=b64 -S creat,mkdir,mknod,link,symlink,mkdirat,mknodat,linkat,symlinkat,openat,open_by_handle_at,open,close,rename,renameat,truncate,ftruncate,rmdir,unlink,unlinkat -F exit=-EPERM -k <%= $auditd::config::audit_profiles::simp::audit_unsuccessful_file_operations_tag %>
+-a always,exit -F arch=b64 -S creat,mkdir,mknod,link,symlink,mkdirat,mknodat,linkat,symlinkat,openat,open_by_handle_at,open,close,rename,renameat,truncate,ftruncate,rmdir,unlink,unlinkat -F exit=-EACCES -k <%= $auditd::config::audit_profiles::simp::audit_unsuccessful_file_operations_tag %>
+-a always,exit -F arch=b64 -S creat,mkdir,mknod,link,symlink,mkdirat,mknodat,linkat,symlinkat,openat,open_by_handle_at,open,close,rename,renameat,truncate,ftruncate,rmdir,unlink,unlinkat -F exit=-EPERM -k <%= $auditd::config::audit_profiles::simp::audit_unsuccessful_file_operations_tag %>
 <%   } -%>
--a exit,always -F arch=b32 -S creat,mkdir,mknod,link,symlink,mkdirat,mknodat,linkat,symlinkat,openat,open_by_handle_at,open,close,rename,renameat,truncate,ftruncate,rmdir,unlink,unlinkat -F exit=-EACCES -k <%= $auditd::config::audit_profiles::simp::audit_unsuccessful_file_operations_tag %>
--a exit,always -F arch=b32 -S creat,mkdir,mknod,link,symlink,mkdirat,mknodat,linkat,symlinkat,openat,open_by_handle_at,open,close,rename,renameat,truncate,ftruncate,rmdir,unlink,unlinkat -F exit=-EPERM -k <%= $auditd::config::audit_profiles::simp::audit_unsuccessful_file_operations_tag %>
+-a always,exit -F arch=b32 -S creat,mkdir,mknod,link,symlink,mkdirat,mknodat,linkat,symlinkat,openat,open_by_handle_at,open,close,rename,renameat,truncate,ftruncate,rmdir,unlink,unlinkat -F exit=-EACCES -k <%= $auditd::config::audit_profiles::simp::audit_unsuccessful_file_operations_tag %>
+-a always,exit -F arch=b32 -S creat,mkdir,mknod,link,symlink,mkdirat,mknodat,linkat,symlinkat,openat,open_by_handle_at,open,close,rename,renameat,truncate,ftruncate,rmdir,unlink,unlinkat -F exit=-EPERM -k <%= $auditd::config::audit_profiles::simp::audit_unsuccessful_file_operations_tag %>
 
--a exit,always -F perm=a -F exit=-EACCES -k <%= $auditd::config::audit_profiles::simp::audit_unsuccessful_file_operations_tag %>
--a exit,always -F perm=a -F exit=-EPERM -k <%= $auditd::config::audit_profiles::simp::audit_unsuccessful_file_operations_tag %>
+-a always,exit -F perm=a -F exit=-EACCES -k <%= $auditd::config::audit_profiles::simp::audit_unsuccessful_file_operations_tag %>
+-a always,exit -F perm=a -F exit=-EPERM -k <%= $auditd::config::audit_profiles::simp::audit_unsuccessful_file_operations_tag %>
 <% } -%>
 <% if $auditd::config::audit_profiles::simp::audit_passwd_cmds  { -%>
 
 ## Audit the execution of password commands
--a exit,always -F path=/usr/bin/passwd -F perm=x -k <%= $auditd::config::audit_profiles::simp::audit_passwd_cmds_tag %>
+-a always,exit -F path=/usr/bin/passwd -F perm=x -k <%= $auditd::config::audit_profiles::simp::audit_passwd_cmds_tag %>
 <%   if $facts['os']['release']['major'] > '6'  { -%>
--a exit,always -F path=/bin/passwd -F perm=x -k <%= $auditd::config::audit_profiles::simp::audit_passwd_cmds_tag %>
+-a always,exit -F path=/bin/passwd -F perm=x -k <%= $auditd::config::audit_profiles::simp::audit_passwd_cmds_tag %>
 <%   } -%>
 
 <%   if $facts['os']['release']['major'] > '6'  { -%>
--a exit,always -F path=/usr/sbin/unix_chkpwd -F perm=x -k <%= $auditd::config::audit_profiles::simp::audit_passwd_cmds_tag %>
+-a always,exit -F path=/usr/sbin/unix_chkpwd -F perm=x -k <%= $auditd::config::audit_profiles::simp::audit_passwd_cmds_tag %>
 <%   } -%>
--a exit,always -F path=/sbin/unix_chkpwd -F perm=x -k <%= $auditd::config::audit_profiles::simp::audit_passwd_cmds_tag %>
+-a always,exit -F path=/sbin/unix_chkpwd -F perm=x -k <%= $auditd::config::audit_profiles::simp::audit_passwd_cmds_tag %>
 
--a exit,always -F path=/usr/bin/gpasswd -F perm=x -k <%= $auditd::config::audit_profiles::simp::audit_passwd_cmds_tag %>
+-a always,exit -F path=/usr/bin/gpasswd -F perm=x -k <%= $auditd::config::audit_profiles::simp::audit_passwd_cmds_tag %>
 <%   if $facts['os']['release']['major'] > '6'  { -%>
--a exit,always -F path=/bin/gpasswd -F perm=x -k <%= $auditd::config::audit_profiles::simp::audit_passwd_cmds_tag %>
-<%   } -%>
-
--a exit,always -F path=/usr/bin/chage -F perm=x -k <%= $auditd::config::audit_profiles::simp::audit_passwd_cmds_tag %>
-<%   if $facts['os']['release']['major'] > '6'  { -%>
--a exit,always -F path=/bin/chage -F perm=x -k <%= $auditd::config::audit_profiles::simp::audit_passwd_cmds_tag %>
+-a always,exit -F path=/bin/gpasswd -F perm=x -k <%= $auditd::config::audit_profiles::simp::audit_passwd_cmds_tag %>
 <%   } -%>
 
--a exit,always -F path=/usr/sbin/userhelper -F perm=x -k <%= $auditd::config::audit_profiles::simp::audit_passwd_cmds_tag %>
+-a always,exit -F path=/usr/bin/chage -F perm=x -k <%= $auditd::config::audit_profiles::simp::audit_passwd_cmds_tag %>
 <%   if $facts['os']['release']['major'] > '6'  { -%>
--a exit,always -F path=/sbin/userhelper -F perm=x -k <%= $auditd::config::audit_profiles::simp::audit_passwd_cmds_tag %>
+-a always,exit -F path=/bin/chage -F perm=x -k <%= $auditd::config::audit_profiles::simp::audit_passwd_cmds_tag %>
+<%   } -%>
+
+-a always,exit -F path=/usr/sbin/userhelper -F perm=x -k <%= $auditd::config::audit_profiles::simp::audit_passwd_cmds_tag %>
+<%   if $facts['os']['release']['major'] > '6'  { -%>
+-a always,exit -F path=/sbin/userhelper -F perm=x -k <%= $auditd::config::audit_profiles::simp::audit_passwd_cmds_tag %>
 <%   } -%>
 <% } -%>
 <% if $auditd::config::audit_profiles::simp::audit_priv_cmds  { -%>
 
 ## Audit the execution of privilege-related commands
 <%   if $facts['os']['release']['major'] > '6'  { -%>
--a exit,always -F path=/usr/bin/su -F perm=x -k <%= $auditd::config::audit_profiles::simp::audit_priv_cmds_tag %>
+-a always,exit -F path=/usr/bin/su -F perm=x -k <%= $auditd::config::audit_profiles::simp::audit_priv_cmds_tag %>
 <%   } -%>
--a exit,always -F path=/bin/su -F perm=x -k <%= $auditd::config::audit_profiles::simp::audit_priv_cmds_tag %>
+-a always,exit -F path=/bin/su -F perm=x -k <%= $auditd::config::audit_profiles::simp::audit_priv_cmds_tag %>
 
--a exit,always -F path=/usr/bin/sudo -F perm=x -k <%= $auditd::config::audit_profiles::simp::audit_priv_cmds_tag %>
+-a always,exit -F path=/usr/bin/sudo -F perm=x -k <%= $auditd::config::audit_profiles::simp::audit_priv_cmds_tag %>
 <%   if $facts['os']['release']['major'] > '6'  { -%>
--a exit,always -F path=/bin/sudo -F perm=x -k <%= $auditd::config::audit_profiles::simp::audit_priv_cmds_tag %>
-<%   } -%>
-
--a exit,always -F path=/usr/bin/newgrp -F perm=x -k <%= $auditd::config::audit_profiles::simp::audit_priv_cmds_tag %>
-<%   if $facts['os']['release']['major'] > '6'  { -%>
--a exit,always -F path=/bin/newgrp -F perm=x -k <%= $auditd::config::audit_profiles::simp::audit_priv_cmds_tag %>
+-a always,exit -F path=/bin/sudo -F perm=x -k <%= $auditd::config::audit_profiles::simp::audit_priv_cmds_tag %>
 <%   } -%>
 
--a exit,always -F path=/usr/bin/chsh -F perm=x -k <%= $auditd::config::audit_profiles::simp::audit_priv_cmds_tag %>
+-a always,exit -F path=/usr/bin/newgrp -F perm=x -k <%= $auditd::config::audit_profiles::simp::audit_priv_cmds_tag %>
 <%   if $facts['os']['release']['major'] > '6'  { -%>
--a exit,always -F path=/bin/chsh -F perm=x -k <%= $auditd::config::audit_profiles::simp::audit_priv_cmds_tag %>
+-a always,exit -F path=/bin/newgrp -F perm=x -k <%= $auditd::config::audit_profiles::simp::audit_priv_cmds_tag %>
 <%   } -%>
 
--a exit,always -F path=/usr/bin/sudoedit -F perm=x -k <%= $auditd::config::audit_profiles::simp::audit_priv_cmds_tag %>
+-a always,exit -F path=/usr/bin/chsh -F perm=x -k <%= $auditd::config::audit_profiles::simp::audit_priv_cmds_tag %>
 <%   if $facts['os']['release']['major'] > '6'  { -%>
--a exit,always -F path=/bin/sudoedit -F perm=x -k <%= $auditd::config::audit_profiles::simp::audit_priv_cmds_tag %>
+-a always,exit -F path=/bin/chsh -F perm=x -k <%= $auditd::config::audit_profiles::simp::audit_priv_cmds_tag %>
+<%   } -%>
+
+-a always,exit -F path=/usr/bin/sudoedit -F perm=x -k <%= $auditd::config::audit_profiles::simp::audit_priv_cmds_tag %>
+<%   if $facts['os']['release']['major'] > '6'  { -%>
+-a always,exit -F path=/bin/sudoedit -F perm=x -k <%= $auditd::config::audit_profiles::simp::audit_priv_cmds_tag %>
 <%   } -%>
 <% } -%>
 <% if $auditd::config::audit_profiles::simp::audit_postfix_cmds  { -%>
 
 ## Audit the execution of postfix-related commands
--a exit,always -F path=/usr/sbin/postdrop -F perm=x -k <%= $auditd::config::audit_profiles::simp::audit_postfix_cmds_tag %>
+-a always,exit -F path=/usr/sbin/postdrop -F perm=x -k <%= $auditd::config::audit_profiles::simp::audit_postfix_cmds_tag %>
 <%   if $facts['os']['release']['major'] > '6'  { -%>
--a exit,always -F path=/sbin/postdrop -F perm=x -k <%= $auditd::config::audit_profiles::simp::audit_postfix_cmds_tag %>
+-a always,exit -F path=/sbin/postdrop -F perm=x -k <%= $auditd::config::audit_profiles::simp::audit_postfix_cmds_tag %>
 <%   } -%>
 
--a exit,always -F path=/usr/sbin/postqueue -F perm=x -k <%= $auditd::config::audit_profiles::simp::audit_postfix_cmds_tag %>
+-a always,exit -F path=/usr/sbin/postqueue -F perm=x -k <%= $auditd::config::audit_profiles::simp::audit_postfix_cmds_tag %>
 <%   if $facts['os']['release']['major'] > '6'  { -%>
--a exit,always -F path=/sbin/postqueue -F perm=x -k <%= $auditd::config::audit_profiles::simp::audit_postfix_cmds_tag %>
+-a always,exit -F path=/sbin/postqueue -F perm=x -k <%= $auditd::config::audit_profiles::simp::audit_postfix_cmds_tag %>
 <%   } -%>
 <% } -%>
 <% if $auditd::config::audit_profiles::simp::audit_ssh_keysign_cmd  { -%>
 
 ## Audit the execution of the ssh-keysign command
--a exit,always -F path=/usr/libexec/openssh/ssh-keysign -F perm=x -k <%= $auditd::config::audit_profiles::simp::audit_ssh_keysign_cmd_tag %>
+-a always,exit -F path=/usr/libexec/openssh/ssh-keysign -F perm=x -k <%= $auditd::config::audit_profiles::simp::audit_ssh_keysign_cmd_tag %>
 <% } -%>
 <% if $auditd::config::audit_profiles::simp::audit_crontab_cmd  { -%>
 
 ## Audit the execution of the crontab command
--a exit,always -F path=/usr/bin/crontab -F perm=x -k <%= $auditd::config::audit_profiles::simp::audit_crontab_cmd_tag %>
+-a always,exit -F path=/usr/bin/crontab -F perm=x -k <%= $auditd::config::audit_profiles::simp::audit_crontab_cmd_tag %>
 <%   if $facts['os']['release']['major'] > '6'  { -%>
--a exit,always -F path=/bin/crontab -F perm=x -k <%= $auditd::config::audit_profiles::simp::audit_crontab_cmd_tag %>
+-a always,exit -F path=/bin/crontab -F perm=x -k <%= $auditd::config::audit_profiles::simp::audit_crontab_cmd_tag %>
 <%   } -%>
 <% } -%>
 <% if $auditd::config::audit_profiles::simp::audit_pam_timestamp_check_cmd  { -%>
 
 ## Audit the execution of the pam_timestamp_check command
 <%   if $facts['os']['release']['major'] > '6'  { -%>
--a exit,always -F path=/usr/sbin/pam_timestamp_check -F perm=x -k <%= $auditd::config::audit_profiles::simp::audit_pam_timestamp_check_cmd_tag %>
+-a always,exit -F path=/usr/sbin/pam_timestamp_check -F perm=x -k <%= $auditd::config::audit_profiles::simp::audit_pam_timestamp_check_cmd_tag %>
 <%   } -%>
--a exit,always -F path=/sbin/pam_timestamp_check -F perm=x -k <%= $auditd::config::audit_profiles::simp::audit_pam_timestamp_check_cmd_tag %>
+-a always,exit -F path=/sbin/pam_timestamp_check -F perm=x -k <%= $auditd::config::audit_profiles::simp::audit_pam_timestamp_check_cmd_tag %>
 <% } -%>
 <% if $auditd::config::audit_profiles::simp::audit_selinux_cmds  { -%>
 
@@ -136,56 +136,56 @@
 # NOTE:  These rules come before the *xattr* checks, to ensure the
 #        correct tag is recorded.
 #
--a exit,always -F path=/usr/sbin/semanage -F perm=x -k <%= $auditd::config::audit_profiles::simp::audit_selinux_cmds_tag %>
+-a always,exit -F path=/usr/sbin/semanage -F perm=x -k <%= $auditd::config::audit_profiles::simp::audit_selinux_cmds_tag %>
 <%   if $facts['os']['release']['major'] > '6'  { -%>
--a exit,always -F path=/sbin/semanage -F perm=x -k <%= $auditd::config::audit_profiles::simp::audit_selinux_cmds_tag %>
+-a always,exit -F path=/sbin/semanage -F perm=x -k <%= $auditd::config::audit_profiles::simp::audit_selinux_cmds_tag %>
 <%   } -%>
 
--a exit,always -F path=/usr/sbin/setsebool -F perm=x -k <%= $auditd::config::audit_profiles::simp::audit_selinux_cmds_tag %>
+-a always,exit -F path=/usr/sbin/setsebool -F perm=x -k <%= $auditd::config::audit_profiles::simp::audit_selinux_cmds_tag %>
 <%   if $facts['os']['release']['major'] > '6'  { -%>
--a exit,always -F path=/sbin/setsebool -F perm=x -k <%= $auditd::config::audit_profiles::simp::audit_selinux_cmds_tag %>
+-a always,exit -F path=/sbin/setsebool -F perm=x -k <%= $auditd::config::audit_profiles::simp::audit_selinux_cmds_tag %>
 <%   } -%>
 
--a exit,always -F path=/usr/bin/chcon -F perm=x -k <%= $auditd::config::audit_profiles::simp::audit_selinux_cmds_tag %>
+-a always,exit -F path=/usr/bin/chcon -F perm=x -k <%= $auditd::config::audit_profiles::simp::audit_selinux_cmds_tag %>
 <%   if $facts['os']['release']['major'] > '6'  { -%>
--a exit,always -F path=/bin/chcon -F perm=x -k <%= $auditd::config::audit_profiles::simp::audit_selinux_cmds_tag %>
+-a always,exit -F path=/bin/chcon -F perm=x -k <%= $auditd::config::audit_profiles::simp::audit_selinux_cmds_tag %>
 <%   } -%>
 
 <%   if $facts['os']['release']['major'] > '6'  { -%>
--a exit,always -F path=/usr/sbin/setfiles -F perm=x -k <%= $auditd::config::audit_profiles::simp::audit_selinux_cmds_tag %>
+-a always,exit -F path=/usr/sbin/setfiles -F perm=x -k <%= $auditd::config::audit_profiles::simp::audit_selinux_cmds_tag %>
 <%   } -%>
--a exit,always -F path=/sbin/setfiles -F perm=x -k <%= $auditd::config::audit_profiles::simp::audit_selinux_cmds_tag %>
+-a always,exit -F path=/sbin/setfiles -F perm=x -k <%= $auditd::config::audit_profiles::simp::audit_selinux_cmds_tag %>
 <% } -%>
 
 ## Permissions auditing separated by chown, chmod, and attr
 <% if $auditd::config::audit_profiles::simp::audit_chown  { -%>
 
 <%   if $facts['hardwaremodel'] == "x86_64"  { -%>
--a exit,always -F arch=b64 -S chown,fchown,fchownat,lchown -k <%= $auditd::config::audit_profiles::simp::audit_chown_tag %>
+-a always,exit -F arch=b64 -S chown,fchown,fchownat,lchown -k <%= $auditd::config::audit_profiles::simp::audit_chown_tag %>
 <%   } -%>
--a exit,always -F arch=b32 -S chown,fchown,fchownat,lchown -k <%= $auditd::config::audit_profiles::simp::audit_chown_tag %>
+-a always,exit -F arch=b32 -S chown,fchown,fchownat,lchown -k <%= $auditd::config::audit_profiles::simp::audit_chown_tag %>
 <% } -%>
 <% if $auditd::config::audit_profiles::simp::audit_chmod  { -%>
 
 <%   if $facts['hardwaremodel'] == "x86_64"  { -%>
--a exit,always -F arch=b64 -S chmod,fchmod,fchmodat -k <%= $auditd::config::audit_profiles::simp::audit_chmod_tag %>
+-a always,exit -F arch=b64 -S chmod,fchmod,fchmodat -k <%= $auditd::config::audit_profiles::simp::audit_chmod_tag %>
 <%   } -%>
--a exit,always -F arch=b32 -S chmod,fchmod,fchmodat -k <%= $auditd::config::audit_profiles::simp::audit_chmod_tag %>
+-a always,exit -F arch=b32 -S chmod,fchmod,fchmodat -k <%= $auditd::config::audit_profiles::simp::audit_chmod_tag %>
 <% } -%>
 <% if $auditd::config::audit_profiles::simp::audit_attr  { -%>
 
 <%   if $facts['hardwaremodel'] == "x86_64"  { -%>
--a exit,always -F arch=b64 -S setxattr,lsetxattr,fsetxattr,removexattr,lremovexattr,fremovexattr -k <%= $auditd::config::audit_profiles::simp::audit_attr_tag %>
+-a always,exit -F arch=b64 -S setxattr,lsetxattr,fsetxattr,removexattr,lremovexattr,fremovexattr -k <%= $auditd::config::audit_profiles::simp::audit_attr_tag %>
 <%   } -%>
--a exit,always -F arch=b32 -S setxattr,lsetxattr,fsetxattr,removexattr,lremovexattr,fremovexattr -k <%= $auditd::config::audit_profiles::simp::audit_attr_tag %>
+-a always,exit -F arch=b32 -S setxattr,lsetxattr,fsetxattr,removexattr,lremovexattr,fremovexattr -k <%= $auditd::config::audit_profiles::simp::audit_attr_tag %>
 <% } -%>
 <% if $auditd::config::audit_profiles::simp::audit_rename_remove  { -%>
 
 ## Audit rename/removal operations
 <%   if $facts['hardwaremodel'] == "x86_64"  { -%>
--a exit,always -F arch=b64 -S rename,renameat,rmdir,unlink,unlinkat -F perm=x -k <%= $auditd::config::audit_profiles::simp::audit_rename_remove_tag %>
+-a always,exit -F arch=b64 -S rename,renameat,rmdir,unlink,unlinkat -F perm=x -k <%= $auditd::config::audit_profiles::simp::audit_rename_remove_tag %>
 <%   } -%>
--a exit,always -F arch=b32 -S rename,renameat,rmdir,unlink,unlinkat -F perm=x -k <%= $auditd::config::audit_profiles::simp::audit_rename_remove_tag %>
+-a always,exit -F arch=b32 -S rename,renameat,rmdir,unlink,unlinkat -F perm=x -k <%= $auditd::config::audit_profiles::simp::audit_rename_remove_tag %>
 <% } -%>
 <% if $auditd::config::audit_profiles::simp::audit_su_root_activity  { -%>
 
@@ -202,17 +202,17 @@
 -%>
 ## Audit useful items that someone does when su'ing to root.
 <%   if $facts['hardwaremodel'] == "x86_64"  { -%>
--a exit,always -F arch=b64 -F auid!=0 -F uid=0 -S <%= $_su_rules %> -k <%= $auditd::config::audit_profiles::simp::audit_su_root_activity_tag %>
+-a always,exit -F arch=b64 -F auid!=0 -F uid=0 -S <%= $_su_rules %> -k <%= $auditd::config::audit_profiles::simp::audit_su_root_activity_tag %>
 <%   } -%>
--a exit,always -F arch=b32 -F auid!=0 -F uid=0 -S <%= $_su_rules %> -k <%= $auditd::config::audit_profiles::simp::audit_su_root_activity_tag %>
+-a always,exit -F arch=b32 -F auid!=0 -F uid=0 -S <%= $_su_rules %> -k <%= $auditd::config::audit_profiles::simp::audit_su_root_activity_tag %>
 <% } -%>
 <% if $auditd::config::audit_profiles::simp::audit_suid_sgid  { -%>
 
 ## Audit the execution of suid and sgid binaries.
 <%   if $facts['hardwaremodel'] == "x86_64"  { -%>
--a exit,always -F arch=b64 -F euid=0 -F uid!=0 -S execve -k <%= $auditd::config::audit_profiles::simp::audit_suid_sgid_tag %>
+-a always,exit -F arch=b64 -F euid=0 -F uid!=0 -S execve -k <%= $auditd::config::audit_profiles::simp::audit_suid_sgid_tag %>
 <%   } -%>
--a exit,always -F arch=b32 -F euid=0 -F uid!=0 -S execve -k <%= $auditd::config::audit_profiles::simp::audit_suid_sgid_tag %>
+-a always,exit -F arch=b32 -F euid=0 -F uid!=0 -S execve -k <%= $auditd::config::audit_profiles::simp::audit_suid_sgid_tag %>
 <% } -%>
 <% if $auditd::config::audit_profiles::simp::audit_kernel_modules  { -%>
 
@@ -235,19 +235,19 @@
 -w /sbin/modprobe -p x -k <%= $auditd::config::audit_profiles::simp::audit_kernel_modules_tag %>
 
 <%   if $facts['hardwaremodel'] == "x86_64"  { -%>
--a exit,always -F arch=b64 -S create_module,init_module,finit_module,delete_module -k <%= $auditd::config::audit_profiles::simp::audit_kernel_modules_tag %>
+-a always,exit -F arch=b64 -S create_module,init_module,finit_module,delete_module -k <%= $auditd::config::audit_profiles::simp::audit_kernel_modules_tag %>
 <%   } -%>
--a exit,always -F arch=b32 -S create_module,init_module,finit_module,delete_module -k <%= $auditd::config::audit_profiles::simp::audit_kernel_modules_tag %>
+-a always,exit -F arch=b32 -S create_module,init_module,finit_module,delete_module -k <%= $auditd::config::audit_profiles::simp::audit_kernel_modules_tag %>
 <% } -%>
 <% if $auditd::config::audit_profiles::simp::audit_time  { -%>
 
 ## Audit things that could affect time
 <%   if $facts['hardwaremodel'] == "x86_64"  { -%>
--a exit,always -F arch=b64 -S adjtimex,settimeofday -k <%= $auditd::config::audit_profiles::simp::audit_time_tag %>
--a exit,always -F arch=b64 -S clock_settime -F a0=0x0 -k <%= $auditd::config::audit_profiles::simp::audit_time_tag %>
+-a always,exit -F arch=b64 -S adjtimex,settimeofday -k <%= $auditd::config::audit_profiles::simp::audit_time_tag %>
+-a always,exit -F arch=b64 -S clock_settime -F a0=0x0 -k <%= $auditd::config::audit_profiles::simp::audit_time_tag %>
 <%   } -%>
--a exit,always -F arch=b32 -S adjtimex,stime,settimeofday -k <%= $auditd::config::audit_profiles::simp::audit_time_tag %>
--a exit,always -F arch=b32 -S clock_settime -F a0=0x0 -k <%= $auditd::config::audit_profiles::simp::audit_time_tag %>
+-a always,exit -F arch=b32 -S adjtimex,stime,settimeofday -k <%= $auditd::config::audit_profiles::simp::audit_time_tag %>
+-a always,exit -F arch=b32 -S clock_settime -F a0=0x0 -k <%= $auditd::config::audit_profiles::simp::audit_time_tag %>
 
 -w /etc/localtime -p wa -k <%= $auditd::config::audit_profiles::simp::audit_time_tag %>
 <% } -%>
@@ -255,9 +255,9 @@
 
 ## Audit things that could affect system locale
 <%   if $facts['hardwaremodel'] == "x86_64"  { -%>
--a exit,always -F arch=b64 -S sethostname,setdomainname -k <%= $auditd::config::audit_profiles::simp::audit_locale_tag %>
+-a always,exit -F arch=b64 -S sethostname,setdomainname -k <%= $auditd::config::audit_profiles::simp::audit_locale_tag %>
 <%   } -%>
--a exit,always -F arch=b32 -S sethostname,setdomainname -k <%= $auditd::config::audit_profiles::simp::audit_locale_tag %>
+-a always,exit -F arch=b32 -S sethostname,setdomainname -k <%= $auditd::config::audit_profiles::simp::audit_locale_tag %>
 
 -w /etc/issue -p wa -k <%= $auditd::config::audit_profiles::simp::audit_locale_tag %>
 -w /etc/issue.net -p wa -k <%= $auditd::config::audit_profiles::simp::audit_locale_tag %>
@@ -265,40 +265,40 @@
 -w /etc/hostname -p wa -k <%= $auditd::config::audit_profiles::simp::audit_locale_tag %>
 -w /etc/sysconfig/network -p wa -k <%= $auditd::config::audit_profiles::simp::audit_locale_tag %>
 <%   if $facts['os']['release']['major'] > '6'  { -%>
--a exit,always -F dir=/etc/NetworkManager/ -F perm=wa -k <%= $auditd::config::audit_profiles::simp::audit_locale_tag %>
+-a always,exit -F dir=/etc/NetworkManager/ -F perm=wa -k <%= $auditd::config::audit_profiles::simp::audit_locale_tag %>
 <%   } -%>
 <% } -%>
 <% if $auditd::config::audit_profiles::simp::audit_mount  { -%>
 
 ## Audit mount operations
 <%   if $facts['hardwaremodel'] == "x86_64"  { -%>
--a exit,always -F arch=b64 -S mount,umount2 -k <%= $auditd::config::audit_profiles::simp::audit_mount_tag %>
+-a always,exit -F arch=b64 -S mount,umount2 -k <%= $auditd::config::audit_profiles::simp::audit_mount_tag %>
 <%   } -%>
--a exit,always -F arch=b32 -S mount,umount,umount2 -k <%= $auditd::config::audit_profiles::simp::audit_mount_tag %>
+-a always,exit -F arch=b32 -S mount,umount,umount2 -k <%= $auditd::config::audit_profiles::simp::audit_mount_tag %>
 
 <%   if $facts['hardwaremodel'] == "x86_64"  { -%>
 <%     if $facts['os']['release']['major'] > '6'  { -%>
--a exit,always -F arch=b64 -F path=/usr/bin/mount -k <%= $auditd::config::audit_profiles::simp::audit_mount_tag %>
+-a always,exit -F arch=b64 -F path=/usr/bin/mount -k <%= $auditd::config::audit_profiles::simp::audit_mount_tag %>
 <%     } -%>
--a exit,always -F arch=b64 -F path=/bin/mount -k <%= $auditd::config::audit_profiles::simp::audit_mount_tag %>
+-a always,exit -F arch=b64 -F path=/bin/mount -k <%= $auditd::config::audit_profiles::simp::audit_mount_tag %>
 <%   } -%>
 <%   if $facts['os']['release']['major'] > '6'  { -%>
--a exit,always -F arch=b32 -F path=/usr/bin/mount -k <%= $auditd::config::audit_profiles::simp::audit_mount_tag %>
+-a always,exit -F arch=b32 -F path=/usr/bin/mount -k <%= $auditd::config::audit_profiles::simp::audit_mount_tag %>
 <%   } -%>
--a exit,always -F arch=b32 -F path=/bin/mount -k <%= $auditd::config::audit_profiles::simp::audit_mount_tag %>
+-a always,exit -F arch=b32 -F path=/bin/mount -k <%= $auditd::config::audit_profiles::simp::audit_mount_tag %>
 <%   if $facts['os']['release']['major'] > '6'  { -%>
--a exit,always -F path=/usr/bin/umount -F perm=x -k <%= $auditd::config::audit_profiles::simp::audit_mount_tag %>
+-a always,exit -F path=/usr/bin/umount -F perm=x -k <%= $auditd::config::audit_profiles::simp::audit_mount_tag %>
 <%   } -%>
--a exit,always -F path=/bin/umount -F perm=x -k <%= $auditd::config::audit_profiles::simp::audit_mount_tag %>
+-a always,exit -F path=/bin/umount -F perm=x -k <%= $auditd::config::audit_profiles::simp::audit_mount_tag %>
 <% } -%>
 <% if $auditd::config::audit_profiles::simp::audit_umask  { -%>
 
 ## Audit umask changes.
 # This is uselessly noisy in most cases
 <%   if $facts['hardwaremodel'] == "x86_64"  { -%>
--a exit,always -F arch=b64 -S umask -k <%= $auditd::config::audit_profiles::simp::audit_umask_tag %>
+-a always,exit -F arch=b64 -S umask -k <%= $auditd::config::audit_profiles::simp::audit_umask_tag %>
 <%   } -%>
--a exit,always -F arch=b32 -S umask -k <%= $auditd::config::audit_profiles::simp::audit_umask_tag %>
+-a always,exit -F arch=b32 -S umask -k <%= $auditd::config::audit_profiles::simp::audit_umask_tag %>
 <% } -%>
 <% if $auditd::config::audit_profiles::simp::audit_local_account  { -%>
 
@@ -449,19 +449,19 @@
 <% } -%>
 <% if $auditd::config::audit_profiles::simp::audit_ptrace  { -%>
 <%   if $facts['hardwaremodel'] == "x86_64"  { -%>
--a exit,always -F arch=b64 -S ptrace -F a0=0x4 -k <%= $auditd::config::audit_profiles::simp::audit_ptrace_tag %>_code_injection
--a exit,always -F arch=b64 -S ptrace -F a0=0x5 -k <%= $auditd::config::audit_profiles::simp::audit_ptrace_tag %>_data_injection
--a exit,always -F arch=b64 -S ptrace -F a0=0x6 -k <%= $auditd::config::audit_profiles::simp::audit_ptrace_tag %>_register_injection
--a exit,always -F arch=b64 -S ptrace -k <%= $auditd::config::audit_profiles::simp::audit_ptrace_tag %>
+-a always,exit -F arch=b64 -S ptrace -F a0=0x4 -k <%= $auditd::config::audit_profiles::simp::audit_ptrace_tag %>_code_injection
+-a always,exit -F arch=b64 -S ptrace -F a0=0x5 -k <%= $auditd::config::audit_profiles::simp::audit_ptrace_tag %>_data_injection
+-a always,exit -F arch=b64 -S ptrace -F a0=0x6 -k <%= $auditd::config::audit_profiles::simp::audit_ptrace_tag %>_register_injection
+-a always,exit -F arch=b64 -S ptrace -k <%= $auditd::config::audit_profiles::simp::audit_ptrace_tag %>
 <%   } -%>
--a exit,always -F arch=b32 -S ptrace -F a0=0x4 -k <%= $auditd::config::audit_profiles::simp::audit_ptrace_tag %>_code_injection
--a exit,always -F arch=b32 -S ptrace -F a0=0x5 -k <%= $auditd::config::audit_profiles::simp::audit_ptrace_tag %>_data_injection
--a exit,always -F arch=b32 -S ptrace -F a0=0x6 -k <%= $auditd::config::audit_profiles::simp::audit_ptrace_tag %>_register_injection
--a exit,always -F arch=b32 -S ptrace -k <%= $auditd::config::audit_profiles::simp::audit_ptrace_tag %>
+-a always,exit -F arch=b32 -S ptrace -F a0=0x4 -k <%= $auditd::config::audit_profiles::simp::audit_ptrace_tag %>_code_injection
+-a always,exit -F arch=b32 -S ptrace -F a0=0x5 -k <%= $auditd::config::audit_profiles::simp::audit_ptrace_tag %>_data_injection
+-a always,exit -F arch=b32 -S ptrace -F a0=0x6 -k <%= $auditd::config::audit_profiles::simp::audit_ptrace_tag %>_register_injection
+-a always,exit -F arch=b32 -S ptrace -k <%= $auditd::config::audit_profiles::simp::audit_ptrace_tag %>
 <% } -%>
 <% if $auditd::config::audit_profiles::simp::audit_personality  { -%>
 <%   if $facts['hardwaremodel'] == "x86_64"  { -%>
--a exit,always -F arch=b64 -S personality -k <%= $auditd::config::audit_profiles::simp::audit_personality_tag %>
+-a always,exit -F arch=b64 -S personality -k <%= $auditd::config::audit_profiles::simp::audit_personality_tag %>
 <%   } -%>
--a exit,always -F arch=b32 -S personality -k <%= $auditd::config::audit_profiles::simp::audit_personality_tag %>
+-a always,exit -F arch=b32 -S personality -k <%= $auditd::config::audit_profiles::simp::audit_personality_tag %>
 <% } -%>

--- a/templates/rule_profiles/stig/base.epp
+++ b/templates/rule_profiles/stig/base.epp
@@ -3,270 +3,270 @@
 
 ## Audit unsuccessful file operations
 <%   if $facts['hardwaremodel'] == "x86_64" { -%>
--a exit,always -F arch=b64 -S creat -F exit=-EPERM -F auid>=<%= $auditd::config::audit_profiles::stig::uid_min %> -F auid!=4294967295 -k <%= $auditd::config::audit_profiles::stig::audit_unsuccessful_file_operations_tag %>
--a exit,always -F arch=b64 -S creat -F exit=-EACCES -F auid>=<%= $auditd::config::audit_profiles::stig::uid_min %> -F auid!=4294967295 -k <%= $auditd::config::audit_profiles::stig::audit_unsuccessful_file_operations_tag %>
+-a always,exit -F arch=b64 -S creat -F exit=-EPERM -F auid>=<%= $auditd::config::audit_profiles::stig::uid_min %> -F auid!=4294967295 -k <%= $auditd::config::audit_profiles::stig::audit_unsuccessful_file_operations_tag %>
+-a always,exit -F arch=b64 -S creat -F exit=-EACCES -F auid>=<%= $auditd::config::audit_profiles::stig::uid_min %> -F auid!=4294967295 -k <%= $auditd::config::audit_profiles::stig::audit_unsuccessful_file_operations_tag %>
 <%   } -%>
--a exit,always -F arch=b32 -S creat -F exit=-EPERM -F auid>=<%= $auditd::config::audit_profiles::stig::uid_min %> -F auid!=4294967295 -k <%= $auditd::config::audit_profiles::stig::audit_unsuccessful_file_operations_tag %>
--a exit,always -F arch=b32 -S creat -F exit=-EACCES -F auid>=<%= $auditd::config::audit_profiles::stig::uid_min %> -F auid!=4294967295 -k <%= $auditd::config::audit_profiles::stig::audit_unsuccessful_file_operations_tag %>
+-a always,exit -F arch=b32 -S creat -F exit=-EPERM -F auid>=<%= $auditd::config::audit_profiles::stig::uid_min %> -F auid!=4294967295 -k <%= $auditd::config::audit_profiles::stig::audit_unsuccessful_file_operations_tag %>
+-a always,exit -F arch=b32 -S creat -F exit=-EACCES -F auid>=<%= $auditd::config::audit_profiles::stig::uid_min %> -F auid!=4294967295 -k <%= $auditd::config::audit_profiles::stig::audit_unsuccessful_file_operations_tag %>
 
 <%   if $facts['hardwaremodel'] == "x86_64" { -%>
--a exit,always -F arch=b64 -S open -F exit=-EPERM -F auid>=<%= $auditd::config::audit_profiles::stig::uid_min %> -F auid!=4294967295 -k <%= $auditd::config::audit_profiles::stig::audit_unsuccessful_file_operations_tag %>
--a exit,always -F arch=b64 -S open -F exit=-EACCES -F auid>=<%= $auditd::config::audit_profiles::stig::uid_min %> -F auid!=4294967295 -k <%= $auditd::config::audit_profiles::stig::audit_unsuccessful_file_operations_tag %>
+-a always,exit -F arch=b64 -S open -F exit=-EPERM -F auid>=<%= $auditd::config::audit_profiles::stig::uid_min %> -F auid!=4294967295 -k <%= $auditd::config::audit_profiles::stig::audit_unsuccessful_file_operations_tag %>
+-a always,exit -F arch=b64 -S open -F exit=-EACCES -F auid>=<%= $auditd::config::audit_profiles::stig::uid_min %> -F auid!=4294967295 -k <%= $auditd::config::audit_profiles::stig::audit_unsuccessful_file_operations_tag %>
 <%   } -%>
--a exit,always -F arch=b32 -S open -F exit=-EPERM -F auid>=<%= $auditd::config::audit_profiles::stig::uid_min %> -F auid!=4294967295 -k <%= $auditd::config::audit_profiles::stig::audit_unsuccessful_file_operations_tag %>
--a exit,always -F arch=b32 -S open -F exit=-EACCES -F auid>=<%= $auditd::config::audit_profiles::stig::uid_min %> -F auid!=4294967295 -k <%= $auditd::config::audit_profiles::stig::audit_unsuccessful_file_operations_tag %>
+-a always,exit -F arch=b32 -S open -F exit=-EPERM -F auid>=<%= $auditd::config::audit_profiles::stig::uid_min %> -F auid!=4294967295 -k <%= $auditd::config::audit_profiles::stig::audit_unsuccessful_file_operations_tag %>
+-a always,exit -F arch=b32 -S open -F exit=-EACCES -F auid>=<%= $auditd::config::audit_profiles::stig::uid_min %> -F auid!=4294967295 -k <%= $auditd::config::audit_profiles::stig::audit_unsuccessful_file_operations_tag %>
 
 <%   if $facts['hardwaremodel'] == "x86_64" { -%>
--a exit,always -F arch=b64 -S openat -F exit=-EPERM -F auid>=<%= $auditd::config::audit_profiles::stig::uid_min %> -F auid!=4294967295 -k <%= $auditd::config::audit_profiles::stig::audit_unsuccessful_file_operations_tag %>
--a exit,always -F arch=b64 -S openat -F exit=-EACCES -F auid>=<%= $auditd::config::audit_profiles::stig::uid_min %> -F auid!=4294967295 -k <%= $auditd::config::audit_profiles::stig::audit_unsuccessful_file_operations_tag %>
+-a always,exit -F arch=b64 -S openat -F exit=-EPERM -F auid>=<%= $auditd::config::audit_profiles::stig::uid_min %> -F auid!=4294967295 -k <%= $auditd::config::audit_profiles::stig::audit_unsuccessful_file_operations_tag %>
+-a always,exit -F arch=b64 -S openat -F exit=-EACCES -F auid>=<%= $auditd::config::audit_profiles::stig::uid_min %> -F auid!=4294967295 -k <%= $auditd::config::audit_profiles::stig::audit_unsuccessful_file_operations_tag %>
 <%   } -%>
--a exit,always -F arch=b32 -S openat -F exit=-EPERM -F auid>=<%= $auditd::config::audit_profiles::stig::uid_min %> -F auid!=4294967295 -k <%= $auditd::config::audit_profiles::stig::audit_unsuccessful_file_operations_tag %>
--a exit,always -F arch=b32 -S openat -F exit=-EACCES -F auid>=<%= $auditd::config::audit_profiles::stig::uid_min %> -F auid!=4294967295 -k <%= $auditd::config::audit_profiles::stig::audit_unsuccessful_file_operations_tag %>
+-a always,exit -F arch=b32 -S openat -F exit=-EPERM -F auid>=<%= $auditd::config::audit_profiles::stig::uid_min %> -F auid!=4294967295 -k <%= $auditd::config::audit_profiles::stig::audit_unsuccessful_file_operations_tag %>
+-a always,exit -F arch=b32 -S openat -F exit=-EACCES -F auid>=<%= $auditd::config::audit_profiles::stig::uid_min %> -F auid!=4294967295 -k <%= $auditd::config::audit_profiles::stig::audit_unsuccessful_file_operations_tag %>
 
 <%   if $facts['hardwaremodel'] == "x86_64" { -%>
--a exit,always -F arch=b64 -S open_by_handle_at -F exit=-EPERM -F auid>=<%= $auditd::config::audit_profiles::stig::uid_min %> -F auid!=4294967295 -k <%= $auditd::config::audit_profiles::stig::audit_unsuccessful_file_operations_tag %>
--a exit,always -F arch=b64 -S open_by_handle_at -F exit=-EACCES -F auid>=<%= $auditd::config::audit_profiles::stig::uid_min %> -F auid!=4294967295 -k <%= $auditd::config::audit_profiles::stig::audit_unsuccessful_file_operations_tag %>
+-a always,exit -F arch=b64 -S open_by_handle_at -F exit=-EPERM -F auid>=<%= $auditd::config::audit_profiles::stig::uid_min %> -F auid!=4294967295 -k <%= $auditd::config::audit_profiles::stig::audit_unsuccessful_file_operations_tag %>
+-a always,exit -F arch=b64 -S open_by_handle_at -F exit=-EACCES -F auid>=<%= $auditd::config::audit_profiles::stig::uid_min %> -F auid!=4294967295 -k <%= $auditd::config::audit_profiles::stig::audit_unsuccessful_file_operations_tag %>
 <%   } -%>
--a exit,always -F arch=b32 -S open_by_handle_at -F exit=-EPERM -F auid>=<%= $auditd::config::audit_profiles::stig::uid_min %> -F auid!=4294967295 -k <%= $auditd::config::audit_profiles::stig::audit_unsuccessful_file_operations_tag %>
--a exit,always -F arch=b32 -S open_by_handle_at -F exit=-EACCES -F auid>=<%= $auditd::config::audit_profiles::stig::uid_min %> -F auid!=4294967295 -k <%= $auditd::config::audit_profiles::stig::audit_unsuccessful_file_operations_tag %>
+-a always,exit -F arch=b32 -S open_by_handle_at -F exit=-EPERM -F auid>=<%= $auditd::config::audit_profiles::stig::uid_min %> -F auid!=4294967295 -k <%= $auditd::config::audit_profiles::stig::audit_unsuccessful_file_operations_tag %>
+-a always,exit -F arch=b32 -S open_by_handle_at -F exit=-EACCES -F auid>=<%= $auditd::config::audit_profiles::stig::uid_min %> -F auid!=4294967295 -k <%= $auditd::config::audit_profiles::stig::audit_unsuccessful_file_operations_tag %>
 
 <%   if $facts['hardwaremodel'] == "x86_64" { -%>
--a exit,always -F arch=b64 -S truncate -F exit=-EPERM -F auid>=<%= $auditd::config::audit_profiles::stig::uid_min %> -F auid!=4294967295 -k <%= $auditd::config::audit_profiles::stig::audit_unsuccessful_file_operations_tag %>
--a exit,always -F arch=b64 -S truncate -F exit=-EACCES -F auid>=<%= $auditd::config::audit_profiles::stig::uid_min %> -F auid!=4294967295 -k <%= $auditd::config::audit_profiles::stig::audit_unsuccessful_file_operations_tag %>
+-a always,exit -F arch=b64 -S truncate -F exit=-EPERM -F auid>=<%= $auditd::config::audit_profiles::stig::uid_min %> -F auid!=4294967295 -k <%= $auditd::config::audit_profiles::stig::audit_unsuccessful_file_operations_tag %>
+-a always,exit -F arch=b64 -S truncate -F exit=-EACCES -F auid>=<%= $auditd::config::audit_profiles::stig::uid_min %> -F auid!=4294967295 -k <%= $auditd::config::audit_profiles::stig::audit_unsuccessful_file_operations_tag %>
 <%   } -%>
--a exit,always -F arch=b32 -S truncate -F exit=-EPERM -F auid>=<%= $auditd::config::audit_profiles::stig::uid_min %> -F auid!=4294967295 -k <%= $auditd::config::audit_profiles::stig::audit_unsuccessful_file_operations_tag %>
--a exit,always -F arch=b32 -S truncate -F exit=-EACCES -F auid>=<%= $auditd::config::audit_profiles::stig::uid_min %> -F auid!=4294967295 -k <%= $auditd::config::audit_profiles::stig::audit_unsuccessful_file_operations_tag %>
+-a always,exit -F arch=b32 -S truncate -F exit=-EPERM -F auid>=<%= $auditd::config::audit_profiles::stig::uid_min %> -F auid!=4294967295 -k <%= $auditd::config::audit_profiles::stig::audit_unsuccessful_file_operations_tag %>
+-a always,exit -F arch=b32 -S truncate -F exit=-EACCES -F auid>=<%= $auditd::config::audit_profiles::stig::uid_min %> -F auid!=4294967295 -k <%= $auditd::config::audit_profiles::stig::audit_unsuccessful_file_operations_tag %>
 
 <%   if $facts['hardwaremodel'] == "x86_64" { -%>
--a exit,always -F arch=b64 -S ftruncate -F exit=-EPERM -F auid>=<%= $auditd::config::audit_profiles::stig::uid_min %> -F auid!=4294967295 -k <%= $auditd::config::audit_profiles::stig::audit_unsuccessful_file_operations_tag %>
--a exit,always -F arch=b64 -S ftruncate -F exit=-EACCES -F auid>=<%= $auditd::config::audit_profiles::stig::uid_min %> -F auid!=4294967295 -k <%= $auditd::config::audit_profiles::stig::audit_unsuccessful_file_operations_tag %>
+-a always,exit -F arch=b64 -S ftruncate -F exit=-EPERM -F auid>=<%= $auditd::config::audit_profiles::stig::uid_min %> -F auid!=4294967295 -k <%= $auditd::config::audit_profiles::stig::audit_unsuccessful_file_operations_tag %>
+-a always,exit -F arch=b64 -S ftruncate -F exit=-EACCES -F auid>=<%= $auditd::config::audit_profiles::stig::uid_min %> -F auid!=4294967295 -k <%= $auditd::config::audit_profiles::stig::audit_unsuccessful_file_operations_tag %>
 <%   } -%>
--a exit,always -F arch=b32 -S ftruncate -F exit=-EPERM -F auid>=<%= $auditd::config::audit_profiles::stig::uid_min %> -F auid!=4294967295 -k <%= $auditd::config::audit_profiles::stig::audit_unsuccessful_file_operations_tag %>
--a exit,always -F arch=b32 -S ftruncate -F exit=-EACCES -F auid>=<%= $auditd::config::audit_profiles::stig::uid_min %> -F auid!=4294967295 -k <%= $auditd::config::audit_profiles::stig::audit_unsuccessful_file_operations_tag %>
+-a always,exit -F arch=b32 -S ftruncate -F exit=-EPERM -F auid>=<%= $auditd::config::audit_profiles::stig::uid_min %> -F auid!=4294967295 -k <%= $auditd::config::audit_profiles::stig::audit_unsuccessful_file_operations_tag %>
+-a always,exit -F arch=b32 -S ftruncate -F exit=-EACCES -F auid>=<%= $auditd::config::audit_profiles::stig::uid_min %> -F auid!=4294967295 -k <%= $auditd::config::audit_profiles::stig::audit_unsuccessful_file_operations_tag %>
 <% } -%>
 <% if $auditd::config::audit_profiles::stig::audit_passwd_cmds { -%>
 
 ## Audit the execution of password commands
--a exit,always -F path=/usr/bin/passwd -F perm=x -F auid>=<%= $auditd::config::audit_profiles::stig::uid_min %> -F auid!=4294967295 -k <%= $auditd::config::audit_profiles::stig::audit_passwd_cmds_tag %>
+-a always,exit -F path=/usr/bin/passwd -F perm=x -F auid>=<%= $auditd::config::audit_profiles::stig::uid_min %> -F auid!=4294967295 -k <%= $auditd::config::audit_profiles::stig::audit_passwd_cmds_tag %>
 <%   if $facts['os']['release']['major'] > '6' { -%>
--a exit,always -F path=/bin/passwd -F perm=x -F auid>=<%= $auditd::config::audit_profiles::stig::uid_min %> -F auid!=4294967295 -k <%= $auditd::config::audit_profiles::stig::audit_passwd_cmds_tag %>
+-a always,exit -F path=/bin/passwd -F perm=x -F auid>=<%= $auditd::config::audit_profiles::stig::uid_min %> -F auid!=4294967295 -k <%= $auditd::config::audit_profiles::stig::audit_passwd_cmds_tag %>
 <%   } -%>
 
 <%   if $facts['os']['release']['major'] > '6' { -%>
--a exit,always -F path=/usr/sbin/unix_chkpwd -F perm=x -F auid>=<%= $auditd::config::audit_profiles::stig::uid_min %> -F auid!=4294967295 -k <%= $auditd::config::audit_profiles::stig::audit_passwd_cmds_tag %>
+-a always,exit -F path=/usr/sbin/unix_chkpwd -F perm=x -F auid>=<%= $auditd::config::audit_profiles::stig::uid_min %> -F auid!=4294967295 -k <%= $auditd::config::audit_profiles::stig::audit_passwd_cmds_tag %>
 <%   } -%>
--a exit,always -F path=/sbin/unix_chkpwd -F perm=x -F auid>=<%= $auditd::config::audit_profiles::stig::uid_min %> -F auid!=4294967295 -k <%= $auditd::config::audit_profiles::stig::audit_passwd_cmds_tag %>
+-a always,exit -F path=/sbin/unix_chkpwd -F perm=x -F auid>=<%= $auditd::config::audit_profiles::stig::uid_min %> -F auid!=4294967295 -k <%= $auditd::config::audit_profiles::stig::audit_passwd_cmds_tag %>
 
--a exit,always -F path=/usr/bin/gpasswd -F perm=x -F auid>=<%= $auditd::config::audit_profiles::stig::uid_min %> -F auid!=4294967295 -k <%= $auditd::config::audit_profiles::stig::audit_passwd_cmds_tag %>
+-a always,exit -F path=/usr/bin/gpasswd -F perm=x -F auid>=<%= $auditd::config::audit_profiles::stig::uid_min %> -F auid!=4294967295 -k <%= $auditd::config::audit_profiles::stig::audit_passwd_cmds_tag %>
 <%   if $facts['os']['release']['major'] > '6' { -%>
--a exit,always -F path=/bin/gpasswd -F perm=x -F auid>=<%= $auditd::config::audit_profiles::stig::uid_min %> -F auid!=4294967295 -k <%= $auditd::config::audit_profiles::stig::audit_passwd_cmds_tag %>
-<%   } -%>
-
--a exit,always -F path=/usr/bin/chage -F perm=x -F auid>=<%= $auditd::config::audit_profiles::stig::uid_min %> -F auid!=4294967295 -k <%= $auditd::config::audit_profiles::stig::audit_passwd_cmds_tag %>
-<%   if $facts['os']['release']['major'] > '6' { -%>
--a exit,always -F path=/bin/chage -F perm=x -F auid>=<%= $auditd::config::audit_profiles::stig::uid_min %> -F auid!=4294967295 -k <%= $auditd::config::audit_profiles::stig::audit_passwd_cmds_tag %>
+-a always,exit -F path=/bin/gpasswd -F perm=x -F auid>=<%= $auditd::config::audit_profiles::stig::uid_min %> -F auid!=4294967295 -k <%= $auditd::config::audit_profiles::stig::audit_passwd_cmds_tag %>
 <%   } -%>
 
--a exit,always -F path=/usr/sbin/userhelper -F perm=x -F auid>=<%= $auditd::config::audit_profiles::stig::uid_min %> -F auid!=4294967295 -k <%= $auditd::config::audit_profiles::stig::audit_passwd_cmds_tag %>
+-a always,exit -F path=/usr/bin/chage -F perm=x -F auid>=<%= $auditd::config::audit_profiles::stig::uid_min %> -F auid!=4294967295 -k <%= $auditd::config::audit_profiles::stig::audit_passwd_cmds_tag %>
 <%   if $facts['os']['release']['major'] > '6' { -%>
--a exit,always -F path=/sbin/userhelper -F perm=x -F auid>=<%= $auditd::config::audit_profiles::stig::uid_min %> -F auid!=4294967295 -k <%= $auditd::config::audit_profiles::stig::audit_passwd_cmds_tag %>
+-a always,exit -F path=/bin/chage -F perm=x -F auid>=<%= $auditd::config::audit_profiles::stig::uid_min %> -F auid!=4294967295 -k <%= $auditd::config::audit_profiles::stig::audit_passwd_cmds_tag %>
+<%   } -%>
+
+-a always,exit -F path=/usr/sbin/userhelper -F perm=x -F auid>=<%= $auditd::config::audit_profiles::stig::uid_min %> -F auid!=4294967295 -k <%= $auditd::config::audit_profiles::stig::audit_passwd_cmds_tag %>
+<%   if $facts['os']['release']['major'] > '6' { -%>
+-a always,exit -F path=/sbin/userhelper -F perm=x -F auid>=<%= $auditd::config::audit_profiles::stig::uid_min %> -F auid!=4294967295 -k <%= $auditd::config::audit_profiles::stig::audit_passwd_cmds_tag %>
 <%   } -%>
 <% } -%>
 <% if $auditd::config::audit_profiles::stig::audit_priv_cmds { -%>
 
 ## Audit the execution of privilege-related commands
 <%   if $facts['os']['release']['major'] > '6' { -%>
--a exit,always -F path=/usr/bin/su -F perm=x -F auid>=<%= $auditd::config::audit_profiles::stig::uid_min %> -F auid!=4294967295 -k <%= $auditd::config::audit_profiles::stig::audit_priv_cmds_tag %>
+-a always,exit -F path=/usr/bin/su -F perm=x -F auid>=<%= $auditd::config::audit_profiles::stig::uid_min %> -F auid!=4294967295 -k <%= $auditd::config::audit_profiles::stig::audit_priv_cmds_tag %>
 <%   } -%>
--a exit,always -F path=/bin/su -F perm=x -F auid>=<%= $auditd::config::audit_profiles::stig::uid_min %> -F auid!=4294967295 -k <%= $auditd::config::audit_profiles::stig::audit_priv_cmds_tag %>
+-a always,exit -F path=/bin/su -F perm=x -F auid>=<%= $auditd::config::audit_profiles::stig::uid_min %> -F auid!=4294967295 -k <%= $auditd::config::audit_profiles::stig::audit_priv_cmds_tag %>
 
--a exit,always -F path=/usr/bin/sudo -F perm=x -F auid>=<%= $auditd::config::audit_profiles::stig::uid_min %> -F auid!=4294967295 -k <%= $auditd::config::audit_profiles::stig::audit_priv_cmds_tag %>
+-a always,exit -F path=/usr/bin/sudo -F perm=x -F auid>=<%= $auditd::config::audit_profiles::stig::uid_min %> -F auid!=4294967295 -k <%= $auditd::config::audit_profiles::stig::audit_priv_cmds_tag %>
 <%   if $facts['os']['release']['major'] > '6' { -%>
--a exit,always -F path=/bin/sudo -F perm=x -F auid>=<%= $auditd::config::audit_profiles::stig::uid_min %> -F auid!=4294967295 -k <%= $auditd::config::audit_profiles::stig::audit_priv_cmds_tag %>
-<%   } -%>
-
--a exit,always -F path=/usr/bin/newgrp -F perm=x -F auid>=<%= $auditd::config::audit_profiles::stig::uid_min %> -F auid!=4294967295 -k <%= $auditd::config::audit_profiles::stig::audit_priv_cmds_tag %>
-<%   if $facts['os']['release']['major'] > '6' { -%>
--a exit,always -F path=/bin/newgrp -F perm=x -F auid>=<%= $auditd::config::audit_profiles::stig::uid_min %> -F auid!=4294967295 -k <%= $auditd::config::audit_profiles::stig::audit_priv_cmds_tag %>
+-a always,exit -F path=/bin/sudo -F perm=x -F auid>=<%= $auditd::config::audit_profiles::stig::uid_min %> -F auid!=4294967295 -k <%= $auditd::config::audit_profiles::stig::audit_priv_cmds_tag %>
 <%   } -%>
 
--a exit,always -F path=/usr/bin/chsh -F perm=x -F auid>=<%= $auditd::config::audit_profiles::stig::uid_min %> -F auid!=4294967295 -k <%= $auditd::config::audit_profiles::stig::audit_priv_cmds_tag %>
+-a always,exit -F path=/usr/bin/newgrp -F perm=x -F auid>=<%= $auditd::config::audit_profiles::stig::uid_min %> -F auid!=4294967295 -k <%= $auditd::config::audit_profiles::stig::audit_priv_cmds_tag %>
 <%   if $facts['os']['release']['major'] > '6' { -%>
--a exit,always -F path=/bin/chsh -F perm=x -F auid>=<%= $auditd::config::audit_profiles::stig::uid_min %> -F auid!=4294967295 -k <%= $auditd::config::audit_profiles::stig::audit_priv_cmds_tag %>
+-a always,exit -F path=/bin/newgrp -F perm=x -F auid>=<%= $auditd::config::audit_profiles::stig::uid_min %> -F auid!=4294967295 -k <%= $auditd::config::audit_profiles::stig::audit_priv_cmds_tag %>
 <%   } -%>
 
--a exit,always -F path=/usr/bin/sudoedit -F perm=x -F auid>=<%= $auditd::config::audit_profiles::stig::uid_min %> -F auid!=4294967295 -k <%= $auditd::config::audit_profiles::stig::audit_priv_cmds_tag %>
+-a always,exit -F path=/usr/bin/chsh -F perm=x -F auid>=<%= $auditd::config::audit_profiles::stig::uid_min %> -F auid!=4294967295 -k <%= $auditd::config::audit_profiles::stig::audit_priv_cmds_tag %>
 <%   if $facts['os']['release']['major'] > '6' { -%>
--a exit,always -F path=/bin/sudoedit -F perm=x -F auid>=<%= $auditd::config::audit_profiles::stig::uid_min %> -F auid!=4294967295 -k <%= $auditd::config::audit_profiles::stig::audit_priv_cmds_tag %>
+-a always,exit -F path=/bin/chsh -F perm=x -F auid>=<%= $auditd::config::audit_profiles::stig::uid_min %> -F auid!=4294967295 -k <%= $auditd::config::audit_profiles::stig::audit_priv_cmds_tag %>
+<%   } -%>
+
+-a always,exit -F path=/usr/bin/sudoedit -F perm=x -F auid>=<%= $auditd::config::audit_profiles::stig::uid_min %> -F auid!=4294967295 -k <%= $auditd::config::audit_profiles::stig::audit_priv_cmds_tag %>
+<%   if $facts['os']['release']['major'] > '6' { -%>
+-a always,exit -F path=/bin/sudoedit -F perm=x -F auid>=<%= $auditd::config::audit_profiles::stig::uid_min %> -F auid!=4294967295 -k <%= $auditd::config::audit_profiles::stig::audit_priv_cmds_tag %>
 <%   } -%>
 <% } -%>
 <% if $auditd::config::audit_profiles::stig::audit_postfix_cmds { -%>
 
 ## Audit the execution of postfix-related commands
--a exit,always -F path=/usr/sbin/postdrop -F perm=x -F auid>=<%= $auditd::config::audit_profiles::stig::uid_min %> -F auid!=4294967295 -k <%= $auditd::config::audit_profiles::stig::audit_postfix_cmds_tag %>
+-a always,exit -F path=/usr/sbin/postdrop -F perm=x -F auid>=<%= $auditd::config::audit_profiles::stig::uid_min %> -F auid!=4294967295 -k <%= $auditd::config::audit_profiles::stig::audit_postfix_cmds_tag %>
 <%   if $facts['os']['release']['major'] > '6' { -%>
--a exit,always -F path=/sbin/postdrop -F perm=x -F auid>=<%= $auditd::config::audit_profiles::stig::uid_min %> -F auid!=4294967295 -k <%= $auditd::config::audit_profiles::stig::audit_postfix_cmds_tag %>
+-a always,exit -F path=/sbin/postdrop -F perm=x -F auid>=<%= $auditd::config::audit_profiles::stig::uid_min %> -F auid!=4294967295 -k <%= $auditd::config::audit_profiles::stig::audit_postfix_cmds_tag %>
 <%   } -%>
 
--a exit,always -F path=/usr/sbin/postqueue -F perm=x -F auid>=<%= $auditd::config::audit_profiles::stig::uid_min %> -F auid!=4294967295 -k <%= $auditd::config::audit_profiles::stig::audit_postfix_cmds_tag %>
+-a always,exit -F path=/usr/sbin/postqueue -F perm=x -F auid>=<%= $auditd::config::audit_profiles::stig::uid_min %> -F auid!=4294967295 -k <%= $auditd::config::audit_profiles::stig::audit_postfix_cmds_tag %>
 <%   if $facts['os']['release']['major'] > '6' { -%>
--a exit,always -F path=/sbin/postqueue -F perm=x -F auid>=<%= $auditd::config::audit_profiles::stig::uid_min %> -F auid!=4294967295 -k <%= $auditd::config::audit_profiles::stig::audit_postfix_cmds_tag %>
+-a always,exit -F path=/sbin/postqueue -F perm=x -F auid>=<%= $auditd::config::audit_profiles::stig::uid_min %> -F auid!=4294967295 -k <%= $auditd::config::audit_profiles::stig::audit_postfix_cmds_tag %>
 <%   } -%>
 <% } -%>
 <% if $auditd::config::audit_profiles::stig::audit_ssh_keysign_cmd { -%>
 
 ## Audit the execution of the ssh-keysign command
--a exit,always -F path=/usr/libexec/openssh/ssh-keysign -F perm=x -F auid>=<%= $auditd::config::audit_profiles::stig::uid_min %> -F auid!=4294967295 -k <%= $auditd::config::audit_profiles::stig::audit_ssh_keysign_cmd_tag %>
+-a always,exit -F path=/usr/libexec/openssh/ssh-keysign -F perm=x -F auid>=<%= $auditd::config::audit_profiles::stig::uid_min %> -F auid!=4294967295 -k <%= $auditd::config::audit_profiles::stig::audit_ssh_keysign_cmd_tag %>
 <% } -%>
 <% if $auditd::config::audit_profiles::stig::audit_crontab_cmd { -%>
 
 ## Audit the execution of the crontab command
--a exit,always -F path=/usr/bin/crontab -F perm=x -F auid>=<%= $auditd::config::audit_profiles::stig::uid_min %> -F auid!=4294967295 -k <%= $auditd::config::audit_profiles::stig::audit_crontab_cmd_tag %>
+-a always,exit -F path=/usr/bin/crontab -F perm=x -F auid>=<%= $auditd::config::audit_profiles::stig::uid_min %> -F auid!=4294967295 -k <%= $auditd::config::audit_profiles::stig::audit_crontab_cmd_tag %>
 <%   if $facts['os']['release']['major'] > '6' { -%>
--a exit,always -F path=/bin/crontab -F perm=x -F auid>=<%= $auditd::config::audit_profiles::stig::uid_min %> -F auid!=4294967295 -k <%= $auditd::config::audit_profiles::stig::audit_crontab_cmd_tag %>
+-a always,exit -F path=/bin/crontab -F perm=x -F auid>=<%= $auditd::config::audit_profiles::stig::uid_min %> -F auid!=4294967295 -k <%= $auditd::config::audit_profiles::stig::audit_crontab_cmd_tag %>
 <%   } -%>
 <% } -%>
 <% if $auditd::config::audit_profiles::stig::audit_pam_timestamp_check_cmd { -%>
 
 ## Audit the execution of the pam_timestamp_check command
 <%   if $facts['os']['release']['major'] > '6' { -%>
--a exit,always -F path=/usr/sbin/pam_timestamp_check -F perm=x -F auid>=<%= $auditd::config::audit_profiles::stig::uid_min %> -F auid!=4294967295 -k <%= $auditd::config::audit_profiles::stig::audit_pam_timestamp_check_cmd_tag %>
+-a always,exit -F path=/usr/sbin/pam_timestamp_check -F perm=x -F auid>=<%= $auditd::config::audit_profiles::stig::uid_min %> -F auid!=4294967295 -k <%= $auditd::config::audit_profiles::stig::audit_pam_timestamp_check_cmd_tag %>
 <%   } -%>
--a exit,always -F path=/sbin/pam_timestamp_check -F perm=x -F auid>=<%= $auditd::config::audit_profiles::stig::uid_min %> -F auid!=4294967295 -k <%= $auditd::config::audit_profiles::stig::audit_pam_timestamp_check_cmd_tag %>
+-a always,exit -F path=/sbin/pam_timestamp_check -F perm=x -F auid>=<%= $auditd::config::audit_profiles::stig::uid_min %> -F auid!=4294967295 -k <%= $auditd::config::audit_profiles::stig::audit_pam_timestamp_check_cmd_tag %>
 <% } -%>
 <% if $auditd::config::audit_profiles::stig::audit_selinux_cmds { -%>
 
 ## Audit selinux commands
--a exit,always -F path=/usr/sbin/semanage -F perm=x -F auid>=<%= $auditd::config::audit_profiles::stig::uid_min %> -F auid!=4294967295 -k <%= $auditd::config::audit_profiles::stig::audit_selinux_cmds_tag %>
+-a always,exit -F path=/usr/sbin/semanage -F perm=x -F auid>=<%= $auditd::config::audit_profiles::stig::uid_min %> -F auid!=4294967295 -k <%= $auditd::config::audit_profiles::stig::audit_selinux_cmds_tag %>
 <%   if $facts['os']['release']['major'] > '6' { -%>
--a exit,always -F path=/sbin/semanage -F perm=x -F auid>=<%= $auditd::config::audit_profiles::stig::uid_min %> -F auid!=4294967295 -k <%= $auditd::config::audit_profiles::stig::audit_selinux_cmds_tag %>
+-a always,exit -F path=/sbin/semanage -F perm=x -F auid>=<%= $auditd::config::audit_profiles::stig::uid_min %> -F auid!=4294967295 -k <%= $auditd::config::audit_profiles::stig::audit_selinux_cmds_tag %>
 <%   } -%>
 
--a exit,always -F path=/usr/sbin/setsebool -F perm=x -F auid>=<%= $auditd::config::audit_profiles::stig::uid_min %> -F auid!=4294967295 -k <%= $auditd::config::audit_profiles::stig::audit_selinux_cmds_tag %>
+-a always,exit -F path=/usr/sbin/setsebool -F perm=x -F auid>=<%= $auditd::config::audit_profiles::stig::uid_min %> -F auid!=4294967295 -k <%= $auditd::config::audit_profiles::stig::audit_selinux_cmds_tag %>
 <%   if $facts['os']['release']['major'] > '6' { -%>
--a exit,always -F path=/sbin/setsebool -F perm=x -F auid>=<%= $auditd::config::audit_profiles::stig::uid_min %> -F auid!=4294967295 -k <%= $auditd::config::audit_profiles::stig::audit_selinux_cmds_tag %>
+-a always,exit -F path=/sbin/setsebool -F perm=x -F auid>=<%= $auditd::config::audit_profiles::stig::uid_min %> -F auid!=4294967295 -k <%= $auditd::config::audit_profiles::stig::audit_selinux_cmds_tag %>
 <%   } -%>
 
--a exit,always -F path=/usr/bin/chcon -F perm=x -F auid>=<%= $auditd::config::audit_profiles::stig::uid_min %> -F auid!=4294967295 -k <%= $auditd::config::audit_profiles::stig::audit_selinux_cmds_tag %>
+-a always,exit -F path=/usr/bin/chcon -F perm=x -F auid>=<%= $auditd::config::audit_profiles::stig::uid_min %> -F auid!=4294967295 -k <%= $auditd::config::audit_profiles::stig::audit_selinux_cmds_tag %>
 <%   if $facts['os']['release']['major'] > '6' { -%>
--a exit,always -F path=/bin/chcon -F perm=x -F auid>=<%= $auditd::config::audit_profiles::stig::uid_min %> -F auid!=4294967295 -k <%= $auditd::config::audit_profiles::stig::audit_selinux_cmds_tag %>
+-a always,exit -F path=/bin/chcon -F perm=x -F auid>=<%= $auditd::config::audit_profiles::stig::uid_min %> -F auid!=4294967295 -k <%= $auditd::config::audit_profiles::stig::audit_selinux_cmds_tag %>
 <%   } -%>
 
 <%   if $facts['os']['release']['major'] > '6' { -%>
--a exit,always -F path=/usr/sbin/setfiles -F perm=x -F auid>=<%= $auditd::config::audit_profiles::stig::uid_min %> -F auid!=4294967295 -k <%= $auditd::config::audit_profiles::stig::audit_selinux_cmds_tag %>
+-a always,exit -F path=/usr/sbin/setfiles -F perm=x -F auid>=<%= $auditd::config::audit_profiles::stig::uid_min %> -F auid!=4294967295 -k <%= $auditd::config::audit_profiles::stig::audit_selinux_cmds_tag %>
 <%   } -%>
--a exit,always -F path=/sbin/setfiles -F perm=x -F auid>=<%= $auditd::config::audit_profiles::stig::uid_min %> -F auid!=4294967295 -k <%= $auditd::config::audit_profiles::stig::audit_selinux_cmds_tag %>
+-a always,exit -F path=/sbin/setfiles -F perm=x -F auid>=<%= $auditd::config::audit_profiles::stig::uid_min %> -F auid!=4294967295 -k <%= $auditd::config::audit_profiles::stig::audit_selinux_cmds_tag %>
 
--a exit,always -F path=/sbin/restorecon -F perm=x -F auid>=<%= $auditd::config::audit_profiles::stig::uid_min %> -F auid!=4294967295 -k <%= $auditd::config::audit_profiles::stig::audit_selinux_cmds_tag %>
+-a always,exit -F path=/sbin/restorecon -F perm=x -F auid>=<%= $auditd::config::audit_profiles::stig::uid_min %> -F auid!=4294967295 -k <%= $auditd::config::audit_profiles::stig::audit_selinux_cmds_tag %>
 <%   if $facts['os']['release']['major'] > '6' { -%>
--a exit,always -F path=/usr/sbin/restorecon -F perm=x -F auid>=<%= $auditd::config::audit_profiles::stig::uid_min %> -F auid!=4294967295 -k <%= $auditd::config::audit_profiles::stig::audit_selinux_cmds_tag %>
+-a always,exit -F path=/usr/sbin/restorecon -F perm=x -F auid>=<%= $auditd::config::audit_profiles::stig::uid_min %> -F auid!=4294967295 -k <%= $auditd::config::audit_profiles::stig::audit_selinux_cmds_tag %>
 <%   } -%>
 <% } -%>
 
 ## Permissions auditing separated by chown, chmod, and attr
 <% if $auditd::config::audit_profiles::stig::audit_chown { -%>
 <%   if $facts['hardwaremodel'] == "x86_64" { -%>
--a exit,always -F arch=b64 -S chown -F auid>=<%= $auditd::config::audit_profiles::stig::uid_min %> -F auid!=4294967295 -k <%= $auditd::config::audit_profiles::stig::audit_chown_tag %>
+-a always,exit -F arch=b64 -S chown -F auid>=<%= $auditd::config::audit_profiles::stig::uid_min %> -F auid!=4294967295 -k <%= $auditd::config::audit_profiles::stig::audit_chown_tag %>
 <%   } -%>
--a exit,always -F arch=b32 -S chown -F auid>=<%= $auditd::config::audit_profiles::stig::uid_min %> -F auid!=4294967295 -k <%= $auditd::config::audit_profiles::stig::audit_chown_tag %>
+-a always,exit -F arch=b32 -S chown -F auid>=<%= $auditd::config::audit_profiles::stig::uid_min %> -F auid!=4294967295 -k <%= $auditd::config::audit_profiles::stig::audit_chown_tag %>
 
 <%   if $facts['hardwaremodel'] == "x86_64" { -%>
--a exit,always -F arch=b64 -S fchown -F auid>=<%= $auditd::config::audit_profiles::stig::uid_min %> -F auid!=4294967295 -k <%= $auditd::config::audit_profiles::stig::audit_chown_tag %>
+-a always,exit -F arch=b64 -S fchown -F auid>=<%= $auditd::config::audit_profiles::stig::uid_min %> -F auid!=4294967295 -k <%= $auditd::config::audit_profiles::stig::audit_chown_tag %>
 <%   } -%>
--a exit,always -F arch=b32 -S fchown -F auid>=<%= $auditd::config::audit_profiles::stig::uid_min %> -F auid!=4294967295 -k <%= $auditd::config::audit_profiles::stig::audit_chown_tag %>
+-a always,exit -F arch=b32 -S fchown -F auid>=<%= $auditd::config::audit_profiles::stig::uid_min %> -F auid!=4294967295 -k <%= $auditd::config::audit_profiles::stig::audit_chown_tag %>
 
 <%   if $facts['hardwaremodel'] == "x86_64" { -%>
--a exit,always -F arch=b64 -S lchown -F auid>=<%= $auditd::config::audit_profiles::stig::uid_min %> -F auid!=4294967295 -k <%= $auditd::config::audit_profiles::stig::audit_chown_tag %>
+-a always,exit -F arch=b64 -S lchown -F auid>=<%= $auditd::config::audit_profiles::stig::uid_min %> -F auid!=4294967295 -k <%= $auditd::config::audit_profiles::stig::audit_chown_tag %>
 <%   } -%>
--a exit,always -F arch=b32 -S lchown -F auid>=<%= $auditd::config::audit_profiles::stig::uid_min %> -F auid!=4294967295 -k <%= $auditd::config::audit_profiles::stig::audit_chown_tag %>
+-a always,exit -F arch=b32 -S lchown -F auid>=<%= $auditd::config::audit_profiles::stig::uid_min %> -F auid!=4294967295 -k <%= $auditd::config::audit_profiles::stig::audit_chown_tag %>
 
 <%   if $facts['hardwaremodel'] == "x86_64" { -%>
--a exit,always -F arch=b64 -S fchownat -F auid>=<%= $auditd::config::audit_profiles::stig::uid_min %> -F auid!=4294967295 -k <%= $auditd::config::audit_profiles::stig::audit_chown_tag %>
+-a always,exit -F arch=b64 -S fchownat -F auid>=<%= $auditd::config::audit_profiles::stig::uid_min %> -F auid!=4294967295 -k <%= $auditd::config::audit_profiles::stig::audit_chown_tag %>
 <%   } -%>
--a exit,always -F arch=b32 -S fchownat -F auid>=<%= $auditd::config::audit_profiles::stig::uid_min %> -F auid!=4294967295 -k <%= $auditd::config::audit_profiles::stig::audit_chown_tag %>
+-a always,exit -F arch=b32 -S fchownat -F auid>=<%= $auditd::config::audit_profiles::stig::uid_min %> -F auid!=4294967295 -k <%= $auditd::config::audit_profiles::stig::audit_chown_tag %>
 <% } -%>
 <% if $auditd::config::audit_profiles::stig::audit_chmod { -%>
 
--a exit,always -F arch=b64 -S chmod -F auid>=<%= $auditd::config::audit_profiles::stig::uid_min %> -F auid!=4294967295 -k <%= $auditd::config::audit_profiles::stig::audit_chmod_tag %>
+-a always,exit -F arch=b64 -S chmod -F auid>=<%= $auditd::config::audit_profiles::stig::uid_min %> -F auid!=4294967295 -k <%= $auditd::config::audit_profiles::stig::audit_chmod_tag %>
 <%   if $facts['hardwaremodel'] == "x86_64" { -%>
--a exit,always -F arch=b32 -S chmod -F auid>=<%= $auditd::config::audit_profiles::stig::uid_min %> -F auid!=4294967295 -k <%= $auditd::config::audit_profiles::stig::audit_chmod_tag %>
+-a always,exit -F arch=b32 -S chmod -F auid>=<%= $auditd::config::audit_profiles::stig::uid_min %> -F auid!=4294967295 -k <%= $auditd::config::audit_profiles::stig::audit_chmod_tag %>
 <%   } -%>
 
--a exit,always -F arch=b64 -S fchmod -F auid>=<%= $auditd::config::audit_profiles::stig::uid_min %> -F auid!=4294967295 -k <%= $auditd::config::audit_profiles::stig::audit_chmod_tag %>
+-a always,exit -F arch=b64 -S fchmod -F auid>=<%= $auditd::config::audit_profiles::stig::uid_min %> -F auid!=4294967295 -k <%= $auditd::config::audit_profiles::stig::audit_chmod_tag %>
 <%   if $facts['hardwaremodel'] == "x86_64" { -%>
--a exit,always -F arch=b32 -S fchmod -F auid>=<%= $auditd::config::audit_profiles::stig::uid_min %> -F auid!=4294967295 -k <%= $auditd::config::audit_profiles::stig::audit_chmod_tag %>
+-a always,exit -F arch=b32 -S fchmod -F auid>=<%= $auditd::config::audit_profiles::stig::uid_min %> -F auid!=4294967295 -k <%= $auditd::config::audit_profiles::stig::audit_chmod_tag %>
 <%   } -%>
 
--a exit,always -F arch=b64 -S fchmodat -F auid>=<%= $auditd::config::audit_profiles::stig::uid_min %> -F auid!=4294967295 -k <%= $auditd::config::audit_profiles::stig::audit_chmod_tag %>
+-a always,exit -F arch=b64 -S fchmodat -F auid>=<%= $auditd::config::audit_profiles::stig::uid_min %> -F auid!=4294967295 -k <%= $auditd::config::audit_profiles::stig::audit_chmod_tag %>
 <%   if $facts['hardwaremodel'] == "x86_64" { -%>
--a exit,always -F arch=b32 -S fchmodat -F auid>=<%= $auditd::config::audit_profiles::stig::uid_min %> -F auid!=4294967295 -k <%= $auditd::config::audit_profiles::stig::audit_chmod_tag %>
+-a always,exit -F arch=b32 -S fchmodat -F auid>=<%= $auditd::config::audit_profiles::stig::uid_min %> -F auid!=4294967295 -k <%= $auditd::config::audit_profiles::stig::audit_chmod_tag %>
 <%   } -%>
 <% } -%>
 <% if $auditd::config::audit_profiles::stig::audit_attr { -%>
 
 <%   if $facts['hardwaremodel'] == "x86_64" { -%>
--a exit,always -F arch=b64 -S setxattr -F auid>=<%= $auditd::config::audit_profiles::stig::uid_min %> -F auid!=4294967295 -k <%= $auditd::config::audit_profiles::stig::audit_attr_tag %>
+-a always,exit -F arch=b64 -S setxattr -F auid>=<%= $auditd::config::audit_profiles::stig::uid_min %> -F auid!=4294967295 -k <%= $auditd::config::audit_profiles::stig::audit_attr_tag %>
 <%   } -%>
--a exit,always -F arch=b32 -S setxattr -F auid>=<%= $auditd::config::audit_profiles::stig::uid_min %> -F auid!=4294967295 -k <%= $auditd::config::audit_profiles::stig::audit_attr_tag %>
+-a always,exit -F arch=b32 -S setxattr -F auid>=<%= $auditd::config::audit_profiles::stig::uid_min %> -F auid!=4294967295 -k <%= $auditd::config::audit_profiles::stig::audit_attr_tag %>
 
 <%   if $facts['hardwaremodel'] == "x86_64" { -%>
--a exit,always -F arch=b64 -S fsetxattr -F auid>=<%= $auditd::config::audit_profiles::stig::uid_min %> -F auid!=4294967295 -k <%= $auditd::config::audit_profiles::stig::audit_attr_tag %>
+-a always,exit -F arch=b64 -S fsetxattr -F auid>=<%= $auditd::config::audit_profiles::stig::uid_min %> -F auid!=4294967295 -k <%= $auditd::config::audit_profiles::stig::audit_attr_tag %>
 <%   } -%>
--a exit,always -F arch=b32 -S fsetxattr -F auid>=<%= $auditd::config::audit_profiles::stig::uid_min %> -F auid!=4294967295 -k <%= $auditd::config::audit_profiles::stig::audit_attr_tag %>
+-a always,exit -F arch=b32 -S fsetxattr -F auid>=<%= $auditd::config::audit_profiles::stig::uid_min %> -F auid!=4294967295 -k <%= $auditd::config::audit_profiles::stig::audit_attr_tag %>
 
 <%   if $facts['hardwaremodel'] == "x86_64" { -%>
--a exit,always -F arch=b64 -S lsetxattr -F auid>=<%= $auditd::config::audit_profiles::stig::uid_min %> -F auid!=4294967295 -k <%= $auditd::config::audit_profiles::stig::audit_attr_tag %>
+-a always,exit -F arch=b64 -S lsetxattr -F auid>=<%= $auditd::config::audit_profiles::stig::uid_min %> -F auid!=4294967295 -k <%= $auditd::config::audit_profiles::stig::audit_attr_tag %>
 <%   } -%>
--a exit,always -F arch=b32 -S lsetxattr -F auid>=<%= $auditd::config::audit_profiles::stig::uid_min %> -F auid!=4294967295 -k <%= $auditd::config::audit_profiles::stig::audit_attr_tag %>
+-a always,exit -F arch=b32 -S lsetxattr -F auid>=<%= $auditd::config::audit_profiles::stig::uid_min %> -F auid!=4294967295 -k <%= $auditd::config::audit_profiles::stig::audit_attr_tag %>
 
 <%   if $facts['hardwaremodel'] == "x86_64" { -%>
--a exit,always -F arch=b64 -S removexattr -F auid>=<%= $auditd::config::audit_profiles::stig::uid_min %> -F auid!=4294967295 -k <%= $auditd::config::audit_profiles::stig::audit_attr_tag %>
+-a always,exit -F arch=b64 -S removexattr -F auid>=<%= $auditd::config::audit_profiles::stig::uid_min %> -F auid!=4294967295 -k <%= $auditd::config::audit_profiles::stig::audit_attr_tag %>
 <%   } -%>
--a exit,always -F arch=b32 -S removexattr -F auid>=<%= $auditd::config::audit_profiles::stig::uid_min %> -F auid!=4294967295 -k <%= $auditd::config::audit_profiles::stig::audit_attr_tag %>
+-a always,exit -F arch=b32 -S removexattr -F auid>=<%= $auditd::config::audit_profiles::stig::uid_min %> -F auid!=4294967295 -k <%= $auditd::config::audit_profiles::stig::audit_attr_tag %>
 
 <%   if $facts['hardwaremodel'] == "x86_64" { -%>
--a exit,always -F arch=b64 -S fremovexattr -F auid>=<%= $auditd::config::audit_profiles::stig::uid_min %> -F auid!=4294967295 -k <%= $auditd::config::audit_profiles::stig::audit_attr_tag %>
+-a always,exit -F arch=b64 -S fremovexattr -F auid>=<%= $auditd::config::audit_profiles::stig::uid_min %> -F auid!=4294967295 -k <%= $auditd::config::audit_profiles::stig::audit_attr_tag %>
 <%   } -%>
--a exit,always -F arch=b32 -S fremovexattr -F auid>=<%= $auditd::config::audit_profiles::stig::uid_min %> -F auid!=4294967295 -k <%= $auditd::config::audit_profiles::stig::audit_attr_tag %>
+-a always,exit -F arch=b32 -S fremovexattr -F auid>=<%= $auditd::config::audit_profiles::stig::uid_min %> -F auid!=4294967295 -k <%= $auditd::config::audit_profiles::stig::audit_attr_tag %>
 
 <%   if $facts['hardwaremodel'] == "x86_64" { -%>
--a exit,always -F arch=b64 -S lremovexattr -F auid>=<%= $auditd::config::audit_profiles::stig::uid_min %> -F auid!=4294967295 -k <%= $auditd::config::audit_profiles::stig::audit_attr_tag %>
+-a always,exit -F arch=b64 -S lremovexattr -F auid>=<%= $auditd::config::audit_profiles::stig::uid_min %> -F auid!=4294967295 -k <%= $auditd::config::audit_profiles::stig::audit_attr_tag %>
 <%   } -%>
--a exit,always -F arch=b32 -S lremovexattr -F auid>=<%= $auditd::config::audit_profiles::stig::uid_min %> -F auid!=4294967295 -k <%= $auditd::config::audit_profiles::stig::audit_attr_tag %>
+-a always,exit -F arch=b32 -S lremovexattr -F auid>=<%= $auditd::config::audit_profiles::stig::uid_min %> -F auid!=4294967295 -k <%= $auditd::config::audit_profiles::stig::audit_attr_tag %>
 <% } -%>
 <% if $auditd::config::audit_profiles::stig::audit_rename_remove { -%>
 
 ## Audit rename/removal operations
 <%   if $facts['hardwaremodel'] == "x86_64" { -%>
--a exit,always -F arch=b64 -S rename -F perm=x -F auid>=<%= $auditd::config::audit_profiles::stig::uid_min %> -F auid!=4294967295 -k <%= $auditd::config::audit_profiles::stig::audit_rename_remove_tag %>
+-a always,exit -F arch=b64 -S rename -F perm=x -F auid>=<%= $auditd::config::audit_profiles::stig::uid_min %> -F auid!=4294967295 -k <%= $auditd::config::audit_profiles::stig::audit_rename_remove_tag %>
 <%   } -%>
--a exit,always -F arch=b32 -S rename -F perm=x -F auid>=<%= $auditd::config::audit_profiles::stig::uid_min %> -F auid!=4294967295 -k <%= $auditd::config::audit_profiles::stig::audit_rename_remove_tag %>
+-a always,exit -F arch=b32 -S rename -F perm=x -F auid>=<%= $auditd::config::audit_profiles::stig::uid_min %> -F auid!=4294967295 -k <%= $auditd::config::audit_profiles::stig::audit_rename_remove_tag %>
 
 <%   if $facts['hardwaremodel'] == "x86_64" { -%>
--a exit,always -F arch=b64 -S renameat -F perm=x -F auid>=<%= $auditd::config::audit_profiles::stig::uid_min %> -F auid!=4294967295 -k <%= $auditd::config::audit_profiles::stig::audit_rename_remove_tag %>
+-a always,exit -F arch=b64 -S renameat -F perm=x -F auid>=<%= $auditd::config::audit_profiles::stig::uid_min %> -F auid!=4294967295 -k <%= $auditd::config::audit_profiles::stig::audit_rename_remove_tag %>
 <%   } -%>
--a exit,always -F arch=b32 -S renameat -F perm=x -F auid>=<%= $auditd::config::audit_profiles::stig::uid_min %> -F auid!=4294967295 -k <%= $auditd::config::audit_profiles::stig::audit_rename_remove_tag %>
+-a always,exit -F arch=b32 -S renameat -F perm=x -F auid>=<%= $auditd::config::audit_profiles::stig::uid_min %> -F auid!=4294967295 -k <%= $auditd::config::audit_profiles::stig::audit_rename_remove_tag %>
 
 <%   if $facts['hardwaremodel'] == "x86_64" { -%>
--a exit,always -F arch=b64 -S rmdir -F perm=x -F auid>=<%= $auditd::config::audit_profiles::stig::uid_min %> -F auid!=4294967295 -k <%= $auditd::config::audit_profiles::stig::audit_rename_remove_tag %>
+-a always,exit -F arch=b64 -S rmdir -F perm=x -F auid>=<%= $auditd::config::audit_profiles::stig::uid_min %> -F auid!=4294967295 -k <%= $auditd::config::audit_profiles::stig::audit_rename_remove_tag %>
 <%   } -%>
--a exit,always -F arch=b32 -S rmdir -F perm=x -F auid>=<%= $auditd::config::audit_profiles::stig::uid_min %> -F auid!=4294967295 -k <%= $auditd::config::audit_profiles::stig::audit_rename_remove_tag %>
+-a always,exit -F arch=b32 -S rmdir -F perm=x -F auid>=<%= $auditd::config::audit_profiles::stig::uid_min %> -F auid!=4294967295 -k <%= $auditd::config::audit_profiles::stig::audit_rename_remove_tag %>
 
 <%   if $facts['hardwaremodel'] == "x86_64" { -%>
--a exit,always -F arch=b64 -S unlink -F perm=x -F auid>=<%= $auditd::config::audit_profiles::stig::uid_min %> -F auid!=4294967295 -k <%= $auditd::config::audit_profiles::stig::audit_rename_remove_tag %>
+-a always,exit -F arch=b64 -S unlink -F perm=x -F auid>=<%= $auditd::config::audit_profiles::stig::uid_min %> -F auid!=4294967295 -k <%= $auditd::config::audit_profiles::stig::audit_rename_remove_tag %>
 <%   } -%>
--a exit,always -F arch=b32 -S unlink -F perm=x -F auid>=<%= $auditd::config::audit_profiles::stig::uid_min %> -F auid!=4294967295 -k <%= $auditd::config::audit_profiles::stig::audit_rename_remove_tag %>
+-a always,exit -F arch=b32 -S unlink -F perm=x -F auid>=<%= $auditd::config::audit_profiles::stig::uid_min %> -F auid!=4294967295 -k <%= $auditd::config::audit_profiles::stig::audit_rename_remove_tag %>
 
 <%   if $facts['hardwaremodel'] == "x86_64" { -%>
--a exit,always -F arch=b64 -S unlinkat -F perm=x -F auid>=<%= $auditd::config::audit_profiles::stig::uid_min %> -F auid!=4294967295 -k <%= $auditd::config::audit_profiles::stig::audit_rename_remove_tag %>
+-a always,exit -F arch=b64 -S unlinkat -F perm=x -F auid>=<%= $auditd::config::audit_profiles::stig::uid_min %> -F auid!=4294967295 -k <%= $auditd::config::audit_profiles::stig::audit_rename_remove_tag %>
 <%   } -%>
--a exit,always -F arch=b32 -S unlinkat -F perm=x -F auid>=<%= $auditd::config::audit_profiles::stig::uid_min %> -F auid!=4294967295 -k <%= $auditd::config::audit_profiles::stig::audit_rename_remove_tag %>
+-a always,exit -F arch=b32 -S unlinkat -F perm=x -F auid>=<%= $auditd::config::audit_profiles::stig::uid_min %> -F auid!=4294967295 -k <%= $auditd::config::audit_profiles::stig::audit_rename_remove_tag %>
 <% } -%>
 <% if $auditd::config::audit_profiles::stig::audit_suid_sgid { -%>
 
 ## Audit the execution of suid and sgid binaries.
 <%   $auditd::config::audit_profiles::stig::_suid_sgid_cmds.each |$cmd| { -%>
--a exit,always -F path=<%= $cmd %> -F perm=x -F auid>=<%= $auditd::config::audit_profiles::stig::uid_min %> -F auid!=4294967295 -k <%= $auditd::config::audit_profiles::stig::audit_suid_sgid_tag %>
+-a always,exit -F path=<%= $cmd %> -F perm=x -F auid>=<%= $auditd::config::audit_profiles::stig::uid_min %> -F auid!=4294967295 -k <%= $auditd::config::audit_profiles::stig::audit_suid_sgid_tag %>
 <%   } -%>
 <% } -%>
 <% if $auditd::config::audit_profiles::stig::audit_kernel_modules { -%>
@@ -292,45 +292,45 @@
 -w /sbin/modprobe -p x -F auid!=4294967295 -k <%= $auditd::config::audit_profiles::stig::audit_kernel_modules_tag %>
 
 <%   if $facts['hardwaremodel'] == "x86_64" { -%>
--a exit,always -F arch=b64 -S create_module -k <%= $auditd::config::audit_profiles::stig::audit_kernel_modules_tag %>
+-a always,exit -F arch=b64 -S create_module -k <%= $auditd::config::audit_profiles::stig::audit_kernel_modules_tag %>
 <%   } -%>
--a exit,always -F arch=b32 -S create_module -k <%= $auditd::config::audit_profiles::stig::audit_kernel_modules_tag %>
+-a always,exit -F arch=b32 -S create_module -k <%= $auditd::config::audit_profiles::stig::audit_kernel_modules_tag %>
 
 <%   if $facts['hardwaremodel'] == "x86_64" { -%>
--a exit,always -F arch=b64 -S init_module -k <%= $auditd::config::audit_profiles::stig::audit_kernel_modules_tag %>
+-a always,exit -F arch=b64 -S init_module -k <%= $auditd::config::audit_profiles::stig::audit_kernel_modules_tag %>
 <%   } -%>
--a exit,always -F arch=b32 -S init_module -k <%= $auditd::config::audit_profiles::stig::audit_kernel_modules_tag %>
+-a always,exit -F arch=b32 -S init_module -k <%= $auditd::config::audit_profiles::stig::audit_kernel_modules_tag %>
 
 <%   if $facts['hardwaremodel'] == "x86_64" { -%>
--a exit,always -F arch=b64 -S finit_module -k <%= $auditd::config::audit_profiles::stig::audit_kernel_modules_tag %>
+-a always,exit -F arch=b64 -S finit_module -k <%= $auditd::config::audit_profiles::stig::audit_kernel_modules_tag %>
 <%   } -%>
--a exit,always -F arch=b32 -S finit_module -k <%= $auditd::config::audit_profiles::stig::audit_kernel_modules_tag %>
+-a always,exit -F arch=b32 -S finit_module -k <%= $auditd::config::audit_profiles::stig::audit_kernel_modules_tag %>
 
 <%   if $facts['hardwaremodel'] == "x86_64" { -%>
--a exit,always -F arch=b64 -S delete_module -k <%= $auditd::config::audit_profiles::stig::audit_kernel_modules_tag %>
+-a always,exit -F arch=b64 -S delete_module -k <%= $auditd::config::audit_profiles::stig::audit_kernel_modules_tag %>
 <%   } -%>
--a exit,always -F arch=b32 -S delete_module -k <%= $auditd::config::audit_profiles::stig::audit_kernel_modules_tag %>
+-a always,exit -F arch=b32 -S delete_module -k <%= $auditd::config::audit_profiles::stig::audit_kernel_modules_tag %>
 <% } -%>
 <% if $auditd::config::audit_profiles::stig::audit_mount { -%>
 
 ## Audit mount operations
 <%   if $facts['hardwaremodel'] == "x86_64" { -%>
--a exit,always -F arch=b64 -S mount -F auid>=<%= $auditd::config::audit_profiles::stig::uid_min %> -F auid!=4294967295 -k <%= $auditd::config::audit_profiles::stig::audit_mount_tag %>
+-a always,exit -F arch=b64 -S mount -F auid>=<%= $auditd::config::audit_profiles::stig::uid_min %> -F auid!=4294967295 -k <%= $auditd::config::audit_profiles::stig::audit_mount_tag %>
 <%     if $facts['os']['release']['major'] > '6' { -%>
--a exit,always -F arch=b64 -F path=/usr/bin/mount -F auid>=<%= $auditd::config::audit_profiles::stig::uid_min %> -F auid!=4294967295 -k <%= $auditd::config::audit_profiles::stig::audit_mount_tag %>
+-a always,exit -F arch=b64 -F path=/usr/bin/mount -F auid>=<%= $auditd::config::audit_profiles::stig::uid_min %> -F auid!=4294967295 -k <%= $auditd::config::audit_profiles::stig::audit_mount_tag %>
 <%     } -%>
--a exit,always -F arch=b64 -F path=/bin/mount -F auid>=<%= $auditd::config::audit_profiles::stig::uid_min %> -F auid!=4294967295 -k <%= $auditd::config::audit_profiles::stig::audit_mount_tag %>
+-a always,exit -F arch=b64 -F path=/bin/mount -F auid>=<%= $auditd::config::audit_profiles::stig::uid_min %> -F auid!=4294967295 -k <%= $auditd::config::audit_profiles::stig::audit_mount_tag %>
 <%   } -%>
--a exit,always -F arch=b32 -S mount -F auid>=<%= $auditd::config::audit_profiles::stig::uid_min %> -F auid!=4294967295 -k <%= $auditd::config::audit_profiles::stig::audit_mount_tag %>
+-a always,exit -F arch=b32 -S mount -F auid>=<%= $auditd::config::audit_profiles::stig::uid_min %> -F auid!=4294967295 -k <%= $auditd::config::audit_profiles::stig::audit_mount_tag %>
 <%   if $facts['os']['release']['major'] > '6' { -%>
--a exit,always -F arch=b32 -F path=/usr/bin/mount -F auid>=<%= $auditd::config::audit_profiles::stig::uid_min %> -F auid!=4294967295 -k <%= $auditd::config::audit_profiles::stig::audit_mount_tag %>
+-a always,exit -F arch=b32 -F path=/usr/bin/mount -F auid>=<%= $auditd::config::audit_profiles::stig::uid_min %> -F auid!=4294967295 -k <%= $auditd::config::audit_profiles::stig::audit_mount_tag %>
 <%   } -%>
--a exit,always -F arch=b32 -F path=/bin/mount -F auid>=<%= $auditd::config::audit_profiles::stig::uid_min %> -F auid!=4294967295 -k <%= $auditd::config::audit_profiles::stig::audit_mount_tag %>
+-a always,exit -F arch=b32 -F path=/bin/mount -F auid>=<%= $auditd::config::audit_profiles::stig::uid_min %> -F auid!=4294967295 -k <%= $auditd::config::audit_profiles::stig::audit_mount_tag %>
 
 <%   if $facts['os']['release']['major'] > '6' { -%>
--a exit,always -F path=/usr/bin/umount -F perm=x -F auid>=<%= $auditd::config::audit_profiles::stig::uid_min %> -F auid!=4294967295 -k <%= $auditd::config::audit_profiles::stig::audit_mount_tag %>
+-a always,exit -F path=/usr/bin/umount -F perm=x -F auid>=<%= $auditd::config::audit_profiles::stig::uid_min %> -F auid!=4294967295 -k <%= $auditd::config::audit_profiles::stig::audit_mount_tag %>
 <%   } -%>
--a exit,always -F path=/bin/umount -F perm=x -F auid>=<%= $auditd::config::audit_profiles::stig::uid_min %> -F auid!=4294967295 -k <%= $auditd::config::audit_profiles::stig::audit_mount_tag %>
+-a always,exit -F path=/bin/umount -F perm=x -F auid>=<%= $auditd::config::audit_profiles::stig::uid_min %> -F auid!=4294967295 -k <%= $auditd::config::audit_profiles::stig::audit_mount_tag %>
 <% } -%>
 <% if $auditd::config::audit_profiles::stig::audit_local_account { -%>
 


### PR DESCRIPTION
Fixed:
  - Switch auditd rules to be 'always,exit' instead of 'exit,always' to match the
    man pages and general scanner updates.

SIMP-9602 #close