### PR TITLE
replace dep on herculesteam/augeasproviders_grub

### DIFF
--- a/metadata.json
+++ b/metadata.json
@@ -22,8 +22,8 @@
       "version_requirement": ">= 4.4.0 < 5.0.0"
     },
     {
-      "name": "herculesteam/augeasproviders_grub",
-      "version_requirement": ">= 2.4.0 < 4.0.0"
+      "name": "puppet/augeasproviders_grub",
+      "version_requirement": ">= 2.4.0 < 6.0.0"
     }
   ],
   "simp": {


### PR DESCRIPTION
with puppet/augeasproviders_grub as the module was transfered to voxpupuli. Additionally, allow the 4.x release.