### PR TITLE
(SIMP-MAINT) Restore compliance suite's centos8 nodeset

### DIFF
--- a/spec/acceptance/suites/compliance/nodesets/centos8.yml
+++ b/spec/acceptance/suites/compliance/nodesets/centos8.yml
@@ -2,16 +2,16 @@
   vagrant_memsize = ENV['BEAKER_VAGRANT_MEMSIZE'] ? ENV['BEAKER_VAGRANT_MEMSIZE'] : 256
 -%>
 HOSTS:
-  el7:
+  el8:
     roles:
       - default
-      - el7
-    platform:   el-7-x86_64
-    box:        centos/7
+      - el8
+    platform:   el-8-x86_64
+    box:        centos/8
     hypervisor: vagrant
     yum_repos:
       chef-current:
-        baseurl: 'https://packages.chef.io/repos/yum/current/el/7/$basearch'
+        baseurl: 'https://packages.chef.io/repos/yum/current/el/8/$basearch'
         gpgkeys:
           - https://packages.chef.io/chef.asc
 

--- a/spec/spec_helper_acceptance.rb
+++ b/spec/spec_helper_acceptance.rb
@@ -20,6 +20,10 @@ RSpec.configure do |c|
   # ensure that environment OS is ready on each host
   fix_errata_on hosts
 
+  # Detect cases in which no examples are executed (e.g., nodeset does not
+  # have hosts with required roles)
+  c.fail_if_no_examples = true
+
   # Readable test descriptions
   c.formatter = :documentation
 


### PR DESCRIPTION
- Restored compliance suite's centos8 nodeset which is used in .gitlab-ci.yml
- Fail acceptance tests if no examples are run.

SIMP-9666 #comment pupmod-simp-auditd acceptance tests configured