### PR TITLE
(SIMP-MAINT) auditd: Unpin systemd in fixtures

### DIFF
--- a/.fixtures.yml
+++ b/.fixtures.yml
@@ -1,23 +1,21 @@
 ---
 fixtures:
   repositories:
-    compliance_markup: https://github.com/simp/pupmod-simp-compliance_markup
-    augeasproviders_core: https://github.com/simp/augeasproviders_core
-    augeasproviders_grub: https://github.com/simp/augeasproviders_grub
-    concat: https://github.com/simp/puppetlabs-concat
-    logrotate: https://github.com/simp/pupmod-simp-logrotate
-    pki: https://github.com/simp/pupmod-simp-pki
-    rsyslog: https://github.com/simp/pupmod-simp-rsyslog
-    simp_options: https://github.com/simp/pupmod-simp-simp_options
-    simplib: https://github.com/simp/pupmod-simp-simplib
-    stdlib: https://github.com/simp/puppetlabs-stdlib
-    systemd:
-      repo: https://github.com/simp/puppet-systemd
-      ref: "2.12.0"
+    compliance_markup: https://github.com/simp/pupmod-simp-compliance_markup.git
+    augeasproviders_core: https://github.com/simp/augeasproviders_core.git
+    augeasproviders_grub: https://github.com/simp/augeasproviders_grub.git
+    concat: https://github.com/simp/puppetlabs-concat.git
+    logrotate: https://github.com/simp/pupmod-simp-logrotate.git
+    pki: https://github.com/simp/pupmod-simp-pki.git
+    rsyslog: https://github.com/simp/pupmod-simp-rsyslog.git
+    simp_options: https://github.com/simp/pupmod-simp-simp_options.git
+    simplib: https://github.com/simp/pupmod-simp-simplib.git
+    stdlib: https://github.com/simp/puppetlabs-stdlib.git
+    systemd: https://github.com/simp/puppet-systemd.git
     disa_stig-el7-baseline:
-      repo: https://github.com/simp/inspec-profile-disa_stig-el7
+      repo: https://github.com/simp/inspec-profile-disa_stig-el7.git
       branch:  master
-      target: spec/fixtures/inspec_deps/inspec_profiles/profiles
+      target: spec/fixtures/inspec_deps/inspec_profiles/profiles.git
     augeas_core:
       repo: https://github.com/simp/pupmod-puppetlabs-augeas_core.git
       puppet_version: ">= 6.0.0"

--- a/.fixtures.yml
+++ b/.fixtures.yml
@@ -15,7 +15,7 @@ fixtures:
     disa_stig-el7-baseline:
       repo: https://github.com/simp/inspec-profile-disa_stig-el7.git
       branch:  master
-      target: spec/fixtures/inspec_deps/inspec_profiles/profiles.git
+      target: spec/fixtures/inspec_deps/inspec_profiles/profiles
     augeas_core:
       repo: https://github.com/simp/pupmod-puppetlabs-augeas_core.git
       puppet_version: ">= 6.0.0"


### PR DESCRIPTION
- Unpin systemd in fixtures to ensure testing with latest
- Make sure all fixture URLs end in '.git', as not all private
  GitHub mirrors allow shortened URL