### PR TITLE
Properly fix flapping rotated audit files

### DIFF
--- a/CHANGELOG
+++ b/CHANGELOG
@@ -1,3 +1,6 @@
+* Sat Jun 11 2022 Trevor Vaughan <trevor@sicura.us> - 8.7.5
+- Actually fix flapping on rotated audit log files
+
 * Fri Jun 03 2022 Trevor Vaughan <trevor@sicura.us> - 8.7.4
 - Ensure that permissions do not flap on rotated audit log files
 

--- a/manifests/config.pp
+++ b/manifests/config.pp
@@ -25,8 +25,8 @@ class auditd::config {
   }
 
   $log_file_mode = $auditd::log_group ? {
-    'root'  => 'u+rwX,g-rwx,o-rwx',
-    default => 'u+rwX,g+rX,g-w,o-rwx'
+    'root'  => 'u+rX,g-rwx,o-rwx',
+    default => 'u+rX,g+rX,g-w,o-rwx'
   }
 
   file { '/etc/audit':

--- a/metadata.json
+++ b/metadata.json
@@ -1,6 +1,6 @@
 {
   "name": "simp-auditd",
-  "version": "8.7.4",
+  "version": "8.7.5",
   "author": "SIMP Team",
   "summary": "A SIMP puppet module for managing auditd and audispd",
   "license": "Apache-2.0",

--- a/spec/acceptance/nodesets/default.yml
+++ b/spec/acceptance/nodesets/default.yml
@@ -4,7 +4,6 @@
   else
     hypervisor = 'vagrant'
   end
-  vagrant_memsize = ENV['BEAKER_VAGRANT_MEMSIZE'] ? ENV['BEAKER_VAGRANT_MEMSIZE'] : 256
 -%>
 HOSTS:
   el7:
@@ -25,7 +24,6 @@ HOSTS:
 CONFIG:
   log_level: verbose
   type: aio
-  vagrant_memsize: <%= vagrant_memsize %>
 <% if ENV['BEAKER_PUPPET_COLLECTION'] -%>
   puppet_collection: <%= ENV['BEAKER_PUPPET_COLLECTION'] %>
 <% end -%>

--- a/spec/acceptance/nodesets/oel.yml
+++ b/spec/acceptance/nodesets/oel.yml
@@ -4,7 +4,6 @@
   else
     hypervisor = 'vagrant'
   end
-  vagrant_memsize = ENV['BEAKER_VAGRANT_MEMSIZE'] ? ENV['BEAKER_VAGRANT_MEMSIZE'] : 256
 -%>
 HOSTS:
   oel7:
@@ -35,7 +34,6 @@ HOSTS:
 CONFIG:
   log_level: verbose
   type: aio
-  vagrant_memsize: <%= vagrant_memsize %>
 <% if ENV['BEAKER_PUPPET_COLLECTION'] -%>
   puppet_collection: <%= ENV['BEAKER_PUPPET_COLLECTION'] %>
 <% end -%>

--- a/spec/acceptance/nodesets/rhel8.yml
+++ b/spec/acceptance/nodesets/rhel8.yml
@@ -4,7 +4,6 @@
   else
     hypervisor = 'vagrant'
   end
-  vagrant_memsize = ENV['BEAKER_VAGRANT_MEMSIZE'] ? ENV['BEAKER_VAGRANT_MEMSIZE'] : 256
 -%>
 HOSTS:
   server-el8:
@@ -26,7 +25,6 @@ CONFIG:
   validate: false
   log_level: verbose
   type: aio
-  vagrant_memsize: <%= vagrant_memsize %>
 <% if ENV['BEAKER_PUPPET_COLLECTION'] -%>
   puppet_collection: <%= ENV['BEAKER_PUPPET_COLLECTION'] %>
 <% end -%>

--- a/spec/acceptance/suites/compliance/nodesets/centos8.yml
+++ b/spec/acceptance/suites/compliance/nodesets/centos8.yml
@@ -1,5 +1,4 @@
 <%
-  vagrant_memsize = ENV['BEAKER_VAGRANT_MEMSIZE'] ? ENV['BEAKER_VAGRANT_MEMSIZE'] : 256
 -%>
 HOSTS:
   el8:
@@ -18,4 +17,3 @@ HOSTS:
 CONFIG:
   log_level: verbose
   type:      aio
-  vagrant_memsize: <%= vagrant_memsize %>

--- a/spec/acceptance/suites/compliance/nodesets/default.yml
+++ b/spec/acceptance/suites/compliance/nodesets/default.yml
@@ -1,5 +1,4 @@
 <%
-  vagrant_memsize = ENV['BEAKER_VAGRANT_MEMSIZE'] ? ENV['BEAKER_VAGRANT_MEMSIZE'] : 256
 -%>
 HOSTS:
   el7:
@@ -18,4 +17,3 @@ HOSTS:
 CONFIG:
   log_level: verbose
   type:      aio
-  vagrant_memsize: <%= vagrant_memsize %>

--- a/spec/acceptance/suites/default/00_base_spec.rb
+++ b/spec/acceptance/suites/default/00_base_spec.rb
@@ -91,7 +91,7 @@ describe 'auditd class with simp audit profile' do
         end
 
         it 'should fix incorrect permissions' do
-          on(host, 'chmod 400 /var/log/audit/audit.log')
+          on(host, 'chmod 666 /var/log/audit/audit.log')
           apply_manifest_on(host, manifest, :catch_failures => true)
           result = on(host, "/bin/find /var/log/audit/audit.log -perm 0600")
           expect(result.output).to include('/var/log/audit/audit.log')

--- a/spec/classes/config_spec.rb
+++ b/spec/classes/config_spec.rb
@@ -56,7 +56,7 @@ describe 'auditd' do
               :ensure  => 'directory',
               :owner   => 'root',
               :group   => 'root',
-              :mode    => 'u+rwX,g-rwx,o-rwx',
+              :mode    => 'u+rX,g-rwx,o-rwx',
               :recurse => true
             })
           }
@@ -125,7 +125,7 @@ describe 'auditd' do
               :ensure  => 'directory',
               :owner   => 'root',
               :group   => 'rspec',
-              :mode    => 'u+rwX,g+rX,g-w,o-rwx',
+              :mode    => 'u+rX,g+rX,g-w,o-rwx',
               :recurse => true
             })
           }


### PR DESCRIPTION
The previous fix did not address the case of the rotated files changing
to mode 400 properly

Closes #155
