### PR TITLE
Fix spec test mock

### DIFF
--- a/spec/classes/config/audit_profiles/custom_spec.rb
+++ b/spec/classes/config/audit_profiles/custom_spec.rb
@@ -9,7 +9,10 @@ describe 'auditd::config::audit_profiles::custom' do
         <<-EOM
           function assert_private() { }
 
-          class auditd::config ( $profiles = ['custom'] ){}
+          class auditd::config (
+            $profiles = ['custom'],
+            $config_file_mode = '0600'
+          ){}
           include auditd::config
         EOM
       }
@@ -93,7 +96,8 @@ describe 'auditd::config::audit_profiles::custom' do
             function assert_private() { }
 
             class auditd::config (
-              $profiles = ['simp', 'custom', 'stig']
+              $profiles = ['simp', 'custom', 'stig'],
+              $config_file_mode = '0600'
             ){}
             include auditd::config
           EOM


### PR DESCRIPTION
This should fix the `Unknown variable: 'auditd::config::config_file_mode'` errors during the `auditd::config::audit_profiles::custom` test