### PR TITLE
(SIMP-10737) make parameter $auditd::backlog_wait_time optional

### DIFF
--- a/CHANGELOG
+++ b/CHANGELOG
@@ -1,3 +1,5 @@
+* Fri Jul 29 2022 Benedikt Fischer <108938973+befischer-noris@users.noreply.github.com> - 8.8.1
+
 * Fri Jun 24 2022 Trevor Vaughan <trevor@sicura.us> - 8.8.0
 - Add support for Amazon Linux 2
 

--- a/CHANGELOG
+++ b/CHANGELOG
@@ -1,4 +1,4 @@
-* Fri Jul 29 2022 Benedikt Fischer <108938973+befischer-noris@users.noreply.github.com> - 8.9.0
+* Fri Jul 29 2022 Benedikt Fischer <benedikt.fischer@noris.de> - 8.8.0
 - Make parameter backlog_wait_time optional because there are auditd versions not supporting it
 
 * Fri Jun 24 2022 Trevor Vaughan <trevor@sicura.us> - 8.8.0

--- a/CHANGELOG
+++ b/CHANGELOG
@@ -1,4 +1,5 @@
-* Fri Jul 29 2022 Benedikt Fischer <108938973+befischer-noris@users.noreply.github.com> - 8.8.1
+* Fri Jul 29 2022 Benedikt Fischer <108938973+befischer-noris@users.noreply.github.com> - 8.9.0
+- Make parameter backlog_wait_time optional because there are auditd versions not supporting it
 
 * Fri Jun 24 2022 Trevor Vaughan <trevor@sicura.us> - 8.8.0
 - Add support for Amazon Linux 2

--- a/REFERENCE.md
+++ b/REFERENCE.md
@@ -275,7 +275,7 @@ Default value: `16384`
 
 Data type: `Integer[1,600000]`
 
-Sets the backlog_wait_time option. Some versions of auditctl don't support this parameter because it's an compile option.
+Sets the backlog_wait_time option. Some versions of auditd don't support this parameter because it's an compile option.
 
 Default value: ``undef``
 

