### PR TITLE
add support for systems thats do not use grub

### DIFF
--- a/CHANGELOG
+++ b/CHANGELOG
@@ -1,3 +1,7 @@
+* Tue Nov 15 2022 Joshua Hoblitt <josh@hoblitt.com> - 8.9.0
+- do not include auditd::config::grub on hosts without grub
+- fix simp base profile to work when grub_version fact is not set
+
 * Fri Jul 29 2022 Benedikt Fischer <benedikt.fischer@noris.de> - 8.8.0
 - Make parameter backlog_wait_time optional because there are auditd versions not supporting it
 

--- a/manifests/init.pp
+++ b/manifests/init.pp
@@ -321,7 +321,9 @@ class auditd (
     ~> Class['auditd::service']
     -> Class['auditd']
 
-    Class['auditd::install'] -> Class['::auditd::config::grub']
+    if fact('grub_version') {
+      Class['auditd::install'] -> Class['::auditd::config::grub']
+    }
 
   }
   else {
@@ -332,5 +334,7 @@ class auditd (
   # auditd::config::grub with an include somewhere else. auditd::config::grub
   # would normally be a private class but may be used independently if
   # necessary.
-  class { 'auditd::config::grub': enable => $_grub_enable }
+  if fact('grub_version') {
+    class { 'auditd::config::grub': enable => $_grub_enable }
+  }
 }

--- a/metadata.json
+++ b/metadata.json
@@ -1,6 +1,6 @@
 {
   "name": "simp-auditd",
-  "version": "8.8.0",
+  "version": "8.9.0",
   "author": "SIMP Team",
   "summary": "A SIMP puppet module for managing auditd and audispd",
   "license": "Apache-2.0",

--- a/spec/classes/config/audit_profiles/simp_spec.rb
+++ b/spec/classes/config/audit_profiles/simp_spec.rb
@@ -66,6 +66,19 @@ describe 'auditd' do
             %r(^-a always,exit -F path=/(usr/)?sbin/setfiles -F perm=x -k privileged-priv_change)
           )
         end
+
+        context 'on a host without grub' do
+          let(:facts) { super().merge(grub_version: nil) }
+
+          it 'disables auditing of grub' do
+            is_expected.not_to contain_file('/etc/audit/rules.d/50_00_simp_base.rules').with_content(
+              %r{^-w /boot/grub/grub.conf}
+            )
+            is_expected.not_to contain_file('/etc/audit/rules.d/50_00_simp_base.rules').with_content(
+              %r{^-w /etc/grub.d}
+            )
+          end
+        end
       end
 
       context 'with root audit level set to aggressive' do

--- a/spec/classes/init_spec.rb
+++ b/spec/classes/init_spec.rb
@@ -45,6 +45,14 @@ describe 'auditd' do
           it { is_expected.to contain_class('auditd::install').that_comes_before('Class[auditd::config::grub]') }
           it { is_expected.to contain_class('auditd::config::grub').with_enable(true) }
           it { is_expected.to_not contain_class('auditd::config::logging') }
+
+          context 'on a host without grub' do
+            let(:facts) { super().merge(grub_version: nil) }
+
+            it { is_expected.to contain_class('auditd::install') }
+            it { is_expected.not_to contain_class('auditd::install').that_comes_before('Class[auditd::config::grub]') }
+            it { is_expected.not_to contain_class('auditd::config::grub') }
+          end
         end
 
         context 'auditd with space_left < admin_space_left' do

--- a/templates/rule_profiles/simp/base.epp
+++ b/templates/rule_profiles/simp/base.epp
@@ -365,10 +365,12 @@
 
 ## Generally good things to audit.
 <% if $auditd::config::audit_profiles::simp::_audit_cfg_grub  { -%>
-<%   if versioncmp($facts['grub_version'], '2') < 0  { -%>
+<%   if $facts['grub_version'] { -%>
+<%     if versioncmp($facts['grub_version'], '2') < 0  { -%>
 -w /boot/grub/grub.conf -p wa -k <%= $auditd::config::audit_profiles::simp::_audit_cfg_grub_tag %>
-<%   } else { -%>
+<%     } else { -%>
 -w /etc/grub.d -p wa -k <%= $auditd::config::audit_profiles::simp::_audit_cfg_grub_tag %>
+<%     } -%>
 <%   } -%>
 <% } -%>
 <% if $auditd::config::audit_profiles::simp::audit_cfg_sys  { -%>


### PR DESCRIPTION
I have a number of raspberry pi 4's that are running EL7 which do not use grub.

```bash
# cat /etc/redhat-release 
CentOS Linux release 7.9.2009 (AltArch)
```

This PR fixes an epp template error and this error from attempting to modify the kernel cmdline via grub.

```
Notice: /Stage[main]/Auditd::Config::Grub/Reboot_notify[audit]: Dependency Kernel_parameter[audit] has failures: true
Warning: /Stage[main]/Auditd::Config::Grub/Reboot_notify[audit]: Skipping because of failed dependencies
Error: Could not find a suitable provider for kernel_parameter
Error: post_resource_eval failed for provider Puppet::Type::Reboot_notify::ProviderNotify
```