--- a/REFERENCE.md
+++ b/REFERENCE.md
@@ -82,7 +82,6 @@ The following parameters are available in the `auditd` class:
 * [`at_boot`](#at_boot)
 * [`buffer_size`](#buffer_size)
 * [`backlog_wait_time`](#backlog_wait_time)
-* [`backlog_wait_time_enable`](#backlog_wait_time_enable)
 * [`disk_error_action`](#disk_error_action)
 * [`disk_full_action`](#disk_full_action)
 * [`disp_qos`](#disp_qos)
@@ -276,17 +275,9 @@ Default value: `16384`
 
 Data type: `Integer[1,600000]`
 
+Sets the backlog_wait_time option. Some versions of auditctl don't support this parameter because it's an compile option.
 
-
-Default value: `60000`
-
-##### <a name="backlog_wait_time_enable"></a>`backlog_wait_time_enable`
-
-Data type: `Boolean`
-
-Disable the [`backlog_wait_time`](#backlog_wait_time) parameter completly. You will need to set this to true if you want to use older audit versions on RHEL <= 7.
-
-Default value: ``false``
+Default value: ``undef``
 
 ##### <a name="disk_error_action"></a>`disk_error_action`
 

--- a/REFERENCE.md
+++ b/REFERENCE.md
@@ -82,6 +82,7 @@ The following parameters are available in the `auditd` class:
 * [`at_boot`](#at_boot)
 * [`buffer_size`](#buffer_size)
 * [`backlog_wait_time`](#backlog_wait_time)
+* [`backlog_wait_time_enable`](#backlog_wait_time_enable)
 * [`disk_error_action`](#disk_error_action)
 * [`disk_full_action`](#disk_full_action)
 * [`disp_qos`](#disp_qos)
@@ -278,6 +279,14 @@ Data type: `Integer[1,600000]`
 
 
 Default value: `60000`
+
+##### <a name="backlog_wait_time_enable"></a>`backlog_wait_time_enable`
+
+Data type: `Boolean`
+
+Disable the [`backlog_wait_time`](#backlog_wait_time) parameter completly. You will need to set this to true if you want to use older audit versions on RHEL <= 7.
+
+Default value: ``false``
 
 ##### <a name="disk_error_action"></a>`disk_error_action`
 

--- a/manifests/init.pp
+++ b/manifests/init.pp
@@ -71,6 +71,8 @@
 #   Value of the `auditctl` '-b' option
 #
 # @param backlog_wait_time
+# @param backlog_wait_time_enable
+#   If false, don't set backlog_wait_time
 #
 # @param disk_error_action
 # @param disk_full_action
@@ -224,6 +226,7 @@ class auditd (
   Boolean                                 $at_boot                  = true,
   Integer[0]                              $buffer_size              = 16384,
   Integer[1,600000]                       $backlog_wait_time        = 60000,
+  Boolean                                 $backlog_wait_time_enable = true,
   Auditd::DiskErrorAction                 $disk_error_action        = 'syslog',
   Auditd::DiskFullAction                  $disk_full_action         = 'rotate',
   Enum['lossy','lossless']                $disp_qos                 = 'lossy',

--- a/manifests/init.pp
+++ b/manifests/init.pp
@@ -71,8 +71,6 @@
 #   Value of the `auditctl` '-b' option
 #
 # @param backlog_wait_time
-# @param backlog_wait_time_enable
-#   If false, don't set backlog_wait_time
 #
 # @param disk_error_action
 # @param disk_full_action
@@ -225,8 +223,7 @@ class auditd (
   Auditd::SpaceLeftAction                 $admin_space_left_action  = 'rotate',
   Boolean                                 $at_boot                  = true,
   Integer[0]                              $buffer_size              = 16384,
-  Integer[1,600000]                       $backlog_wait_time        = 60000,
-  Boolean                                 $backlog_wait_time_enable = true,
+  Optional[Integer[1,600000]]             $backlog_wait_time        = undef,
   Auditd::DiskErrorAction                 $disk_error_action        = 'syslog',
   Auditd::DiskFullAction                  $disk_full_action         = 'rotate',
   Enum['lossy','lossless']                $disp_qos                 = 'lossy',

--- a/metadata.json
+++ b/metadata.json
@@ -1,6 +1,6 @@
 {
   "name": "simp-auditd",
-  "version": "8.8.1",
+  "version": "8.9.0",
   "author": "SIMP Team",
   "summary": "A SIMP puppet module for managing auditd and audispd",
   "license": "Apache-2.0",

--- a/metadata.json
+++ b/metadata.json
@@ -1,6 +1,6 @@
 {
   "name": "simp-auditd",
-  "version": "8.8.0",
+  "version": "8.8.1",
   "author": "SIMP Team",
   "summary": "A SIMP puppet module for managing auditd and audispd",
   "license": "Apache-2.0",

--- a/metadata.json
+++ b/metadata.json
@@ -1,6 +1,6 @@
 {
   "name": "simp-auditd",
-  "version": "8.9.0",
+  "version": "8.8.0",
   "author": "SIMP Team",
   "summary": "A SIMP puppet module for managing auditd and audispd",
   "license": "Apache-2.0",

--- a/templates/rule_profiles/common/head.epp
+++ b/templates/rule_profiles/common/head.epp
@@ -26,6 +26,7 @@
 ## Feel free to increase this if the machine panic's
 # Default: 8192
 -b <%= $auditd::config::audit_profiles::_buffer_size %>
+<% if $auditd::backlog_wait_time { -%>
 
 ## The time to wait when the backlog limit is reached before queueing more
 ## audit events. Smaller numbers are more aggressive but may cause excessive
@@ -33,6 +34,7 @@
 # Default: 60000
 --backlog_wait_time <%= $auditd::backlog_wait_time %>
 
+<% } -%>
 ## Set failure mode
 # Default: 2
 -f <%= $auditd::failure_mode %>

--- a/templates/rule_profiles/common/head.epp
+++ b/templates/rule_profiles/common/head.epp
@@ -27,11 +27,13 @@
 # Default: 8192
 -b <%= $auditd::config::audit_profiles::_buffer_size %>
 
+<% if $auditd::backlog_wait_time_enable { -%>
 ## The time to wait when the backlog limit is reached before queueing more
 ## audit events. Smaller numbers are more aggressive but may cause excessive
 ## system load.
 # Default: 60000
 --backlog_wait_time <%= $auditd::backlog_wait_time %>
+<% } -%>
 
 ## Set failure mode
 # Default: 2

--- a/templates/rule_profiles/common/head.epp
+++ b/templates/rule_profiles/common/head.epp
@@ -27,13 +27,11 @@
 # Default: 8192
 -b <%= $auditd::config::audit_profiles::_buffer_size %>
 
-<% if $auditd::backlog_wait_time_enable { -%>
 ## The time to wait when the backlog limit is reached before queueing more
 ## audit events. Smaller numbers are more aggressive but may cause excessive
 ## system load.
 # Default: 60000
 --backlog_wait_time <%= $auditd::backlog_wait_time %>
-<% } -%>
 
 ## Set failure mode
 # Default: 2


### PR DESCRIPTION
This patch makes parameter `$auditd::backlog_wait_time` optional by adding 
a new parameter, `$auditd::backlog_wait_time_enable`.

See [SIMP-10737](https://simp-project.atlassian.net/browse/SIMP-10737) for more details.

SIMP-10737 #close