### PR TITLE
Finalize RockyLinux 8 support

### DIFF
--- a/.github/workflows/pr_tests.yml
+++ b/.github/workflows/pr_tests.yml
@@ -117,6 +117,7 @@ jobs:
             puppet_version: '~> 8.0'
             ruby_version: 3.1
             experimental: true
+      fail-fast: false
     env:
       PUPPET_VERSION: ${{matrix.puppet.puppet_version}}
     steps:

--- a/.gitignore
+++ b/.gitignore
@@ -24,3 +24,4 @@ dist
 /junit
 /log
 /doc
+/Gemfile.lock

--- a/.gitlab-ci.yml
+++ b/.gitlab-ci.yml
@@ -340,6 +340,7 @@ pup7.pe-unit:
   <<: *pup_7_pe
   <<: *unit_tests
 
+# Commenting until Puppet 8 is released
 #pup8.x-unit:
 #  <<: *pup_8_x
 #  <<: *unit_tests

--- a/REFERENCE.md
+++ b/REFERENCE.md
@@ -7,51 +7,51 @@
 ### Classes
 
 * [`auditd`](#auditd): Configure the audit daemon for use with a specified audit profile.
-* [`auditd::config`](#auditdconfig): This class is called from auditd for service config.
-* [`auditd::config::audisp`](#auditdconfigaudisp): Configures the audit dispatcher primarily for sending audit logs directly to syslog without intervention.
-* [`auditd::config::audisp::syslog`](#auditdconfigaudispsyslog): Utilizes rsyslog to send all audit records to syslog.
-* [`auditd::config::audisp_service`](#auditdconfigaudisp_service): Notify auditd to restart to ensure the process for audisp
+* [`auditd::config`](#auditd--config): This class is called from auditd for service config.
+* [`auditd::config::audisp`](#auditd--config--audisp): Configures the audit dispatcher primarily for sending audit logs directly to syslog without intervention.
+* [`auditd::config::audisp::syslog`](#auditd--config--audisp--syslog): Utilizes rsyslog to send all audit records to syslog.
+* [`auditd::config::audisp_service`](#auditd--config--audisp_service): Notify auditd to restart to ensure the process for audisp
 is running.
-* [`auditd::config::audit_profiles`](#auditdconfigaudit_profiles): Provides global audit rule configuration and a base set of audit rules based on the built-in audit profile(s).
-* [`auditd::config::audit_profiles::built_in`](#auditdconfigaudit_profilesbuilt_in): An audit profile that allows the use of sample rulesets included with the
+* [`auditd::config::audit_profiles`](#auditd--config--audit_profiles): Provides global audit rule configuration and a base set of audit rules based on the built-in audit profile(s).
+* [`auditd::config::audit_profiles::built_in`](#auditd--config--audit_profiles--built_in): An audit profile that allows the use of sample rulesets included with the
 audit package to be used to configure a system.
-* [`auditd::config::audit_profiles::custom`](#auditdconfigaudit_profilescustom): A set of user specified rules in a form that is easy to manipulate via Hiera
-* [`auditd::config::audit_profiles::simp`](#auditdconfigaudit_profilessimp): A set of general purpose audit rules that should meet most security policy requirements
-* [`auditd::config::audit_profiles::stig`](#auditdconfigaudit_profilesstig): A set of audit rules that are configured to satisfy DISA STIG compliance checks for EL7.
-* [`auditd::config::grub`](#auditdconfiggrub): Enables/disables auditing at boot time.
-* [`auditd::config::logging`](#auditdconfiglogging): Ensures that plugin for syslog is installed so audit events
+* [`auditd::config::audit_profiles::custom`](#auditd--config--audit_profiles--custom): A set of user specified rules in a form that is easy to manipulate via Hiera
+* [`auditd::config::audit_profiles::simp`](#auditd--config--audit_profiles--simp): A set of general purpose audit rules that should meet most security policy requirements
+* [`auditd::config::audit_profiles::stig`](#auditd--config--audit_profiles--stig): A set of audit rules that are configured to satisfy DISA STIG compliance checks for EL7.
+* [`auditd::config::grub`](#auditd--config--grub): Enables/disables auditing at boot time.
+* [`auditd::config::logging`](#auditd--config--logging): Ensures that plugin for syslog is installed so audit events
 can be sent to syslog in addition the audit partition.
-* [`auditd::install`](#auditdinstall): Install the auditd packages
-* [`auditd::service`](#auditdservice): Ensure that the auditd service is running
+* [`auditd::install`](#auditd--install): Install the auditd packages
+* [`auditd::service`](#auditd--service): Ensure that the auditd service is running
 
 ### Defined types
 
-* [`auditd::rule`](#auditdrule): Add rules to the audit daemon.
+* [`auditd::rule`](#auditd--rule): Add rules to the audit daemon.
 
 ### Functions
 
-* [`auditd::calculate_space_left`](#auditdcalculate_space_left): Calculates the correct default value for 'space_left' based on the value of 'admin_space_left'.
-* [`auditd::get_array_index`](#auditdget_array_index): Returns a string that represents the first index of the specified element within the Array.
-* [`auditd::validate_init_params`](#auditdvalidate_init_params): Validates selected params from the main auditd class.
+* [`auditd::calculate_space_left`](#auditd--calculate_space_left): Calculates the correct default value for 'space_left' based on the value of 'admin_space_left'.
+* [`auditd::get_array_index`](#auditd--get_array_index): Returns a string that represents the first index of the specified element within the Array.
+* [`auditd::validate_init_params`](#auditd--validate_init_params): Validates selected params from the main auditd class.
 
 ### Data types
 
-* [`Auditd::AuditProfile`](#auditdauditprofile): Matches the types of auditd profiles allowed
-* [`Auditd::DiskErrorAction`](#auditddiskerroraction): Matches disk error actions in auditd.conf
-* [`Auditd::DiskFullAction`](#auditddiskfullaction): Matches actions to take when disk is full (see auditd.conf)
-* [`Auditd::Flush`](#auditdflush): Matches actions flush in auditd.conf
-* [`Auditd::LogFacility`](#auditdlogfacility): Matches log facility that can be used in syslog.conf plugin
-* [`Auditd::LogFormat`](#auditdlogformat): Matches log formats that can be used in auditd.conf
-* [`Auditd::LogPriority`](#auditdlogpriority): Matches log priorities that can be used in syslog.conf plugin
-* [`Auditd::MaxLogFileAction`](#auditdmaxlogfileaction): Matches available matches for maxlogfileaction in auditd.conf
-* [`Auditd::NameFormat`](#auditdnameformat): Matche s available name formats in audotd.conf
-* [`Auditd::OverflowAction`](#auditdoverflowaction): Matches overflow_action settings in auditd.conf or audisp.conf
-* [`Auditd::RootAuditLevel`](#auditdrootauditlevel): Matches root audit level settings in auditd.conf
-* [`Auditd::SpaceLeftAction`](#auditdspaceleftaction): Matches spaceleftaction for auditd.conf
+* [`Auditd::AuditProfile`](#Auditd--AuditProfile): Matches the types of auditd profiles allowed
+* [`Auditd::DiskErrorAction`](#Auditd--DiskErrorAction): Matches disk error actions in auditd.conf
+* [`Auditd::DiskFullAction`](#Auditd--DiskFullAction): Matches actions to take when disk is full (see auditd.conf)
+* [`Auditd::Flush`](#Auditd--Flush): Matches actions flush in auditd.conf
+* [`Auditd::LogFacility`](#Auditd--LogFacility): Matches log facility that can be used in syslog.conf plugin
+* [`Auditd::LogFormat`](#Auditd--LogFormat): Matches log formats that can be used in auditd.conf
+* [`Auditd::LogPriority`](#Auditd--LogPriority): Matches log priorities that can be used in syslog.conf plugin
+* [`Auditd::MaxLogFileAction`](#Auditd--MaxLogFileAction): Matches available matches for maxlogfileaction in auditd.conf
+* [`Auditd::NameFormat`](#Auditd--NameFormat): Matche s available name formats in audotd.conf
+* [`Auditd::OverflowAction`](#Auditd--OverflowAction): Matches overflow_action settings in auditd.conf or audisp.conf
+* [`Auditd::RootAuditLevel`](#Auditd--RootAuditLevel): Matches root audit level settings in auditd.conf
+* [`Auditd::SpaceLeftAction`](#Auditd--SpaceLeftAction): Matches spaceleftaction for auditd.conf
 
 ## Classes
 
-### <a name="auditd"></a> `auditd`
+### <a name="auditd"></a>`auditd`
 
 Any variable that is not described here can be found in auditd.conf(5) and
 auditctl(8).
@@ -64,76 +64,76 @@ auditctl(8).
 
 The following parameters are available in the `auditd` class:
 
-* [`enable`](#enable)
-* [`default_audit_profile`](#default_audit_profile)
-* [`default_audit_profiles`](#default_audit_profiles)
-* [`audit_auditd_config`](#audit_auditd_config)
-* [`lname`](#lname)
-* [`ignore_anonymous`](#ignore_anonymous)
-* [`ignore_crond`](#ignore_crond)
-* [`ignore_time_daemons`](#ignore_time_daemons)
-* [`ignore_crypto_key_user`](#ignore_crypto_key_user)
-* [`ignore_errors`](#ignore_errors)
-* [`ignore_failures`](#ignore_failures)
-* [`ignore_system_services`](#ignore_system_services)
-* [`action_mail_acct`](#action_mail_acct)
-* [`admin_space_left`](#admin_space_left)
-* [`admin_space_left_action`](#admin_space_left_action)
-* [`at_boot`](#at_boot)
-* [`buffer_size`](#buffer_size)
-* [`backlog_wait_time`](#backlog_wait_time)
-* [`disk_error_action`](#disk_error_action)
-* [`disk_full_action`](#disk_full_action)
-* [`disp_qos`](#disp_qos)
-* [`dispatcher`](#dispatcher)
-* [`failure_mode`](#failure_mode)
-* [`flush`](#flush)
-* [`freq`](#freq)
-* [`immutable`](#immutable)
-* [`log_file`](#log_file)
-* [`local_events`](#local_events)
-* [`log_format`](#log_format)
-* [`log_group`](#log_group)
-* [`loginuid_immutable`](#loginuid_immutable)
-* [`max_log_file`](#max_log_file)
-* [`max_log_file_action`](#max_log_file_action)
-* [`max_restarts`](#max_restarts)
-* [`name_format`](#name_format)
-* [`num_logs`](#num_logs)
-* [`overflow_action`](#overflow_action)
-* [`package_name`](#package_name)
-* [`package_ensure`](#package_ensure)
-* [`plugin_dir`](#plugin_dir)
-* [`priority_boost`](#priority_boost)
-* [`q_depth`](#q_depth)
-* [`rate`](#rate)
-* [`root_audit_level`](#root_audit_level)
-* [`service_name`](#service_name)
-* [`space_left`](#space_left)
-* [`space_left_action`](#space_left_action)
-* [`syslog`](#syslog)
-* [`target_selinux_types`](#target_selinux_types)
-* [`uid_min`](#uid_min)
-* [`verify_email`](#verify_email)
-* [`write_logs`](#write_logs)
+* [`enable`](#-auditd--enable)
+* [`default_audit_profile`](#-auditd--default_audit_profile)
+* [`default_audit_profiles`](#-auditd--default_audit_profiles)
+* [`audit_auditd_config`](#-auditd--audit_auditd_config)
+* [`lname`](#-auditd--lname)
+* [`ignore_anonymous`](#-auditd--ignore_anonymous)
+* [`ignore_crond`](#-auditd--ignore_crond)
+* [`ignore_time_daemons`](#-auditd--ignore_time_daemons)
+* [`ignore_crypto_key_user`](#-auditd--ignore_crypto_key_user)
+* [`ignore_errors`](#-auditd--ignore_errors)
+* [`ignore_failures`](#-auditd--ignore_failures)
+* [`ignore_system_services`](#-auditd--ignore_system_services)
+* [`action_mail_acct`](#-auditd--action_mail_acct)
+* [`admin_space_left`](#-auditd--admin_space_left)
+* [`admin_space_left_action`](#-auditd--admin_space_left_action)
+* [`at_boot`](#-auditd--at_boot)
+* [`buffer_size`](#-auditd--buffer_size)
+* [`backlog_wait_time`](#-auditd--backlog_wait_time)
+* [`disk_error_action`](#-auditd--disk_error_action)
+* [`disk_full_action`](#-auditd--disk_full_action)
+* [`disp_qos`](#-auditd--disp_qos)
+* [`dispatcher`](#-auditd--dispatcher)
+* [`failure_mode`](#-auditd--failure_mode)
+* [`flush`](#-auditd--flush)
+* [`freq`](#-auditd--freq)
+* [`immutable`](#-auditd--immutable)
+* [`log_file`](#-auditd--log_file)
+* [`local_events`](#-auditd--local_events)
+* [`log_format`](#-auditd--log_format)
+* [`log_group`](#-auditd--log_group)
+* [`loginuid_immutable`](#-auditd--loginuid_immutable)
+* [`max_log_file`](#-auditd--max_log_file)
+* [`max_log_file_action`](#-auditd--max_log_file_action)
+* [`max_restarts`](#-auditd--max_restarts)
+* [`name_format`](#-auditd--name_format)
+* [`num_logs`](#-auditd--num_logs)
+* [`overflow_action`](#-auditd--overflow_action)
+* [`package_name`](#-auditd--package_name)
+* [`package_ensure`](#-auditd--package_ensure)
+* [`plugin_dir`](#-auditd--plugin_dir)
+* [`priority_boost`](#-auditd--priority_boost)
+* [`q_depth`](#-auditd--q_depth)
+* [`rate`](#-auditd--rate)
+* [`root_audit_level`](#-auditd--root_audit_level)
+* [`service_name`](#-auditd--service_name)
+* [`space_left`](#-auditd--space_left)
+* [`space_left_action`](#-auditd--space_left_action)
+* [`syslog`](#-auditd--syslog)
+* [`target_selinux_types`](#-auditd--target_selinux_types)
+* [`uid_min`](#-auditd--uid_min)
+* [`verify_email`](#-auditd--verify_email)
+* [`write_logs`](#-auditd--write_logs)
 
-##### <a name="enable"></a>`enable`
+##### <a name="-auditd--enable"></a>`enable`
 
 Data type: `Boolean`
 
 If true, enable auditing.
 
-Default value: ``true``
+Default value: `true`
 
-##### <a name="default_audit_profile"></a>`default_audit_profile`
+##### <a name="-auditd--default_audit_profile"></a>`default_audit_profile`
 
 Data type: `Optional[Variant[Enum['simp'],Boolean]]`
 
 Deprecated by `$default_audit_profiles`
 
-Default value: ``undef``
+Default value: `undef`
 
-##### <a name="default_audit_profiles"></a>`default_audit_profiles`
+##### <a name="-auditd--default_audit_profiles"></a>`default_audit_profiles`
 
 Data type: `Array[Auditd::AuditProfile]`
 
@@ -149,24 +149,24 @@ of audit rules.
 
 Default value: `[ 'simp' ]`
 
-##### <a name="audit_auditd_config"></a>`audit_auditd_config`
+##### <a name="-auditd--audit_auditd_config"></a>`audit_auditd_config`
 
 Data type: `Boolean`
 
 Set up an audit rule to audit the `auditd` configuration files.
 
-Default value: ``true``
+Default value: `true`
 
-##### <a name="lname"></a>`lname`
+##### <a name="-auditd--lname"></a>`lname`
 
 Data type: `String`
 
 An alias for the ``name`` variable in the configuration file. This is used
 since ``$name`` is a reserved keyword in Puppet.
 
-Default value: `$facts['fqdn']`
+Default value: `$facts['networking']['fqdn']`
 
-##### <a name="ignore_anonymous"></a>`ignore_anonymous`
+##### <a name="-auditd--ignore_anonymous"></a>`ignore_anonymous`
 
 Data type: `Boolean`
 
@@ -174,51 +174,51 @@ For built-in audit profiles, whether to drop anonymous and daemon
 events, i.e., events for which ``auid`` is '-1' (aka 'unset').
 Audit records from these events are prolific but not useful.
 
-Default value: ``true``
+Default value: `true`
 
-##### <a name="ignore_crond"></a>`ignore_crond`
+##### <a name="-auditd--ignore_crond"></a>`ignore_crond`
 
 Data type: `Boolean`
 
 For built-in audit profiles, whether to drop events related to cron
 jobs. `cron` creates a lot of audit events that are not usually useful.
 
-Default value: ``true``
+Default value: `true`
 
-##### <a name="ignore_time_daemons"></a>`ignore_time_daemons`
+##### <a name="-auditd--ignore_time_daemons"></a>`ignore_time_daemons`
 
 Data type: `Boolean`
 
 Ignore time modifications by time daemons that are running on the system
 since this is valid activity.
 
-Default value: ``true``
+Default value: `true`
 
-##### <a name="ignore_crypto_key_user"></a>`ignore_crypto_key_user`
+##### <a name="-auditd--ignore_crypto_key_user"></a>`ignore_crypto_key_user`
 
 Data type: `Boolean`
 
 Ignore CRYPTO_KEY_USER logs since these are generally noise.
 
-Default value: ``true``
+Default value: `true`
 
-##### <a name="ignore_errors"></a>`ignore_errors`
+##### <a name="-auditd--ignore_errors"></a>`ignore_errors`
 
 Data type: `Boolean`
 
 Whether to set the `auditctl` '-i' option
 
-Default value: ``true``
+Default value: `true`
 
-##### <a name="ignore_failures"></a>`ignore_failures`
+##### <a name="-auditd--ignore_failures"></a>`ignore_failures`
 
 Data type: `Boolean`
 
 Whether to set the `auditctl` '-c' option
 
-Default value: ``true``
+Default value: `true`
 
-##### <a name="ignore_system_services"></a>`ignore_system_services`
+##### <a name="-auditd--ignore_system_services"></a>`ignore_system_services`
 
 Data type: `Boolean`
 
@@ -229,9 +229,9 @@ this filter is attached to every system call rule.  So, by implementing
 the filter in an upfront drop rule, this feature provides optimization
 of that filtering.
 
-Default value: ``true``
+Default value: `true`
 
-##### <a name="action_mail_acct"></a>`action_mail_acct`
+##### <a name="-auditd--action_mail_acct"></a>`action_mail_acct`
 
 Data type: `String[1]`
 
@@ -239,7 +239,7 @@ Data type: `String[1]`
 
 Default value: `'root'`
 
-##### <a name="admin_space_left"></a>`admin_space_left`
+##### <a name="-auditd--admin_space_left"></a>`admin_space_left`
 
 Data type: `Variant[Integer[0],Pattern['^\d+%$']]`
 
@@ -247,7 +247,7 @@ Data type: `Variant[Integer[0],Pattern['^\d+%$']]`
 
 Default value: `50`
 
-##### <a name="admin_space_left_action"></a>`admin_space_left_action`
+##### <a name="-auditd--admin_space_left_action"></a>`admin_space_left_action`
 
 Data type: `Auditd::SpaceLeftAction`
 
@@ -255,15 +255,15 @@ Data type: `Auditd::SpaceLeftAction`
 
 Default value: `'rotate'`
 
-##### <a name="at_boot"></a>`at_boot`
+##### <a name="-auditd--at_boot"></a>`at_boot`
 
 Data type: `Boolean`
 
 If true, modify the Grub settings to enable auditing at boot time.
 
-Default value: ``true``
+Default value: `true`
 
-##### <a name="buffer_size"></a>`buffer_size`
+##### <a name="-auditd--buffer_size"></a>`buffer_size`
 
 Data type: `Integer[0]`
 
@@ -271,15 +271,15 @@ Value of the `auditctl` '-b' option
 
 Default value: `16384`
 
-##### <a name="backlog_wait_time"></a>`backlog_wait_time`
+##### <a name="-auditd--backlog_wait_time"></a>`backlog_wait_time`
 
-Data type: `Integer[1,600000]`
+Data type: `Optional[Integer[1,600000]]`
 
-Sets the backlog_wait_time option. Some versions of auditd don't support this parameter because it's an compile option.
 
-Default value: ``undef``
 
-##### <a name="disk_error_action"></a>`disk_error_action`
+Default value: `undef`
+
+##### <a name="-auditd--disk_error_action"></a>`disk_error_action`
 
 Data type: `Auditd::DiskErrorAction`
 
@@ -287,7 +287,7 @@ Data type: `Auditd::DiskErrorAction`
 
 Default value: `'syslog'`
 
-##### <a name="disk_full_action"></a>`disk_full_action`
+##### <a name="-auditd--disk_full_action"></a>`disk_full_action`
 
 Data type: `Auditd::DiskFullAction`
 
@@ -295,7 +295,7 @@ Data type: `Auditd::DiskFullAction`
 
 Default value: `'rotate'`
 
-##### <a name="disp_qos"></a>`disp_qos`
+##### <a name="-auditd--disp_qos"></a>`disp_qos`
 
 Data type: `Enum['lossy','lossless']`
 
@@ -303,7 +303,7 @@ Data type: `Enum['lossy','lossless']`
 
 Default value: `'lossy'`
 
-##### <a name="dispatcher"></a>`dispatcher`
+##### <a name="-auditd--dispatcher"></a>`dispatcher`
 
 Data type: `Stdlib::Absolutepath`
 
@@ -311,7 +311,7 @@ Data type: `Stdlib::Absolutepath`
 
 Default value: `'/sbin/audispd'`
 
-##### <a name="failure_mode"></a>`failure_mode`
+##### <a name="-auditd--failure_mode"></a>`failure_mode`
 
 Data type: `Integer[0]`
 
@@ -319,7 +319,7 @@ Value of the `auditctl` '-f' option
 
 Default value: `1`
 
-##### <a name="flush"></a>`flush`
+##### <a name="-auditd--flush"></a>`flush`
 
 Data type: `Auditd::Flush`
 
@@ -327,7 +327,7 @@ Data type: `Auditd::Flush`
 
 Default value: `'incremental'`
 
-##### <a name="freq"></a>`freq`
+##### <a name="-auditd--freq"></a>`freq`
 
 Data type: `Integer[0]`
 
@@ -335,7 +335,7 @@ Data type: `Integer[0]`
 
 Default value: `20`
 
-##### <a name="immutable"></a>`immutable`
+##### <a name="-auditd--immutable"></a>`immutable`
 
 Data type: `Boolean`
 
@@ -344,9 +344,9 @@ audit profiles.  Be aware that, should you choose to make the
 configuration immutable, you will not be able to change your audit
 rules without a reboot.
 
-Default value: ``false``
+Default value: `false`
 
-##### <a name="log_file"></a>`log_file`
+##### <a name="-auditd--log_file"></a>`log_file`
 
 Data type: `Stdlib::Absolutepath`
 
@@ -354,15 +354,15 @@ Data type: `Stdlib::Absolutepath`
 
 Default value: `'/var/log/audit/audit.log'`
 
-##### <a name="local_events"></a>`local_events`
+##### <a name="-auditd--local_events"></a>`local_events`
 
 Data type: `Optional[Boolean]`
 
 `auditd` version 3 only
 
-Default value: ``undef``
+Default value: `undef`
 
-##### <a name="log_format"></a>`log_format`
+##### <a name="-auditd--log_format"></a>`log_format`
 
 Data type: `Auditd::LogFormat`
 
@@ -373,7 +373,7 @@ The output log format
 
 Default value: `'raw'`
 
-##### <a name="log_group"></a>`log_group`
+##### <a name="-auditd--log_group"></a>`log_group`
 
 Data type: `String`
 
@@ -381,7 +381,7 @@ Data type: `String`
 
 Default value: `'root'`
 
-##### <a name="loginuid_immutable"></a>`loginuid_immutable`
+##### <a name="-auditd--loginuid_immutable"></a>`loginuid_immutable`
 
 Data type: `Boolean`
 
@@ -391,9 +391,9 @@ Sets the --loginuid-immutable option
   containers but a concrete explanation of what types has not yet been
   found.
 
-Default value: ``true``
+Default value: `true`
 
-##### <a name="max_log_file"></a>`max_log_file`
+##### <a name="-auditd--max_log_file"></a>`max_log_file`
 
 Data type: `Integer[0]`
 
@@ -401,7 +401,7 @@ Data type: `Integer[0]`
 
 Default value: `24`
 
-##### <a name="max_log_file_action"></a>`max_log_file_action`
+##### <a name="-auditd--max_log_file_action"></a>`max_log_file_action`
 
 Data type: `Auditd::MaxLogFileAction`
 
@@ -409,15 +409,15 @@ Data type: `Auditd::MaxLogFileAction`
 
 Default value: `'rotate'`
 
-##### <a name="max_restarts"></a>`max_restarts`
+##### <a name="-auditd--max_restarts"></a>`max_restarts`
 
 Data type: `Optional[Integer[1]]`
 
 sets the number of times a plugin will be restart.
 
-Default value: ``undef``
+Default value: `undef`
 
-##### <a name="name_format"></a>`name_format`
+##### <a name="-auditd--name_format"></a>`name_format`
 
 Data type: `Auditd::NameFormat`
 
@@ -425,7 +425,7 @@ Data type: `Auditd::NameFormat`
 
 Default value: `'user'`
 
-##### <a name="num_logs"></a>`num_logs`
+##### <a name="-auditd--num_logs"></a>`num_logs`
 
 Data type: `Integer[0]`
 
@@ -433,15 +433,15 @@ Data type: `Integer[0]`
 
 Default value: `5`
 
-##### <a name="overflow_action"></a>`overflow_action`
+##### <a name="-auditd--overflow_action"></a>`overflow_action`
 
 Data type: `Optional[Auditd::Overflowaction]`
 
 sets the overflow action.
 
-Default value: ``undef``
+Default value: `undef`
 
-##### <a name="package_name"></a>`package_name`
+##### <a name="-auditd--package_name"></a>`package_name`
 
 Data type: `String[1]`
 
@@ -449,7 +449,7 @@ The name of the auditd package.
 
 Default value: `'audit'`
 
-##### <a name="package_ensure"></a>`package_ensure`
+##### <a name="-auditd--package_ensure"></a>`package_ensure`
 
 Data type: `Simplib::PackageEnsure`
 
@@ -457,13 +457,13 @@ Data type: `Simplib::PackageEnsure`
 
 Default value: `simplib::lookup('simp_options::package_ensure', { 'default_value' => 'installed' })`
 
-##### <a name="plugin_dir"></a>`plugin_dir`
+##### <a name="-auditd--plugin_dir"></a>`plugin_dir`
 
 Data type: `Stdlib::Absolutepath`
 
 sets the directory for the plugin configuration files.
 
-##### <a name="priority_boost"></a>`priority_boost`
+##### <a name="-auditd--priority_boost"></a>`priority_boost`
 
 Data type: `Integer[0]`
 
@@ -471,7 +471,7 @@ Data type: `Integer[0]`
 
 Default value: `3`
 
-##### <a name="q_depth"></a>`q_depth`
+##### <a name="-auditd--q_depth"></a>`q_depth`
 
 Data type: `Integer[0]`
 
@@ -479,7 +479,7 @@ how big to make the internal queue of the audit event dispatcher
 
 Default value: `400`
 
-##### <a name="rate"></a>`rate`
+##### <a name="-auditd--rate"></a>`rate`
 
 Data type: `Integer[0]`
 
@@ -487,7 +487,7 @@ Value of the `auditctl` '-r' option
 
 Default value: `0`
 
-##### <a name="root_audit_level"></a>`root_audit_level`
+##### <a name="-auditd--root_audit_level"></a>`root_audit_level`
 
 Data type: `Auditd::RootAuditLevel`
 
@@ -505,7 +505,7 @@ profile, these options are as follows:
 
 Default value: `'basic'`
 
-##### <a name="service_name"></a>`service_name`
+##### <a name="-auditd--service_name"></a>`service_name`
 
 Data type: `String[1]`
 
@@ -513,7 +513,7 @@ The name of the auditd service.
 
 Default value: `'auditd'`
 
-##### <a name="space_left"></a>`space_left`
+##### <a name="-auditd--space_left"></a>`space_left`
 
 Data type: `Variant[Integer[0],Pattern['^\d+%$']]`
 
@@ -524,7 +524,7 @@ Must be larger than `$admin_space_left`.
 
 Default value: `auditd::calculate_space_left($admin_space_left)`
 
-##### <a name="space_left_action"></a>`space_left_action`
+##### <a name="-auditd--space_left_action"></a>`space_left_action`
 
 Data type: `Auditd::SpaceLeftAction`
 
@@ -532,7 +532,7 @@ Data type: `Auditd::SpaceLeftAction`
 
 Default value: `'syslog'`
 
-##### <a name="syslog"></a>`syslog`
+##### <a name="-auditd--syslog"></a>`syslog`
 
 Data type: `Boolean`
 
@@ -548,7 +548,7 @@ If this is set to false the plugin settings are not managed by puppet.
 
 Default value: `simplib::lookup('simp_options::syslog', {'default_value' => false })`
 
-##### <a name="target_selinux_types"></a>`target_selinux_types`
+##### <a name="-auditd--target_selinux_types"></a>`target_selinux_types`
 
 Data type: `Optional[Array[Pattern['^.*_t$']]]`
 
@@ -558,9 +558,9 @@ For systems that require all users and processes to be in a confined
 namespace, you may find that only auditing unconfined types will be
 sufficient since all other invalid system actions are already audited.
 
-Default value: ``undef``
+Default value: `undef`
 
-##### <a name="uid_min"></a>`uid_min`
+##### <a name="-auditd--uid_min"></a>`uid_min`
 
 Data type: `Integer[0]`
 
@@ -573,15 +573,15 @@ parameter to be 'first'.
 
 Default value: `Integer(pick(fact('uid_min'), 1000))`
 
-##### <a name="verify_email"></a>`verify_email`
+##### <a name="-auditd--verify_email"></a>`verify_email`
 
 Data type: `Optional[Boolean]`
 
 auditd version 3 only
 
-Default value: ``undef``
+Default value: `undef`
 
-##### <a name="write_logs"></a>`write_logs`
+##### <a name="-auditd--write_logs"></a>`write_logs`
 
 Data type: `Boolean`
 
@@ -591,13 +591,13 @@ Whether or not to write logs to disk.
   of `auditd` so this attempts to do "the right thing" when `log_format` is
   set to `NOLOG` for legacy support.
 
-Default value: `$log_format`
+Default value: `$log_format ? { /^(?i:nolog)$/ => false, default => true`
 
-### <a name="auditdconfig"></a>`auditd::config`
+### <a name="auditd--config"></a>`auditd::config`
 
 NOTE: THIS IS A [PRIVATE](https://github.com/puppetlabs/puppetlabs-stdlib#assert_private) CLASS**
 
-### <a name="auditdconfigaudisp"></a>`auditd::config::audisp`
+### <a name="auditd--config--audisp"></a>`auditd::config::audisp`
 
 The following parameters are documented in audispd.conf(5).
 
@@ -618,52 +618,52 @@ The following setting maps to the name variable in audisp.conf.
 
 The following parameters are available in the `auditd::config::audisp` class:
 
-* [`q_depth`](#q_depth)
-* [`overflow_action`](#overflow_action)
-* [`priority_boost`](#priority_boost)
-* [`max_restarts`](#max_restarts)
-* [`name_format`](#name_format)
-* [`specific_name`](#specific_name)
+* [`q_depth`](#-auditd--config--audisp--q_depth)
+* [`overflow_action`](#-auditd--config--audisp--overflow_action)
+* [`priority_boost`](#-auditd--config--audisp--priority_boost)
+* [`max_restarts`](#-auditd--config--audisp--max_restarts)
+* [`name_format`](#-auditd--config--audisp--name_format)
+* [`specific_name`](#-auditd--config--audisp--specific_name)
 
-##### <a name="q_depth"></a>`q_depth`
+##### <a name="-auditd--config--audisp--q_depth"></a>`q_depth`
 
 Data type: `Integer`
 
 (deprecated)
 
-##### <a name="overflow_action"></a>`overflow_action`
+##### <a name="-auditd--config--audisp--overflow_action"></a>`overflow_action`
 
 Data type: `Auditd::OverflowAction`
 
 (deprecated)
 
-##### <a name="priority_boost"></a>`priority_boost`
+##### <a name="-auditd--config--audisp--priority_boost"></a>`priority_boost`
 
 Data type: `Integer`
 
 (deprecated)
 
-##### <a name="max_restarts"></a>`max_restarts`
+##### <a name="-auditd--config--audisp--max_restarts"></a>`max_restarts`
 
 Data type: `Integer`
 
 (deprecated)
 
-##### <a name="name_format"></a>`name_format`
+##### <a name="-auditd--config--audisp--name_format"></a>`name_format`
 
 Data type: `Auditd::NameFormat`
 
 (deprecated)
 
-##### <a name="specific_name"></a>`specific_name`
+##### <a name="-auditd--config--audisp--specific_name"></a>`specific_name`
 
 Data type: `String`
 
 
 
-Default value: `$facts['fqdn']`
+Default value: `$facts['networking']['fqdn']`
 
-### <a name="auditdconfigaudispsyslog"></a>`auditd::config::audisp::syslog`
+### <a name="auditd--config--audisp--syslog"></a>`auditd::config::audisp::syslog`
 
 This capability is most useful for forwarding audit records to
 remote servers as syslog messages, since these records are already
@@ -687,17 +687,17 @@ information carried by these messages.
 
 The following parameters are available in the `auditd::config::audisp::syslog` class:
 
-* [`rsyslog`](#rsyslog)
-* [`drop_audit_logs`](#drop_audit_logs)
-* [`enable`](#enable)
-* [`priority`](#priority)
-* [`facility`](#facility)
-* [`syslog_path`](#syslog_path)
-* [`type`](#type)
-* [`pkg_name`](#pkg_name)
-* [`package_ensure`](#package_ensure)
+* [`rsyslog`](#-auditd--config--audisp--syslog--rsyslog)
+* [`drop_audit_logs`](#-auditd--config--audisp--syslog--drop_audit_logs)
+* [`enable`](#-auditd--config--audisp--syslog--enable)
+* [`priority`](#-auditd--config--audisp--syslog--priority)
+* [`facility`](#-auditd--config--audisp--syslog--facility)
+* [`syslog_path`](#-auditd--config--audisp--syslog--syslog_path)
+* [`type`](#-auditd--config--audisp--syslog--type)
+* [`pkg_name`](#-auditd--config--audisp--syslog--pkg_name)
+* [`package_ensure`](#-auditd--config--audisp--syslog--package_ensure)
 
-##### <a name="rsyslog"></a>`rsyslog`
+##### <a name="-auditd--config--audisp--syslog--rsyslog"></a>`rsyslog`
 
 Data type: `Boolean`
 
@@ -707,7 +707,7 @@ for the `auditd` services.
 
 Default value: `simplib::lookup('simp_options::syslog', { 'default_value' => false })`
 
-##### <a name="drop_audit_logs"></a>`drop_audit_logs`
+##### <a name="-auditd--config--audisp--syslog--drop_audit_logs"></a>`drop_audit_logs`
 
 Data type: `Boolean`
 
@@ -721,17 +721,17 @@ the 'enable' parameter in this module to false/true as appropriate.
 It is left here for backwards compatability but will not
 be in the next major release.
 
-Default value: ``true``
+Default value: `true`
 
-##### <a name="enable"></a>`enable`
+##### <a name="-auditd--config--audisp--syslog--enable"></a>`enable`
 
 Data type: `Boolean`
 
 Enable or disable sending audit mesages to syslog.
 
-Default value: ``true``
+Default value: `true`
 
-##### <a name="priority"></a>`priority`
+##### <a name="-auditd--config--audisp--syslog--priority"></a>`priority`
 
 Data type: `Auditd::LogPriority`
 
@@ -740,7 +740,7 @@ This value is used in the /etc/audisp/plugins.d/syslog.conf file.
 
 Default value: `'LOG_INFO'`
 
-##### <a name="facility"></a>`facility`
+##### <a name="-auditd--config--audisp--syslog--facility"></a>`facility`
 
 Data type: `Auditd::LogFacility`
 
@@ -754,28 +754,28 @@ are allowed.
 
 Default value: `'LOG_LOCAL5'`
 
-##### <a name="syslog_path"></a>`syslog_path`
+##### <a name="-auditd--config--audisp--syslog--syslog_path"></a>`syslog_path`
 
 Data type: `String`
 
 The path to the syslog plugin executable.
 
-##### <a name="type"></a>`type`
+##### <a name="-auditd--config--audisp--syslog--type"></a>`type`
 
 Data type: `String`
 
 The type of auditd plugin.
 
-##### <a name="pkg_name"></a>`pkg_name`
+##### <a name="-auditd--config--audisp--syslog--pkg_name"></a>`pkg_name`
 
 Data type: `Optional[String]`
 
 The name of the plugin package to install.  Only needed for
 auditd version 3 and later.
 
-Default value: ``undef``
+Default value: `undef`
 
-##### <a name="package_ensure"></a>`package_ensure`
+##### <a name="-auditd--config--audisp--syslog--package_ensure"></a>`package_ensure`
 
 Data type: `String`
 
@@ -783,13 +783,13 @@ The default ensure parmeter for packages.
 
 Default value: `simplib::lookup('simp_options::package_ensure', { 'default_value' => 'installed' })`
 
-### <a name="auditdconfigaudisp_service"></a>`auditd::config::audisp_service`
+### <a name="auditd--config--audisp_service"></a>`auditd::config::audisp_service`
 
 NOTE: THIS IS A [PRIVATE](https://github.com/puppetlabs/puppetlabs-stdlib#assert_private) CLASS**
 
 Should only be called from audisp processing services.
 
-### <a name="auditdconfigaudit_profiles"></a>`auditd::config::audit_profiles`
+### <a name="auditd--config--audit_profiles"></a>`auditd::config::audit_profiles`
 
 NOTE: THIS IS A [PRIVATE](https://github.com/puppetlabs/puppetlabs-stdlib#assert_private) CLASS**
 
@@ -822,7 +822,7 @@ file. The generated files are as follows:
 - `99_tail.rules`
   - `auditctl` immutable option, when `$auditd::immutable` is 'true'
 
-### <a name="auditdconfigaudit_profilesbuilt_in"></a>`auditd::config::audit_profiles::built_in`
+### <a name="auditd--config--audit_profiles--built_in"></a>`auditd::config::audit_profiles::built_in`
 
 An audit profile that allows the use of sample rulesets included with the
 audit package to be used to configure a system.
@@ -831,9 +831,9 @@ audit package to be used to configure a system.
 
 The following parameters are available in the `auditd::config::audit_profiles::built_in` class:
 
-* [`rulesets`](#rulesets)
+* [`rulesets`](#-auditd--config--audit_profiles--built_in--rulesets)
 
-##### <a name="rulesets"></a>`rulesets`
+##### <a name="-auditd--config--audit_profiles--built_in--rulesets"></a>`rulesets`
 
 Data type: `Array[String[1]]`
 
@@ -842,7 +842,7 @@ can be found in the `auditd_sample_rulesets` fact.
 
 Default value: `[]`
 
-### <a name="auditdconfigaudit_profilescustom"></a>`auditd::config::audit_profiles::custom`
+### <a name="auditd--config--audit_profiles--custom"></a>`auditd::config::audit_profiles::custom`
 
 **NO SANITY CHECKING IS PERFORMED ON THE RESULTING RULES**
 
@@ -878,19 +878,19 @@ auditd::config::audit_profiles::custom::template: "my_templates_module/auditd/my
 
 The following parameters are available in the `auditd::config::audit_profiles::custom` class:
 
-* [`rules`](#rules)
-* [`template`](#template)
+* [`rules`](#-auditd--config--audit_profiles--custom--rules)
+* [`template`](#-auditd--config--audit_profiles--custom--template)
 
-##### <a name="rules"></a>`rules`
+##### <a name="-auditd--config--audit_profiles--custom--rules"></a>`rules`
 
 Data type: `Optional[Array[String[1]]]`
 
 An Array of rules that will be joined with a ``\n`` and inserted as the
 **complete** audit rule set to be applied to the system.
 
-Default value: ``undef``
+Default value: `undef`
 
-##### <a name="template"></a>`template`
+##### <a name="-auditd--config--audit_profiles--custom--template"></a>`template`
 
 Data type: `Optional[String[1]]`
 
@@ -899,9 +899,9 @@ function
 
 * Specifying both `rules` and `template` will result in an error
 
-Default value: ``undef``
+Default value: `undef`
 
-### <a name="auditdconfigaudit_profilessimp"></a>`auditd::config::audit_profiles::simp`
+### <a name="auditd--config--audit_profiles--simp"></a>`auditd::config::audit_profiles::simp`
 
 The defaults for this profile generate a set of audit rules that are
 both usable on most systems and conformant with standard auditing
@@ -933,110 +933,110 @@ should be noted:
 
 The following parameters are available in the `auditd::config::audit_profiles::simp` class:
 
-* [`root_audit_level`](#root_audit_level)
-* [`audit_32bit_operations`](#audit_32bit_operations)
-* [`audit_32bit_operations_tag`](#audit_32bit_operations_tag)
-* [`audit_auditd_cmds`](#audit_auditd_cmds)
-* [`audit_auditd_cmds_tag`](#audit_auditd_cmds_tag)
-* [`audit_auditd_cmds_list`](#audit_auditd_cmds_list)
-* [`basic_root_audit_syscalls`](#basic_root_audit_syscalls)
-* [`aggressive_root_audit_syscalls`](#aggressive_root_audit_syscalls)
-* [`insane_root_audit_syscalls`](#insane_root_audit_syscalls)
-* [`audit_unsuccessful_file_operations`](#audit_unsuccessful_file_operations)
-* [`audit_unsuccessful_file_operations_tag`](#audit_unsuccessful_file_operations_tag)
-* [`audit_chown`](#audit_chown)
-* [`audit_chown_tag`](#audit_chown_tag)
-* [`audit_chmod`](#audit_chmod)
-* [`audit_chmod_tag`](#audit_chmod_tag)
-* [`audit_attr`](#audit_attr)
-* [`audit_attr_tag`](#audit_attr_tag)
-* [`audit_rename_remove`](#audit_rename_remove)
-* [`audit_rename_remove_tag`](#audit_rename_remove_tag)
-* [`audit_su_root_activity`](#audit_su_root_activity)
-* [`audit_su_root_activity_tag`](#audit_su_root_activity_tag)
-* [`audit_suid_sgid`](#audit_suid_sgid)
-* [`audit_suid_sgid_tag`](#audit_suid_sgid_tag)
-* [`audit_kernel_modules`](#audit_kernel_modules)
-* [`audit_kernel_modules_tag`](#audit_kernel_modules_tag)
-* [`audit_time`](#audit_time)
-* [`audit_time_tag`](#audit_time_tag)
-* [`audit_locale`](#audit_locale)
-* [`audit_locale_tag`](#audit_locale_tag)
-* [`audit_network_ipv4_accept`](#audit_network_ipv4_accept)
-* [`audit_network_ipv4_accept_tag`](#audit_network_ipv4_accept_tag)
-* [`audit_network_ipv6_accept`](#audit_network_ipv6_accept)
-* [`audit_network_ipv6_accept_tag`](#audit_network_ipv6_accept_tag)
-* [`audit_network_ipv4_connect`](#audit_network_ipv4_connect)
-* [`audit_network_ipv4_connect_tag`](#audit_network_ipv4_connect_tag)
-* [`audit_network_ipv6_connect`](#audit_network_ipv6_connect)
-* [`audit_network_ipv6_connect_tag`](#audit_network_ipv6_connect_tag)
-* [`audit_mount`](#audit_mount)
-* [`audit_mount_tag`](#audit_mount_tag)
-* [`audit_umask`](#audit_umask)
-* [`audit_umask_tag`](#audit_umask_tag)
-* [`audit_local_account`](#audit_local_account)
-* [`audit_local_account_tag`](#audit_local_account_tag)
-* [`audit_selinux_policy`](#audit_selinux_policy)
-* [`audit_selinux_policy_tag`](#audit_selinux_policy_tag)
-* [`audit_selinux_cmds`](#audit_selinux_cmds)
-* [`audit_selinux_cmds_tag`](#audit_selinux_cmds_tag)
-* [`audit_login_files`](#audit_login_files)
-* [`audit_login_files_tag`](#audit_login_files_tag)
-* [`audit_session_files`](#audit_session_files)
-* [`audit_session_files_tag`](#audit_session_files_tag)
-* [`audit_sudoers`](#audit_sudoers)
-* [`audit_sudoers_tag`](#audit_sudoers_tag)
-* [`audit_cfg_sudoers`](#audit_cfg_sudoers)
-* [`audit_cfg_sudoers_tag`](#audit_cfg_sudoers_tag)
-* [`audit_grub`](#audit_grub)
-* [`audit_grub_tag`](#audit_grub_tag)
-* [`audit_cfg_grub`](#audit_cfg_grub)
-* [`audit_cfg_grub_tag`](#audit_cfg_grub_tag)
-* [`audit_cfg_sys`](#audit_cfg_sys)
-* [`audit_cfg_sys_tag`](#audit_cfg_sys_tag)
-* [`audit_cfg_cron`](#audit_cfg_cron)
-* [`audit_cfg_cron_tag`](#audit_cfg_cron_tag)
-* [`audit_cfg_shell`](#audit_cfg_shell)
-* [`audit_cfg_shell_tag`](#audit_cfg_shell_tag)
-* [`audit_cfg_pam`](#audit_cfg_pam)
-* [`audit_cfg_pam_tag`](#audit_cfg_pam_tag)
-* [`audit_cfg_security`](#audit_cfg_security)
-* [`audit_cfg_security_tag`](#audit_cfg_security_tag)
-* [`audit_cfg_services`](#audit_cfg_services)
-* [`audit_cfg_services_tag`](#audit_cfg_services_tag)
-* [`audit_cfg_xinetd`](#audit_cfg_xinetd)
-* [`audit_cfg_xinetd_tag`](#audit_cfg_xinetd_tag)
-* [`audit_yum`](#audit_yum)
-* [`audit_yum_tag`](#audit_yum_tag)
-* [`audit_cfg_yum`](#audit_cfg_yum)
-* [`audit_cfg_yum_tag`](#audit_cfg_yum_tag)
-* [`audit_yum_cmd`](#audit_yum_cmd)
-* [`audit_yum_cmd_tag`](#audit_yum_cmd_tag)
-* [`audit_rpm_cmd`](#audit_rpm_cmd)
-* [`audit_rpm_cmd_tag`](#audit_rpm_cmd_tag)
-* [`audit_ptrace`](#audit_ptrace)
-* [`audit_ptrace_tag`](#audit_ptrace_tag)
-* [`audit_personality`](#audit_personality)
-* [`audit_personality_tag`](#audit_personality_tag)
-* [`audit_passwd_cmds`](#audit_passwd_cmds)
-* [`audit_passwd_cmds_tag`](#audit_passwd_cmds_tag)
-* [`audit_priv_cmds`](#audit_priv_cmds)
-* [`audit_priv_cmds_tag`](#audit_priv_cmds_tag)
-* [`audit_postfix_cmds`](#audit_postfix_cmds)
-* [`audit_postfix_cmds_tag`](#audit_postfix_cmds_tag)
-* [`audit_ssh_keysign_cmd`](#audit_ssh_keysign_cmd)
-* [`audit_ssh_keysign_cmd_tag`](#audit_ssh_keysign_cmd_tag)
-* [`audit_suspicious_apps`](#audit_suspicious_apps)
-* [`audit_suspicious_apps_tag`](#audit_suspicious_apps_tag)
-* [`audit_suspicious_apps_list`](#audit_suspicious_apps_list)
-* [`audit_systemd`](#audit_systemd)
-* [`audit_systemd_tag`](#audit_systemd_tag)
-* [`audit_crontab_cmd`](#audit_crontab_cmd)
-* [`audit_crontab_cmd_tag`](#audit_crontab_cmd_tag)
-* [`audit_pam_timestamp_check_cmd`](#audit_pam_timestamp_check_cmd)
-* [`audit_pam_timestamp_check_cmd_tag`](#audit_pam_timestamp_check_cmd_tag)
+* [`root_audit_level`](#-auditd--config--audit_profiles--simp--root_audit_level)
+* [`audit_32bit_operations`](#-auditd--config--audit_profiles--simp--audit_32bit_operations)
+* [`audit_32bit_operations_tag`](#-auditd--config--audit_profiles--simp--audit_32bit_operations_tag)
+* [`audit_auditd_cmds`](#-auditd--config--audit_profiles--simp--audit_auditd_cmds)
+* [`audit_auditd_cmds_tag`](#-auditd--config--audit_profiles--simp--audit_auditd_cmds_tag)
+* [`audit_auditd_cmds_list`](#-auditd--config--audit_profiles--simp--audit_auditd_cmds_list)
+* [`basic_root_audit_syscalls`](#-auditd--config--audit_profiles--simp--basic_root_audit_syscalls)
+* [`aggressive_root_audit_syscalls`](#-auditd--config--audit_profiles--simp--aggressive_root_audit_syscalls)
+* [`insane_root_audit_syscalls`](#-auditd--config--audit_profiles--simp--insane_root_audit_syscalls)
+* [`audit_unsuccessful_file_operations`](#-auditd--config--audit_profiles--simp--audit_unsuccessful_file_operations)
+* [`audit_unsuccessful_file_operations_tag`](#-auditd--config--audit_profiles--simp--audit_unsuccessful_file_operations_tag)
+* [`audit_chown`](#-auditd--config--audit_profiles--simp--audit_chown)
+* [`audit_chown_tag`](#-auditd--config--audit_profiles--simp--audit_chown_tag)
+* [`audit_chmod`](#-auditd--config--audit_profiles--simp--audit_chmod)
+* [`audit_chmod_tag`](#-auditd--config--audit_profiles--simp--audit_chmod_tag)
+* [`audit_attr`](#-auditd--config--audit_profiles--simp--audit_attr)
+* [`audit_attr_tag`](#-auditd--config--audit_profiles--simp--audit_attr_tag)
+* [`audit_rename_remove`](#-auditd--config--audit_profiles--simp--audit_rename_remove)
+* [`audit_rename_remove_tag`](#-auditd--config--audit_profiles--simp--audit_rename_remove_tag)
+* [`audit_su_root_activity`](#-auditd--config--audit_profiles--simp--audit_su_root_activity)
+* [`audit_su_root_activity_tag`](#-auditd--config--audit_profiles--simp--audit_su_root_activity_tag)
+* [`audit_suid_sgid`](#-auditd--config--audit_profiles--simp--audit_suid_sgid)
+* [`audit_suid_sgid_tag`](#-auditd--config--audit_profiles--simp--audit_suid_sgid_tag)
+* [`audit_kernel_modules`](#-auditd--config--audit_profiles--simp--audit_kernel_modules)
+* [`audit_kernel_modules_tag`](#-auditd--config--audit_profiles--simp--audit_kernel_modules_tag)
+* [`audit_time`](#-auditd--config--audit_profiles--simp--audit_time)
+* [`audit_time_tag`](#-auditd--config--audit_profiles--simp--audit_time_tag)
+* [`audit_locale`](#-auditd--config--audit_profiles--simp--audit_locale)
+* [`audit_locale_tag`](#-auditd--config--audit_profiles--simp--audit_locale_tag)
+* [`audit_network_ipv4_accept`](#-auditd--config--audit_profiles--simp--audit_network_ipv4_accept)
+* [`audit_network_ipv4_accept_tag`](#-auditd--config--audit_profiles--simp--audit_network_ipv4_accept_tag)
+* [`audit_network_ipv6_accept`](#-auditd--config--audit_profiles--simp--audit_network_ipv6_accept)
+* [`audit_network_ipv6_accept_tag`](#-auditd--config--audit_profiles--simp--audit_network_ipv6_accept_tag)
+* [`audit_network_ipv4_connect`](#-auditd--config--audit_profiles--simp--audit_network_ipv4_connect)
+* [`audit_network_ipv4_connect_tag`](#-auditd--config--audit_profiles--simp--audit_network_ipv4_connect_tag)
+* [`audit_network_ipv6_connect`](#-auditd--config--audit_profiles--simp--audit_network_ipv6_connect)
+* [`audit_network_ipv6_connect_tag`](#-auditd--config--audit_profiles--simp--audit_network_ipv6_connect_tag)
+* [`audit_mount`](#-auditd--config--audit_profiles--simp--audit_mount)
+* [`audit_mount_tag`](#-auditd--config--audit_profiles--simp--audit_mount_tag)
+* [`audit_umask`](#-auditd--config--audit_profiles--simp--audit_umask)
+* [`audit_umask_tag`](#-auditd--config--audit_profiles--simp--audit_umask_tag)
+* [`audit_local_account`](#-auditd--config--audit_profiles--simp--audit_local_account)
+* [`audit_local_account_tag`](#-auditd--config--audit_profiles--simp--audit_local_account_tag)
+* [`audit_selinux_policy`](#-auditd--config--audit_profiles--simp--audit_selinux_policy)
+* [`audit_selinux_policy_tag`](#-auditd--config--audit_profiles--simp--audit_selinux_policy_tag)
+* [`audit_selinux_cmds`](#-auditd--config--audit_profiles--simp--audit_selinux_cmds)
+* [`audit_selinux_cmds_tag`](#-auditd--config--audit_profiles--simp--audit_selinux_cmds_tag)
+* [`audit_login_files`](#-auditd--config--audit_profiles--simp--audit_login_files)
+* [`audit_login_files_tag`](#-auditd--config--audit_profiles--simp--audit_login_files_tag)
+* [`audit_session_files`](#-auditd--config--audit_profiles--simp--audit_session_files)
+* [`audit_session_files_tag`](#-auditd--config--audit_profiles--simp--audit_session_files_tag)
+* [`audit_sudoers`](#-auditd--config--audit_profiles--simp--audit_sudoers)
+* [`audit_sudoers_tag`](#-auditd--config--audit_profiles--simp--audit_sudoers_tag)
+* [`audit_cfg_sudoers`](#-auditd--config--audit_profiles--simp--audit_cfg_sudoers)
+* [`audit_cfg_sudoers_tag`](#-auditd--config--audit_profiles--simp--audit_cfg_sudoers_tag)
+* [`audit_grub`](#-auditd--config--audit_profiles--simp--audit_grub)
+* [`audit_grub_tag`](#-auditd--config--audit_profiles--simp--audit_grub_tag)
+* [`audit_cfg_grub`](#-auditd--config--audit_profiles--simp--audit_cfg_grub)
+* [`audit_cfg_grub_tag`](#-auditd--config--audit_profiles--simp--audit_cfg_grub_tag)
+* [`audit_cfg_sys`](#-auditd--config--audit_profiles--simp--audit_cfg_sys)
+* [`audit_cfg_sys_tag`](#-auditd--config--audit_profiles--simp--audit_cfg_sys_tag)
+* [`audit_cfg_cron`](#-auditd--config--audit_profiles--simp--audit_cfg_cron)
+* [`audit_cfg_cron_tag`](#-auditd--config--audit_profiles--simp--audit_cfg_cron_tag)
+* [`audit_cfg_shell`](#-auditd--config--audit_profiles--simp--audit_cfg_shell)
+* [`audit_cfg_shell_tag`](#-auditd--config--audit_profiles--simp--audit_cfg_shell_tag)
+* [`audit_cfg_pam`](#-auditd--config--audit_profiles--simp--audit_cfg_pam)
+* [`audit_cfg_pam_tag`](#-auditd--config--audit_profiles--simp--audit_cfg_pam_tag)
+* [`audit_cfg_security`](#-auditd--config--audit_profiles--simp--audit_cfg_security)
+* [`audit_cfg_security_tag`](#-auditd--config--audit_profiles--simp--audit_cfg_security_tag)
+* [`audit_cfg_services`](#-auditd--config--audit_profiles--simp--audit_cfg_services)
+* [`audit_cfg_services_tag`](#-auditd--config--audit_profiles--simp--audit_cfg_services_tag)
+* [`audit_cfg_xinetd`](#-auditd--config--audit_profiles--simp--audit_cfg_xinetd)
+* [`audit_cfg_xinetd_tag`](#-auditd--config--audit_profiles--simp--audit_cfg_xinetd_tag)
+* [`audit_yum`](#-auditd--config--audit_profiles--simp--audit_yum)
+* [`audit_yum_tag`](#-auditd--config--audit_profiles--simp--audit_yum_tag)
+* [`audit_cfg_yum`](#-auditd--config--audit_profiles--simp--audit_cfg_yum)
+* [`audit_cfg_yum_tag`](#-auditd--config--audit_profiles--simp--audit_cfg_yum_tag)
+* [`audit_yum_cmd`](#-auditd--config--audit_profiles--simp--audit_yum_cmd)
+* [`audit_yum_cmd_tag`](#-auditd--config--audit_profiles--simp--audit_yum_cmd_tag)
+* [`audit_rpm_cmd`](#-auditd--config--audit_profiles--simp--audit_rpm_cmd)
+* [`audit_rpm_cmd_tag`](#-auditd--config--audit_profiles--simp--audit_rpm_cmd_tag)
+* [`audit_ptrace`](#-auditd--config--audit_profiles--simp--audit_ptrace)
+* [`audit_ptrace_tag`](#-auditd--config--audit_profiles--simp--audit_ptrace_tag)
+* [`audit_personality`](#-auditd--config--audit_profiles--simp--audit_personality)
+* [`audit_personality_tag`](#-auditd--config--audit_profiles--simp--audit_personality_tag)
+* [`audit_passwd_cmds`](#-auditd--config--audit_profiles--simp--audit_passwd_cmds)
+* [`audit_passwd_cmds_tag`](#-auditd--config--audit_profiles--simp--audit_passwd_cmds_tag)
+* [`audit_priv_cmds`](#-auditd--config--audit_profiles--simp--audit_priv_cmds)
+* [`audit_priv_cmds_tag`](#-auditd--config--audit_profiles--simp--audit_priv_cmds_tag)
+* [`audit_postfix_cmds`](#-auditd--config--audit_profiles--simp--audit_postfix_cmds)
+* [`audit_postfix_cmds_tag`](#-auditd--config--audit_profiles--simp--audit_postfix_cmds_tag)
+* [`audit_ssh_keysign_cmd`](#-auditd--config--audit_profiles--simp--audit_ssh_keysign_cmd)
+* [`audit_ssh_keysign_cmd_tag`](#-auditd--config--audit_profiles--simp--audit_ssh_keysign_cmd_tag)
+* [`audit_suspicious_apps`](#-auditd--config--audit_profiles--simp--audit_suspicious_apps)
+* [`audit_suspicious_apps_tag`](#-auditd--config--audit_profiles--simp--audit_suspicious_apps_tag)
+* [`audit_suspicious_apps_list`](#-auditd--config--audit_profiles--simp--audit_suspicious_apps_list)
+* [`audit_systemd`](#-auditd--config--audit_profiles--simp--audit_systemd)
+* [`audit_systemd_tag`](#-auditd--config--audit_profiles--simp--audit_systemd_tag)
+* [`audit_crontab_cmd`](#-auditd--config--audit_profiles--simp--audit_crontab_cmd)
+* [`audit_crontab_cmd_tag`](#-auditd--config--audit_profiles--simp--audit_crontab_cmd_tag)
+* [`audit_pam_timestamp_check_cmd`](#-auditd--config--audit_profiles--simp--audit_pam_timestamp_check_cmd)
+* [`audit_pam_timestamp_check_cmd_tag`](#-auditd--config--audit_profiles--simp--audit_pam_timestamp_check_cmd_tag)
 
-##### <a name="root_audit_level"></a>`root_audit_level`
+##### <a name="-auditd--config--audit_profiles--simp--root_audit_level"></a>`root_audit_level`
 
 Data type: `Auditd::RootAuditLevel`
 
@@ -1053,16 +1053,16 @@ Options can be, 'basic', 'aggressive', 'insane'
 
 Default value: `$::auditd::root_audit_level`
 
-##### <a name="audit_32bit_operations"></a>`audit_32bit_operations`
+##### <a name="-auditd--config--audit_profiles--simp--audit_32bit_operations"></a>`audit_32bit_operations`
 
 Data type: `Boolean`
 
 In general, any 32bit system calls on a 64bit systems should be seen as
 suspicious.
 
-Default value: `$facts['hardwaremodel']`
+Default value: `$facts['os']['hardware'] ? { 'x86_64' => true, default => false`
 
-##### <a name="audit_32bit_operations_tag"></a>`audit_32bit_operations_tag`
+##### <a name="-auditd--config--audit_profiles--simp--audit_32bit_operations_tag"></a>`audit_32bit_operations_tag`
 
 Data type: `String[1]`
 
@@ -1070,15 +1070,15 @@ Tag to be added to entries triggered by `audit_32bit_operations`
 
 Default value: `'32bit-api'`
 
-##### <a name="audit_auditd_cmds"></a>`audit_auditd_cmds`
+##### <a name="-auditd--config--audit_profiles--simp--audit_auditd_cmds"></a>`audit_auditd_cmds`
 
 Data type: `Boolean`
 
 Audit calls to the auditd management CLI commands
 
-Default value: ``true``
+Default value: `true`
 
-##### <a name="audit_auditd_cmds_tag"></a>`audit_auditd_cmds_tag`
+##### <a name="-auditd--config--audit_profiles--simp--audit_auditd_cmds_tag"></a>`audit_auditd_cmds_tag`
 
 Data type: `String[1]`
 
@@ -1086,40 +1086,40 @@ Tag to be added to entries triggered by `audit_auditd_cmds`
 
 Default value: `'access-audit-trail'`
 
-##### <a name="audit_auditd_cmds_list"></a>`audit_auditd_cmds_list`
+##### <a name="-auditd--config--audit_profiles--simp--audit_auditd_cmds_list"></a>`audit_auditd_cmds_list`
 
 Data type: `Array[String[1]]`
 
 Commands to be audited if enabled by `audit_auditd_cmds`
 
-##### <a name="basic_root_audit_syscalls"></a>`basic_root_audit_syscalls`
+##### <a name="-auditd--config--audit_profiles--simp--basic_root_audit_syscalls"></a>`basic_root_audit_syscalls`
 
 Data type: `Array[String[1]]`
 
 Basic syscalls to audit for su-root activity
 
-##### <a name="aggressive_root_audit_syscalls"></a>`aggressive_root_audit_syscalls`
+##### <a name="-auditd--config--audit_profiles--simp--aggressive_root_audit_syscalls"></a>`aggressive_root_audit_syscalls`
 
 Data type: `Array[String[1]]`
 
 Aggressive syscalls to audit for su-root activity
 
-##### <a name="insane_root_audit_syscalls"></a>`insane_root_audit_syscalls`
+##### <a name="-auditd--config--audit_profiles--simp--insane_root_audit_syscalls"></a>`insane_root_audit_syscalls`
 
 Data type: `Array[String[1]]`
 
 Insane syscalls to audit for su-root activity
 
-##### <a name="audit_unsuccessful_file_operations"></a>`audit_unsuccessful_file_operations`
+##### <a name="-auditd--config--audit_profiles--simp--audit_unsuccessful_file_operations"></a>`audit_unsuccessful_file_operations`
 
 Data type: `Boolean`
 
 Whether to audit unsuccessful file operations.  These are file operations
 that fail with EACCES or EPERM error codes
 
-Default value: ``true``
+Default value: `true`
 
-##### <a name="audit_unsuccessful_file_operations_tag"></a>`audit_unsuccessful_file_operations_tag`
+##### <a name="-auditd--config--audit_profiles--simp--audit_unsuccessful_file_operations_tag"></a>`audit_unsuccessful_file_operations_tag`
 
 Data type: `String[1]`
 
@@ -1127,7 +1127,7 @@ The tag to identify the unsuccessful file operations in an audit record
 
 Default value: `'access'`
 
-##### <a name="audit_chown"></a>`audit_chown`
+##### <a name="-auditd--config--audit_profiles--simp--audit_chown"></a>`audit_chown`
 
 Data type: `Boolean`
 
@@ -1135,9 +1135,9 @@ Whether to audit `chown` operations for all non-service users.
 These operations are provided by `chown`, `fchown`, `fchownat`,
 and `lchown` system calls.
 
-Default value: ``true``
+Default value: `true`
 
-##### <a name="audit_chown_tag"></a>`audit_chown_tag`
+##### <a name="-auditd--config--audit_profiles--simp--audit_chown_tag"></a>`audit_chown_tag`
 
 Data type: `String[1]`
 
@@ -1147,7 +1147,7 @@ compliance checks for RHEL7.
 
 Default value: `'chown'`
 
-##### <a name="audit_chmod"></a>`audit_chmod`
+##### <a name="-auditd--config--audit_profiles--simp--audit_chmod"></a>`audit_chmod`
 
 Data type: `Boolean`
 
@@ -1155,9 +1155,9 @@ Whether to audit `chmod` operations for all non-service users.
 These operations are provided by `chmod`, `fchmod`, and `fchmodat`
 system calls.
 
-Default value: ``false``
+Default value: `false`
 
-##### <a name="audit_chmod_tag"></a>`audit_chmod_tag`
+##### <a name="-auditd--config--audit_profiles--simp--audit_chmod_tag"></a>`audit_chmod_tag`
 
 Data type: `String[1]`
 
@@ -1167,7 +1167,7 @@ compliance checks for RHEL7.
 
 Default value: `'chmod'`
 
-##### <a name="audit_attr"></a>`audit_attr`
+##### <a name="-auditd--config--audit_profiles--simp--audit_attr"></a>`audit_attr`
 
 Data type: `Boolean`
 
@@ -1175,9 +1175,9 @@ Whether to audit `xattr` operations for all non-service users.
 These operations are provided by `setxattr`, `lsetxattr`, `fsetxattr`,
 `removexattr`, `lremovexattr` and `fremovexattr` system calls.
 
-Default value: ``true``
+Default value: `true`
 
-##### <a name="audit_attr_tag"></a>`audit_attr_tag`
+##### <a name="-auditd--config--audit_profiles--simp--audit_attr_tag"></a>`audit_attr_tag`
 
 Data type: `String[1]`
 
@@ -1187,7 +1187,7 @@ compliance checks for RHEL7.
 
 Default value: `'attr'`
 
-##### <a name="audit_rename_remove"></a>`audit_rename_remove`
+##### <a name="-auditd--config--audit_profiles--simp--audit_rename_remove"></a>`audit_rename_remove`
 
 Data type: `Boolean`
 
@@ -1195,9 +1195,9 @@ Whether to audit rename/remove operations for all non-service users.
 These operations are provided by `rename`, `renameat`, `rmdir`,
 `unlink`, and `unlinkat` system calls.
 
-Default value: ``false``
+Default value: `false`
 
-##### <a name="audit_rename_remove_tag"></a>`audit_rename_remove_tag`
+##### <a name="-auditd--config--audit_profiles--simp--audit_rename_remove_tag"></a>`audit_rename_remove_tag`
 
 Data type: `String[1]`
 
@@ -1205,16 +1205,16 @@ The tag to identify rename/remove operations in an audit record
 
 Default value: `'delete'`
 
-##### <a name="audit_su_root_activity"></a>`audit_su_root_activity`
+##### <a name="-auditd--config--audit_profiles--simp--audit_su_root_activity"></a>`audit_su_root_activity`
 
 Data type: `Boolean`
 
 Whether to audit other useful actions someone does when su'ing to root.
 The list of system calls audited is controlled by `$root_audit_level`.
 
-Default value: ``true``
+Default value: `true`
 
-##### <a name="audit_su_root_activity_tag"></a>`audit_su_root_activity_tag`
+##### <a name="-auditd--config--audit_profiles--simp--audit_su_root_activity_tag"></a>`audit_su_root_activity_tag`
 
 Data type: `String[1]`
 
@@ -1222,7 +1222,7 @@ The tag to identify `su` operations in an audit record
 
 Default value: `'su-root-activity'`
 
-##### <a name="audit_suid_sgid"></a>`audit_suid_sgid`
+##### <a name="-auditd--config--audit_profiles--simp--audit_suid_sgid"></a>`audit_suid_sgid`
 
 Data type: `Boolean`
 
@@ -1230,9 +1230,9 @@ Whether to audit `setuid`/`setgid` commands.
 `setuid`/`setgid` command execution is audited by a single system call
 rule.
 
-Default value: ``true``
+Default value: `true`
 
-##### <a name="audit_suid_sgid_tag"></a>`audit_suid_sgid_tag`
+##### <a name="-auditd--config--audit_profiles--simp--audit_suid_sgid_tag"></a>`audit_suid_sgid_tag`
 
 Data type: `String[1]`
 
@@ -1242,15 +1242,15 @@ DISA STIG compliance checks for RHEL7.
 
 Default value: `'suid-exec'`
 
-##### <a name="audit_kernel_modules"></a>`audit_kernel_modules`
+##### <a name="-auditd--config--audit_profiles--simp--audit_kernel_modules"></a>`audit_kernel_modules`
 
 Data type: `Boolean`
 
 Whether to audit kernel module operations
 
-Default value: ``true``
+Default value: `true`
 
-##### <a name="audit_kernel_modules_tag"></a>`audit_kernel_modules_tag`
+##### <a name="-auditd--config--audit_profiles--simp--audit_kernel_modules_tag"></a>`audit_kernel_modules_tag`
 
 Data type: `String[1]`
 
@@ -1260,15 +1260,15 @@ compliance checks for RHEL7.
 
 Default value: `'modules'`
 
-##### <a name="audit_time"></a>`audit_time`
+##### <a name="-auditd--config--audit_profiles--simp--audit_time"></a>`audit_time`
 
 Data type: `Boolean`
 
 Whether to audit operations that affect system time
 
-Default value: ``true``
+Default value: `true`
 
-##### <a name="audit_time_tag"></a>`audit_time_tag`
+##### <a name="-auditd--config--audit_profiles--simp--audit_time_tag"></a>`audit_time_tag`
 
 Data type: `String[1]`
 
@@ -1276,15 +1276,15 @@ The tag to identify system time operations in an audit record
 
 Default value: `'audit_time_rules'`
 
-##### <a name="audit_locale"></a>`audit_locale`
+##### <a name="-auditd--config--audit_profiles--simp--audit_locale"></a>`audit_locale`
 
 Data type: `Boolean`
 
 Whether to audit operations that affect system locale
 
-Default value: ``true``
+Default value: `true`
 
-##### <a name="audit_locale_tag"></a>`audit_locale_tag`
+##### <a name="-auditd--config--audit_profiles--simp--audit_locale_tag"></a>`audit_locale_tag`
 
 Data type: `String[1]`
 
@@ -1292,15 +1292,15 @@ The tag to identify system locale operations in an audit record
 
 Default value: `'audit_network_modifications'`
 
-##### <a name="audit_network_ipv4_accept"></a>`audit_network_ipv4_accept`
+##### <a name="-auditd--config--audit_profiles--simp--audit_network_ipv4_accept"></a>`audit_network_ipv4_accept`
 
 Data type: `Boolean`
 
 Audit **incoming** IPv4 connections
 
-Default value: ``true``
+Default value: `true`
 
-##### <a name="audit_network_ipv4_accept_tag"></a>`audit_network_ipv4_accept_tag`
+##### <a name="-auditd--config--audit_profiles--simp--audit_network_ipv4_accept_tag"></a>`audit_network_ipv4_accept_tag`
 
 Data type: `String[1]`
 
@@ -1308,15 +1308,15 @@ Tag to be added to entries triggered by `audit_network_ipv4_accept`
 
 Default value: `'ipv4_in'`
 
-##### <a name="audit_network_ipv6_accept"></a>`audit_network_ipv6_accept`
+##### <a name="-auditd--config--audit_profiles--simp--audit_network_ipv6_accept"></a>`audit_network_ipv6_accept`
 
 Data type: `Boolean`
 
 Audit **incoming** IPv6 connections
 
-Default value: ``true``
+Default value: `true`
 
-##### <a name="audit_network_ipv6_accept_tag"></a>`audit_network_ipv6_accept_tag`
+##### <a name="-auditd--config--audit_profiles--simp--audit_network_ipv6_accept_tag"></a>`audit_network_ipv6_accept_tag`
 
 Data type: `String[1]`
 
@@ -1324,15 +1324,15 @@ Tag to be added to entries triggered by `audit_network_ipv6_accept`
 
 Default value: `'ipv6_in'`
 
-##### <a name="audit_network_ipv4_connect"></a>`audit_network_ipv4_connect`
+##### <a name="-auditd--config--audit_profiles--simp--audit_network_ipv4_connect"></a>`audit_network_ipv4_connect`
 
 Data type: `Boolean`
 
 Audit **outgoing** IPv4 connections
 
-Default value: ``false``
+Default value: `false`
 
-##### <a name="audit_network_ipv4_connect_tag"></a>`audit_network_ipv4_connect_tag`
+##### <a name="-auditd--config--audit_profiles--simp--audit_network_ipv4_connect_tag"></a>`audit_network_ipv4_connect_tag`
 
 Data type: `String[1]`
 
@@ -1340,15 +1340,15 @@ Tag to be added to entries triggered by `audit_network_ipv4_connect`
 
 Default value: `'ipv4_in'`
 
-##### <a name="audit_network_ipv6_connect"></a>`audit_network_ipv6_connect`
+##### <a name="-auditd--config--audit_profiles--simp--audit_network_ipv6_connect"></a>`audit_network_ipv6_connect`
 
 Data type: `Boolean`
 
 Audit **outgoing** IPv6 connections
 
-Default value: ``false``
+Default value: `false`
 
-##### <a name="audit_network_ipv6_connect_tag"></a>`audit_network_ipv6_connect_tag`
+##### <a name="-auditd--config--audit_profiles--simp--audit_network_ipv6_connect_tag"></a>`audit_network_ipv6_connect_tag`
 
 Data type: `String[1]`
 
@@ -1356,15 +1356,15 @@ Tag to be added to entries triggered by `audit_network_ipv6_connect`
 
 Default value: `'ipv6_in'`
 
-##### <a name="audit_mount"></a>`audit_mount`
+##### <a name="-auditd--config--audit_profiles--simp--audit_mount"></a>`audit_mount`
 
 Data type: `Boolean`
 
 Whether to audit mount operations
 
-Default value: ``true``
+Default value: `true`
 
-##### <a name="audit_mount_tag"></a>`audit_mount_tag`
+##### <a name="-auditd--config--audit_profiles--simp--audit_mount_tag"></a>`audit_mount_tag`
 
 Data type: `String[1]`
 
@@ -1374,15 +1374,15 @@ compliance checks for RHEL7.
 
 Default value: `'mount'`
 
-##### <a name="audit_umask"></a>`audit_umask`
+##### <a name="-auditd--config--audit_profiles--simp--audit_umask"></a>`audit_umask`
 
 Data type: `Boolean`
 
 Whether to audit umask changes
 
-Default value: ``false``
+Default value: `false`
 
-##### <a name="audit_umask_tag"></a>`audit_umask_tag`
+##### <a name="-auditd--config--audit_profiles--simp--audit_umask_tag"></a>`audit_umask_tag`
 
 Data type: `String[1]`
 
@@ -1390,15 +1390,15 @@ The tag to identify umask changes in an audit record
 
 Default value: `'umask'`
 
-##### <a name="audit_local_account"></a>`audit_local_account`
+##### <a name="-auditd--config--audit_profiles--simp--audit_local_account"></a>`audit_local_account`
 
 Data type: `Boolean`
 
 Whether to audit local account changes
 
-Default value: ``true``
+Default value: `true`
 
-##### <a name="audit_local_account_tag"></a>`audit_local_account_tag`
+##### <a name="-auditd--config--audit_profiles--simp--audit_local_account_tag"></a>`audit_local_account_tag`
 
 Data type: `String[1]`
 
@@ -1408,15 +1408,15 @@ compliance checks for RHEL7.
 
 Default value: `'audit_account_changes'`
 
-##### <a name="audit_selinux_policy"></a>`audit_selinux_policy`
+##### <a name="-auditd--config--audit_profiles--simp--audit_selinux_policy"></a>`audit_selinux_policy`
 
 Data type: `Boolean`
 
 Whether to audit selinux policy changes
 
-Default value: ``true``
+Default value: `true`
 
-##### <a name="audit_selinux_policy_tag"></a>`audit_selinux_policy_tag`
+##### <a name="-auditd--config--audit_profiles--simp--audit_selinux_policy_tag"></a>`audit_selinux_policy_tag`
 
 Data type: `String[1]`
 
@@ -1424,15 +1424,15 @@ The tag to identify selinux policy changes in an audit record
 
 Default value: `'MAC-policy'`
 
-##### <a name="audit_selinux_cmds"></a>`audit_selinux_cmds`
+##### <a name="-auditd--config--audit_profiles--simp--audit_selinux_cmds"></a>`audit_selinux_cmds`
 
 Data type: `Boolean`
 
 Whether to audit `chcon`, `semanage`, `setsebool`, and `setfiles` commands
 
-Default value: ``false``
+Default value: `false`
 
-##### <a name="audit_selinux_cmds_tag"></a>`audit_selinux_cmds_tag`
+##### <a name="-auditd--config--audit_profiles--simp--audit_selinux_cmds_tag"></a>`audit_selinux_cmds_tag`
 
 Data type: `String[1]`
 
@@ -1440,15 +1440,15 @@ The tag to identify selinux command execution in an audit record
 
 Default value: `'privileged-priv_change'`
 
-##### <a name="audit_login_files"></a>`audit_login_files`
+##### <a name="-auditd--config--audit_profiles--simp--audit_login_files"></a>`audit_login_files`
 
 Data type: `Boolean`
 
 Whether to audit changes to login files
 
-Default value: ``true``
+Default value: `true`
 
-##### <a name="audit_login_files_tag"></a>`audit_login_files_tag`
+##### <a name="-auditd--config--audit_profiles--simp--audit_login_files_tag"></a>`audit_login_files_tag`
 
 Data type: `String[1]`
 
@@ -1456,15 +1456,15 @@ The tag to identify login file changes in an audit record
 
 Default value: `'logins'`
 
-##### <a name="audit_session_files"></a>`audit_session_files`
+##### <a name="-auditd--config--audit_profiles--simp--audit_session_files"></a>`audit_session_files`
 
 Data type: `Boolean`
 
 Whether to audit changes to session files
 
-Default value: ``true``
+Default value: `true`
 
-##### <a name="audit_session_files_tag"></a>`audit_session_files_tag`
+##### <a name="-auditd--config--audit_profiles--simp--audit_session_files_tag"></a>`audit_session_files_tag`
 
 Data type: `String[1]`
 
@@ -1472,31 +1472,31 @@ The tag to identify session file changes in an audit record
 
 Default value: `'session'`
 
-##### <a name="audit_sudoers"></a>`audit_sudoers`
+##### <a name="-auditd--config--audit_profiles--simp--audit_sudoers"></a>`audit_sudoers`
 
 Data type: `Optional[Boolean]`
 
 Deprecated by `$audit_cfg_sudoers`
 
-Default value: ``undef``
+Default value: `undef`
 
-##### <a name="audit_sudoers_tag"></a>`audit_sudoers_tag`
+##### <a name="-auditd--config--audit_profiles--simp--audit_sudoers_tag"></a>`audit_sudoers_tag`
 
 Data type: `Optional[String[1]]`
 
 Deprecated by `$audit_cfg_sudoers_tag`
 
-Default value: ``undef``
+Default value: `undef`
 
-##### <a name="audit_cfg_sudoers"></a>`audit_cfg_sudoers`
+##### <a name="-auditd--config--audit_profiles--simp--audit_cfg_sudoers"></a>`audit_cfg_sudoers`
 
 Data type: `Boolean`
 
 Whether to audit changes to sudoers configuration files
 
-Default value: ``true``
+Default value: `true`
 
-##### <a name="audit_cfg_sudoers_tag"></a>`audit_cfg_sudoers_tag`
+##### <a name="-auditd--config--audit_profiles--simp--audit_cfg_sudoers_tag"></a>`audit_cfg_sudoers_tag`
 
 Data type: `String[1]`
 
@@ -1506,31 +1506,31 @@ automated DISA STIG compliance checks for RHEL7.
 
 Default value: `'CFG_sys'`
 
-##### <a name="audit_grub"></a>`audit_grub`
+##### <a name="-auditd--config--audit_profiles--simp--audit_grub"></a>`audit_grub`
 
 Data type: `Optional[Boolean]`
 
 Deprecated by `$audit_cfg_grub`
 
-Default value: ``undef``
+Default value: `undef`
 
-##### <a name="audit_grub_tag"></a>`audit_grub_tag`
+##### <a name="-auditd--config--audit_profiles--simp--audit_grub_tag"></a>`audit_grub_tag`
 
 Data type: `Optional[String[1]]`
 
 Deprecated by `$audit_cfg_grub_tag`
 
-Default value: ``undef``
+Default value: `undef`
 
-##### <a name="audit_cfg_grub"></a>`audit_cfg_grub`
+##### <a name="-auditd--config--audit_profiles--simp--audit_cfg_grub"></a>`audit_cfg_grub`
 
 Data type: `Boolean`
 
 Whether to audit changes to grub configuration files
 
-Default value: ``true``
+Default value: `true`
 
-##### <a name="audit_cfg_grub_tag"></a>`audit_cfg_grub_tag`
+##### <a name="-auditd--config--audit_profiles--simp--audit_cfg_grub_tag"></a>`audit_cfg_grub_tag`
 
 Data type: `String[1]`
 
@@ -1538,16 +1538,16 @@ The tag to identify grub configuration file changes in an audit record
 
 Default value: `'CFG_grub'`
 
-##### <a name="audit_cfg_sys"></a>`audit_cfg_sys`
+##### <a name="-auditd--config--audit_profiles--simp--audit_cfg_sys"></a>`audit_cfg_sys`
 
 Data type: `Boolean`
 
 Whether to audit changes to key system configuration files not
 otherwise audited
 
-Default value: ``true``
+Default value: `true`
 
-##### <a name="audit_cfg_sys_tag"></a>`audit_cfg_sys_tag`
+##### <a name="-auditd--config--audit_profiles--simp--audit_cfg_sys_tag"></a>`audit_cfg_sys_tag`
 
 Data type: `String[1]`
 
@@ -1556,15 +1556,15 @@ not otherwise audited
 
 Default value: `'CFG_sys'`
 
-##### <a name="audit_cfg_cron"></a>`audit_cfg_cron`
+##### <a name="-auditd--config--audit_profiles--simp--audit_cfg_cron"></a>`audit_cfg_cron`
 
 Data type: `Boolean`
 
 Whether to audit changes to cron configuration files
 
-Default value: ``true``
+Default value: `true`
 
-##### <a name="audit_cfg_cron_tag"></a>`audit_cfg_cron_tag`
+##### <a name="-auditd--config--audit_profiles--simp--audit_cfg_cron_tag"></a>`audit_cfg_cron_tag`
 
 Data type: `String[1]`
 
@@ -1573,15 +1573,15 @@ record
 
 Default value: `'CFG_cron'`
 
-##### <a name="audit_cfg_shell"></a>`audit_cfg_shell`
+##### <a name="-auditd--config--audit_profiles--simp--audit_cfg_shell"></a>`audit_cfg_shell`
 
 Data type: `Boolean`
 
 Whether to audit changes to global shell configuration files
 
-Default value: ``true``
+Default value: `true`
 
-##### <a name="audit_cfg_shell_tag"></a>`audit_cfg_shell_tag`
+##### <a name="-auditd--config--audit_profiles--simp--audit_cfg_shell_tag"></a>`audit_cfg_shell_tag`
 
 Data type: `String[1]`
 
@@ -1590,15 +1590,15 @@ audit record
 
 Default value: `'CFG_shell'`
 
-##### <a name="audit_cfg_pam"></a>`audit_cfg_pam`
+##### <a name="-auditd--config--audit_profiles--simp--audit_cfg_pam"></a>`audit_cfg_pam`
 
 Data type: `Boolean`
 
 Whether to audit changes to PAM configuration files
 
-Default value: ``true``
+Default value: `true`
 
-##### <a name="audit_cfg_pam_tag"></a>`audit_cfg_pam_tag`
+##### <a name="-auditd--config--audit_profiles--simp--audit_cfg_pam_tag"></a>`audit_cfg_pam_tag`
 
 Data type: `String[1]`
 
@@ -1606,15 +1606,15 @@ The tag to identify PAM configuration file changes in an audit record
 
 Default value: `'CFG_pam'`
 
-##### <a name="audit_cfg_security"></a>`audit_cfg_security`
+##### <a name="-auditd--config--audit_profiles--simp--audit_cfg_security"></a>`audit_cfg_security`
 
 Data type: `Boolean`
 
 Whether to audit changes to `/etc/security`
 
-Default value: ``true``
+Default value: `true`
 
-##### <a name="audit_cfg_security_tag"></a>`audit_cfg_security_tag`
+##### <a name="-auditd--config--audit_profiles--simp--audit_cfg_security_tag"></a>`audit_cfg_security_tag`
 
 Data type: `String[1]`
 
@@ -1622,15 +1622,15 @@ The tag to identify `/etc/security` file changes in an audit record
 
 Default value: `'CFG_security'`
 
-##### <a name="audit_cfg_services"></a>`audit_cfg_services`
+##### <a name="-auditd--config--audit_profiles--simp--audit_cfg_services"></a>`audit_cfg_services`
 
 Data type: `Boolean`
 
 Whether to audit changes to `/etc/services`
 
-Default value: ``true``
+Default value: `true`
 
-##### <a name="audit_cfg_services_tag"></a>`audit_cfg_services_tag`
+##### <a name="-auditd--config--audit_profiles--simp--audit_cfg_services_tag"></a>`audit_cfg_services_tag`
 
 Data type: `String[1]`
 
@@ -1638,15 +1638,15 @@ The tag to identify `/etc/services` file changes in an audit record
 
 Default value: `'CFG_services'`
 
-##### <a name="audit_cfg_xinetd"></a>`audit_cfg_xinetd`
+##### <a name="-auditd--config--audit_profiles--simp--audit_cfg_xinetd"></a>`audit_cfg_xinetd`
 
 Data type: `Boolean`
 
 Whether to audit changes to xinetd configuration files
 
-Default value: ``true``
+Default value: `true`
 
-##### <a name="audit_cfg_xinetd_tag"></a>`audit_cfg_xinetd_tag`
+##### <a name="-auditd--config--audit_profiles--simp--audit_cfg_xinetd_tag"></a>`audit_cfg_xinetd_tag`
 
 Data type: `String[1]`
 
@@ -1654,31 +1654,31 @@ The tag to identify xinetd configuration file changes in an audit record
 
 Default value: `'CFG_xinetd'`
 
-##### <a name="audit_yum"></a>`audit_yum`
+##### <a name="-auditd--config--audit_profiles--simp--audit_yum"></a>`audit_yum`
 
 Data type: `Optional[Boolean]`
 
 Deprecated by `$audit_cfg_yum`
 
-Default value: ``undef``
+Default value: `undef`
 
-##### <a name="audit_yum_tag"></a>`audit_yum_tag`
+##### <a name="-auditd--config--audit_profiles--simp--audit_yum_tag"></a>`audit_yum_tag`
 
 Data type: `Optional[String[1]]`
 
 Deprecated by `$audit_cfg_yum_tag`
 
-Default value: ``undef``
+Default value: `undef`
 
-##### <a name="audit_cfg_yum"></a>`audit_cfg_yum`
+##### <a name="-auditd--config--audit_profiles--simp--audit_cfg_yum"></a>`audit_cfg_yum`
 
 Data type: `Boolean`
 
 Whether to audit changes to yum configuration files
 
-Default value: ``true``
+Default value: `true`
 
-##### <a name="audit_cfg_yum_tag"></a>`audit_cfg_yum_tag`
+##### <a name="-auditd--config--audit_profiles--simp--audit_cfg_yum_tag"></a>`audit_cfg_yum_tag`
 
 Data type: `String[1]`
 
@@ -1686,15 +1686,15 @@ The tag to identify yum configuration file changes in an audit record
 
 Default value: `'yum-config'`
 
-##### <a name="audit_yum_cmd"></a>`audit_yum_cmd`
+##### <a name="-auditd--config--audit_profiles--simp--audit_yum_cmd"></a>`audit_yum_cmd`
 
 Data type: `Boolean`
 
 Whether to audit `yum` command execution
 
-Default value: ``false``
+Default value: `false`
 
-##### <a name="audit_yum_cmd_tag"></a>`audit_yum_cmd_tag`
+##### <a name="-auditd--config--audit_profiles--simp--audit_yum_cmd_tag"></a>`audit_yum_cmd_tag`
 
 Data type: `String[1]`
 
@@ -1702,15 +1702,15 @@ The tag to identify `yum` command execution in an audit record
 
 Default value: `'package_changes'`
 
-##### <a name="audit_rpm_cmd"></a>`audit_rpm_cmd`
+##### <a name="-auditd--config--audit_profiles--simp--audit_rpm_cmd"></a>`audit_rpm_cmd`
 
 Data type: `Boolean`
 
 Whether to audit `rpm` command execution
 
-Default value: ``false``
+Default value: `false`
 
-##### <a name="audit_rpm_cmd_tag"></a>`audit_rpm_cmd_tag`
+##### <a name="-auditd--config--audit_profiles--simp--audit_rpm_cmd_tag"></a>`audit_rpm_cmd_tag`
 
 Data type: `String[1]`
 
@@ -1718,15 +1718,15 @@ The tag to identify `rpm` command execution in an audit record
 
 Default value: `'package_changes'`
 
-##### <a name="audit_ptrace"></a>`audit_ptrace`
+##### <a name="-auditd--config--audit_profiles--simp--audit_ptrace"></a>`audit_ptrace`
 
 Data type: `Boolean`
 
 Whether to audit `ptrace` system calls
 
-Default value: ``true``
+Default value: `true`
 
-##### <a name="audit_ptrace_tag"></a>`audit_ptrace_tag`
+##### <a name="-auditd--config--audit_profiles--simp--audit_ptrace_tag"></a>`audit_ptrace_tag`
 
 Data type: `String[1]`
 
@@ -1734,15 +1734,15 @@ The tag to identify `ptrace` system calls in an audit record
 
 Default value: `'paranoid'`
 
-##### <a name="audit_personality"></a>`audit_personality`
+##### <a name="-auditd--config--audit_profiles--simp--audit_personality"></a>`audit_personality`
 
 Data type: `Boolean`
 
 Whether to audit `personality` system calls
 
-Default value: ``true``
+Default value: `true`
 
-##### <a name="audit_personality_tag"></a>`audit_personality_tag`
+##### <a name="-auditd--config--audit_profiles--simp--audit_personality_tag"></a>`audit_personality_tag`
 
 Data type: `String[1]`
 
@@ -1750,16 +1750,16 @@ The tag to identify `personality` system calls in an audit record
 
 Default value: `'paranoid'`
 
-##### <a name="audit_passwd_cmds"></a>`audit_passwd_cmds`
+##### <a name="-auditd--config--audit_profiles--simp--audit_passwd_cmds"></a>`audit_passwd_cmds`
 
 Data type: `Boolean`
 
 Whether to audit the execution of password commands, i.e., `passwd`,
 `unix_chkpwd`, `gpasswd`, `chage`, `userhelper`
 
-Default value: ``true``
+Default value: `true`
 
-##### <a name="audit_passwd_cmds_tag"></a>`audit_passwd_cmds_tag`
+##### <a name="-auditd--config--audit_profiles--simp--audit_passwd_cmds_tag"></a>`audit_passwd_cmds_tag`
 
 Data type: `String[1]`
 
@@ -1767,16 +1767,16 @@ The tag to identify password command execution in an audit record
 
 Default value: `'privileged-passwd'`
 
-##### <a name="audit_priv_cmds"></a>`audit_priv_cmds`
+##### <a name="-auditd--config--audit_profiles--simp--audit_priv_cmds"></a>`audit_priv_cmds`
 
 Data type: `Boolean`
 
 Whether to audit the execution of privilege-related commands, i.e.,
 `su`, `sudo`, `newgrp`, `chsh`, and `sudoedit`
 
-Default value: ``true``
+Default value: `true`
 
-##### <a name="audit_priv_cmds_tag"></a>`audit_priv_cmds_tag`
+##### <a name="-auditd--config--audit_profiles--simp--audit_priv_cmds_tag"></a>`audit_priv_cmds_tag`
 
 Data type: `String[1]`
 
@@ -1784,16 +1784,16 @@ The tag to identify privilege-related command execution in an audit record
 
 Default value: `'privileged-priv_change'`
 
-##### <a name="audit_postfix_cmds"></a>`audit_postfix_cmds`
+##### <a name="-auditd--config--audit_profiles--simp--audit_postfix_cmds"></a>`audit_postfix_cmds`
 
 Data type: `Boolean`
 
 Whether to audit the execution of postfix-related commands, i.e.
 `postdrop` and `postqueue`
 
-Default value: ``true``
+Default value: `true`
 
-##### <a name="audit_postfix_cmds_tag"></a>`audit_postfix_cmds_tag`
+##### <a name="-auditd--config--audit_profiles--simp--audit_postfix_cmds_tag"></a>`audit_postfix_cmds_tag`
 
 Data type: `String[1]`
 
@@ -1801,15 +1801,15 @@ The tag to identify postfix-related command execution in an audit record
 
 Default value: `'privileged-postfix'`
 
-##### <a name="audit_ssh_keysign_cmd"></a>`audit_ssh_keysign_cmd`
+##### <a name="-auditd--config--audit_profiles--simp--audit_ssh_keysign_cmd"></a>`audit_ssh_keysign_cmd`
 
 Data type: `Boolean`
 
 Whether to audit the execution of the `ssh-keysign` command
 
-Default value: ``true``
+Default value: `true`
 
-##### <a name="audit_ssh_keysign_cmd_tag"></a>`audit_ssh_keysign_cmd_tag`
+##### <a name="-auditd--config--audit_profiles--simp--audit_ssh_keysign_cmd_tag"></a>`audit_ssh_keysign_cmd_tag`
 
 Data type: `String[1]`
 
@@ -1817,15 +1817,15 @@ The tag to identify `ssh-keysign` command execution in an audit record
 
 Default value: `'privileged-ssh'`
 
-##### <a name="audit_suspicious_apps"></a>`audit_suspicious_apps`
+##### <a name="-auditd--config--audit_profiles--simp--audit_suspicious_apps"></a>`audit_suspicious_apps`
 
 Data type: `Boolean`
 
 Audit various applications that generally represent suspicious host activity
 
-Default value: ``true``
+Default value: `true`
 
-##### <a name="audit_suspicious_apps_tag"></a>`audit_suspicious_apps_tag`
+##### <a name="-auditd--config--audit_profiles--simp--audit_suspicious_apps_tag"></a>`audit_suspicious_apps_tag`
 
 Data type: `String[1]`
 
@@ -1833,13 +1833,13 @@ Tag to be added to entries triggered by `audit_suspicious_apps`
 
 Default value: `'suspicious_apps'`
 
-##### <a name="audit_suspicious_apps_list"></a>`audit_suspicious_apps_list`
+##### <a name="-auditd--config--audit_profiles--simp--audit_suspicious_apps_list"></a>`audit_suspicious_apps_list`
 
 Data type: `Array[Stdlib::Absolutepath]`
 
 List of applications to be audited when `audit_suspicious_apps` is enabled
 
-##### <a name="audit_systemd"></a>`audit_systemd`
+##### <a name="-auditd--config--audit_profiles--simp--audit_systemd"></a>`audit_systemd`
 
 Data type: `Boolean`
 
@@ -1847,9 +1847,9 @@ Audit systemd components
 
 * Only takes effect on systems with systemd present
 
-Default value: ``true``
+Default value: `true`
 
-##### <a name="audit_systemd_tag"></a>`audit_systemd_tag`
+##### <a name="-auditd--config--audit_profiles--simp--audit_systemd_tag"></a>`audit_systemd_tag`
 
 Data type: `String[1]`
 
@@ -1857,15 +1857,15 @@ Tag to be added to entries triggered by `audit_systemd`
 
 Default value: `'systemd'`
 
-##### <a name="audit_crontab_cmd"></a>`audit_crontab_cmd`
+##### <a name="-auditd--config--audit_profiles--simp--audit_crontab_cmd"></a>`audit_crontab_cmd`
 
 Data type: `Boolean`
 
 Whether to audit the execution of the `crontab` command
 
-Default value: ``true``
+Default value: `true`
 
-##### <a name="audit_crontab_cmd_tag"></a>`audit_crontab_cmd_tag`
+##### <a name="-auditd--config--audit_profiles--simp--audit_crontab_cmd_tag"></a>`audit_crontab_cmd_tag`
 
 Data type: `String[1]`
 
@@ -1873,15 +1873,15 @@ The tag to identify `crontab` command execution in an audit record
 
 Default value: `'privileged-cron'`
 
-##### <a name="audit_pam_timestamp_check_cmd"></a>`audit_pam_timestamp_check_cmd`
+##### <a name="-auditd--config--audit_profiles--simp--audit_pam_timestamp_check_cmd"></a>`audit_pam_timestamp_check_cmd`
 
 Data type: `Boolean`
 
 Whether to audit the execution of the `pam_timestamp_check` command
 
-Default value: ``true``
+Default value: `true`
 
-##### <a name="audit_pam_timestamp_check_cmd_tag"></a>`audit_pam_timestamp_check_cmd_tag`
+##### <a name="-auditd--config--audit_profiles--simp--audit_pam_timestamp_check_cmd_tag"></a>`audit_pam_timestamp_check_cmd_tag`
 
 Data type: `String[1]`
 
@@ -1890,7 +1890,7 @@ record
 
 Default value: `'privileged-pam'`
 
-### <a name="auditdconfigaudit_profilesstig"></a>`auditd::config::audit_profiles::stig`
+### <a name="auditd--config--audit_profiles--stig"></a>`auditd::config::audit_profiles::stig`
 
 The defaults for this profile generate a set of audit rules that conform to
 automated DISA STIG compliance checks for RHEL7. Satisfying the checks,
@@ -1912,49 +1912,49 @@ When auditd performance is an issue, you may wish to
 
 The following parameters are available in the `auditd::config::audit_profiles::stig` class:
 
-* [`uid_min`](#uid_min)
-* [`audit_unsuccessful_file_operations`](#audit_unsuccessful_file_operations)
-* [`audit_unsuccessful_file_operations_tag`](#audit_unsuccessful_file_operations_tag)
-* [`audit_chown`](#audit_chown)
-* [`audit_chown_tag`](#audit_chown_tag)
-* [`audit_chmod`](#audit_chmod)
-* [`audit_chmod_tag`](#audit_chmod_tag)
-* [`audit_attr`](#audit_attr)
-* [`audit_attr_tag`](#audit_attr_tag)
-* [`audit_rename_remove`](#audit_rename_remove)
-* [`audit_rename_remove_tag`](#audit_rename_remove_tag)
-* [`audit_suid_sgid`](#audit_suid_sgid)
-* [`default_suid_sgid_cmds`](#default_suid_sgid_cmds)
-* [`suid_sgid_cmds`](#suid_sgid_cmds)
-* [`audit_suid_tag`](#audit_suid_tag)
-* [`audit_sgid_tag`](#audit_sgid_tag)
-* [`audit_suid_sgid_tag`](#audit_suid_sgid_tag)
-* [`audit_kernel_modules`](#audit_kernel_modules)
-* [`audit_kernel_modules_tag`](#audit_kernel_modules_tag)
-* [`audit_mount`](#audit_mount)
-* [`audit_mount_tag`](#audit_mount_tag)
-* [`audit_local_account`](#audit_local_account)
-* [`audit_local_account_tag`](#audit_local_account_tag)
-* [`audit_selinux_cmds`](#audit_selinux_cmds)
-* [`audit_selinux_cmds_tag`](#audit_selinux_cmds_tag)
-* [`audit_login_files`](#audit_login_files)
-* [`audit_login_files_tag`](#audit_login_files_tag)
-* [`audit_cfg_sudoers`](#audit_cfg_sudoers)
-* [`audit_cfg_sudoers_tag`](#audit_cfg_sudoers_tag)
-* [`audit_passwd_cmds`](#audit_passwd_cmds)
-* [`audit_passwd_cmds_tag`](#audit_passwd_cmds_tag)
-* [`audit_priv_cmds`](#audit_priv_cmds)
-* [`audit_priv_cmds_tag`](#audit_priv_cmds_tag)
-* [`audit_postfix_cmds`](#audit_postfix_cmds)
-* [`audit_postfix_cmds_tag`](#audit_postfix_cmds_tag)
-* [`audit_ssh_keysign_cmd`](#audit_ssh_keysign_cmd)
-* [`audit_ssh_keysign_cmd_tag`](#audit_ssh_keysign_cmd_tag)
-* [`audit_crontab_cmd`](#audit_crontab_cmd)
-* [`audit_crontab_cmd_tag`](#audit_crontab_cmd_tag)
-* [`audit_pam_timestamp_check_cmd`](#audit_pam_timestamp_check_cmd)
-* [`audit_pam_timestamp_check_cmd_tag`](#audit_pam_timestamp_check_cmd_tag)
+* [`uid_min`](#-auditd--config--audit_profiles--stig--uid_min)
+* [`audit_unsuccessful_file_operations`](#-auditd--config--audit_profiles--stig--audit_unsuccessful_file_operations)
+* [`audit_unsuccessful_file_operations_tag`](#-auditd--config--audit_profiles--stig--audit_unsuccessful_file_operations_tag)
+* [`audit_chown`](#-auditd--config--audit_profiles--stig--audit_chown)
+* [`audit_chown_tag`](#-auditd--config--audit_profiles--stig--audit_chown_tag)
+* [`audit_chmod`](#-auditd--config--audit_profiles--stig--audit_chmod)
+* [`audit_chmod_tag`](#-auditd--config--audit_profiles--stig--audit_chmod_tag)
+* [`audit_attr`](#-auditd--config--audit_profiles--stig--audit_attr)
+* [`audit_attr_tag`](#-auditd--config--audit_profiles--stig--audit_attr_tag)
+* [`audit_rename_remove`](#-auditd--config--audit_profiles--stig--audit_rename_remove)
+* [`audit_rename_remove_tag`](#-auditd--config--audit_profiles--stig--audit_rename_remove_tag)
+* [`audit_suid_sgid`](#-auditd--config--audit_profiles--stig--audit_suid_sgid)
+* [`default_suid_sgid_cmds`](#-auditd--config--audit_profiles--stig--default_suid_sgid_cmds)
+* [`suid_sgid_cmds`](#-auditd--config--audit_profiles--stig--suid_sgid_cmds)
+* [`audit_suid_tag`](#-auditd--config--audit_profiles--stig--audit_suid_tag)
+* [`audit_sgid_tag`](#-auditd--config--audit_profiles--stig--audit_sgid_tag)
+* [`audit_suid_sgid_tag`](#-auditd--config--audit_profiles--stig--audit_suid_sgid_tag)
+* [`audit_kernel_modules`](#-auditd--config--audit_profiles--stig--audit_kernel_modules)
+* [`audit_kernel_modules_tag`](#-auditd--config--audit_profiles--stig--audit_kernel_modules_tag)
+* [`audit_mount`](#-auditd--config--audit_profiles--stig--audit_mount)
+* [`audit_mount_tag`](#-auditd--config--audit_profiles--stig--audit_mount_tag)
+* [`audit_local_account`](#-auditd--config--audit_profiles--stig--audit_local_account)
+* [`audit_local_account_tag`](#-auditd--config--audit_profiles--stig--audit_local_account_tag)
+* [`audit_selinux_cmds`](#-auditd--config--audit_profiles--stig--audit_selinux_cmds)
+* [`audit_selinux_cmds_tag`](#-auditd--config--audit_profiles--stig--audit_selinux_cmds_tag)
+* [`audit_login_files`](#-auditd--config--audit_profiles--stig--audit_login_files)
+* [`audit_login_files_tag`](#-auditd--config--audit_profiles--stig--audit_login_files_tag)
+* [`audit_cfg_sudoers`](#-auditd--config--audit_profiles--stig--audit_cfg_sudoers)
+* [`audit_cfg_sudoers_tag`](#-auditd--config--audit_profiles--stig--audit_cfg_sudoers_tag)
+* [`audit_passwd_cmds`](#-auditd--config--audit_profiles--stig--audit_passwd_cmds)
+* [`audit_passwd_cmds_tag`](#-auditd--config--audit_profiles--stig--audit_passwd_cmds_tag)
+* [`audit_priv_cmds`](#-auditd--config--audit_profiles--stig--audit_priv_cmds)
+* [`audit_priv_cmds_tag`](#-auditd--config--audit_profiles--stig--audit_priv_cmds_tag)
+* [`audit_postfix_cmds`](#-auditd--config--audit_profiles--stig--audit_postfix_cmds)
+* [`audit_postfix_cmds_tag`](#-auditd--config--audit_profiles--stig--audit_postfix_cmds_tag)
+* [`audit_ssh_keysign_cmd`](#-auditd--config--audit_profiles--stig--audit_ssh_keysign_cmd)
+* [`audit_ssh_keysign_cmd_tag`](#-auditd--config--audit_profiles--stig--audit_ssh_keysign_cmd_tag)
+* [`audit_crontab_cmd`](#-auditd--config--audit_profiles--stig--audit_crontab_cmd)
+* [`audit_crontab_cmd_tag`](#-auditd--config--audit_profiles--stig--audit_crontab_cmd_tag)
+* [`audit_pam_timestamp_check_cmd`](#-auditd--config--audit_profiles--stig--audit_pam_timestamp_check_cmd)
+* [`audit_pam_timestamp_check_cmd_tag`](#-auditd--config--audit_profiles--stig--audit_pam_timestamp_check_cmd_tag)
 
-##### <a name="uid_min"></a>`uid_min`
+##### <a name="-auditd--config--audit_profiles--stig--uid_min"></a>`uid_min`
 
 Data type: `Integer[0]`
 
@@ -1966,16 +1966,16 @@ parameter to be 'first'.
 
 Default value: `$::auditd::uid_min`
 
-##### <a name="audit_unsuccessful_file_operations"></a>`audit_unsuccessful_file_operations`
+##### <a name="-auditd--config--audit_profiles--stig--audit_unsuccessful_file_operations"></a>`audit_unsuccessful_file_operations`
 
 Data type: `Boolean`
 
 Whether to audit unsuccessful file operations.  These are file operations
 that fail with EACCES or EPERM error codes
 
-Default value: ``true``
+Default value: `true`
 
-##### <a name="audit_unsuccessful_file_operations_tag"></a>`audit_unsuccessful_file_operations_tag`
+##### <a name="-auditd--config--audit_profiles--stig--audit_unsuccessful_file_operations_tag"></a>`audit_unsuccessful_file_operations_tag`
 
 Data type: `String[1]`
 
@@ -1983,7 +1983,7 @@ The tag to identify the unsuccessful file operations in an audit record
 
 Default value: `'access'`
 
-##### <a name="audit_chown"></a>`audit_chown`
+##### <a name="-auditd--config--audit_profiles--stig--audit_chown"></a>`audit_chown`
 
 Data type: `Boolean`
 
@@ -1991,9 +1991,9 @@ Whether to audit `chown` operations for all non-service users.
 These operations are provided by `chown`, `fchown`, `fchownat`,
 and `lchown` system calls.
 
-Default value: ``true``
+Default value: `true`
 
-##### <a name="audit_chown_tag"></a>`audit_chown_tag`
+##### <a name="-auditd--config--audit_profiles--stig--audit_chown_tag"></a>`audit_chown_tag`
 
 Data type: `String[1]`
 
@@ -2001,7 +2001,7 @@ The tag to identify `chown` operations in an audit record
 
 Default value: `'perm_mod'`
 
-##### <a name="audit_chmod"></a>`audit_chmod`
+##### <a name="-auditd--config--audit_profiles--stig--audit_chmod"></a>`audit_chmod`
 
 Data type: `Boolean`
 
@@ -2009,9 +2009,9 @@ Whether to audit `chmod` operations for all non-service users.
 These operations are provided by `chmod`, `fchmod`, and `fchmodat`
 system calls.
 
-Default value: ``true``
+Default value: `true`
 
-##### <a name="audit_chmod_tag"></a>`audit_chmod_tag`
+##### <a name="-auditd--config--audit_profiles--stig--audit_chmod_tag"></a>`audit_chmod_tag`
 
 Data type: `String[1]`
 
@@ -2019,7 +2019,7 @@ The tag to identify `chmod` operations in an audit record
 
 Default value: `'perm_mod'`
 
-##### <a name="audit_attr"></a>`audit_attr`
+##### <a name="-auditd--config--audit_profiles--stig--audit_attr"></a>`audit_attr`
 
 Data type: `Boolean`
 
@@ -2027,9 +2027,9 @@ Whether to audit `xattr` operations for all non-service users.
 These operations are provided by `setxattr`, `lsetxattr`, `fsetxattr`,
 `removexattr`, `lremovexattr` and `fremovexattr` system calls.
 
-Default value: ``true``
+Default value: `true`
 
-##### <a name="audit_attr_tag"></a>`audit_attr_tag`
+##### <a name="-auditd--config--audit_profiles--stig--audit_attr_tag"></a>`audit_attr_tag`
 
 Data type: `String[1]`
 
@@ -2037,7 +2037,7 @@ The tag to identify `xattr` operations in an audit record
 
 Default value: `'perm_mod'`
 
-##### <a name="audit_rename_remove"></a>`audit_rename_remove`
+##### <a name="-auditd--config--audit_profiles--stig--audit_rename_remove"></a>`audit_rename_remove`
 
 Data type: `Boolean`
 
@@ -2045,9 +2045,9 @@ Whether to audit rename/remove operations for all non-service users.
 These operations are provided by `rename`, `renameat`, `rmdir`,
 `unlink`, and `unlinkat` system calls.
 
-Default value: ``true``
+Default value: `true`
 
-##### <a name="audit_rename_remove_tag"></a>`audit_rename_remove_tag`
+##### <a name="-auditd--config--audit_profiles--stig--audit_rename_remove_tag"></a>`audit_rename_remove_tag`
 
 Data type: `String[1]`
 
@@ -2055,22 +2055,22 @@ The tag to identify rename/remove operations in an audit record
 
 Default value: `'delete'`
 
-##### <a name="audit_suid_sgid"></a>`audit_suid_sgid`
+##### <a name="-auditd--config--audit_profiles--stig--audit_suid_sgid"></a>`audit_suid_sgid`
 
 Data type: `Boolean`
 
 Whether to audit `setuid`/`setgid` commands
 
-Default value: ``true``
+Default value: `true`
 
-##### <a name="default_suid_sgid_cmds"></a>`default_suid_sgid_cmds`
+##### <a name="-auditd--config--audit_profiles--stig--default_suid_sgid_cmds"></a>`default_suid_sgid_cmds`
 
 Data type: `Array[String[1]]`
 
 The default list of `setuid`/`setgid` commands to be audited.
 * Should not include commands audited by other rules.
 
-##### <a name="suid_sgid_cmds"></a>`suid_sgid_cmds`
+##### <a name="-auditd--config--audit_profiles--stig--suid_sgid_cmds"></a>`suid_sgid_cmds`
 
 Data type: `Array[String[1]]`
 
@@ -2080,7 +2080,7 @@ per your site's needs.
 
 Default value: `[]`
 
-##### <a name="audit_suid_tag"></a>`audit_suid_tag`
+##### <a name="-auditd--config--audit_profiles--stig--audit_suid_tag"></a>`audit_suid_tag`
 
 Data type: `String[1]`
 
@@ -2088,7 +2088,7 @@ The tag to identify `setuid` command execution in an audit record
 
 Default value: `'setuid'`
 
-##### <a name="audit_sgid_tag"></a>`audit_sgid_tag`
+##### <a name="-auditd--config--audit_profiles--stig--audit_sgid_tag"></a>`audit_sgid_tag`
 
 Data type: `String[1]`
 
@@ -2096,7 +2096,7 @@ The tag to identify `setgid` command execution in an audit record
 
 Default value: `'setgid'`
 
-##### <a name="audit_suid_sgid_tag"></a>`audit_suid_sgid_tag`
+##### <a name="-auditd--config--audit_profiles--stig--audit_suid_sgid_tag"></a>`audit_suid_sgid_tag`
 
 Data type: `String[1]`
 
@@ -2104,15 +2104,15 @@ The tag to identify `setuid`/`setgid` command execution in an audit record
 
 Default value: `"${audit_suid_tag}/${audit_sgid_tag}"`
 
-##### <a name="audit_kernel_modules"></a>`audit_kernel_modules`
+##### <a name="-auditd--config--audit_profiles--stig--audit_kernel_modules"></a>`audit_kernel_modules`
 
 Data type: `Boolean`
 
 Whether to audit kernel module operations
 
-Default value: ``true``
+Default value: `true`
 
-##### <a name="audit_kernel_modules_tag"></a>`audit_kernel_modules_tag`
+##### <a name="-auditd--config--audit_profiles--stig--audit_kernel_modules_tag"></a>`audit_kernel_modules_tag`
 
 Data type: `String[1]`
 
@@ -2120,15 +2120,15 @@ The tag to identify kernel module operations in an audit record
 
 Default value: `'module-change'`
 
-##### <a name="audit_mount"></a>`audit_mount`
+##### <a name="-auditd--config--audit_profiles--stig--audit_mount"></a>`audit_mount`
 
 Data type: `Boolean`
 
 Whether to audit mount operations
 
-Default value: ``true``
+Default value: `true`
 
-##### <a name="audit_mount_tag"></a>`audit_mount_tag`
+##### <a name="-auditd--config--audit_profiles--stig--audit_mount_tag"></a>`audit_mount_tag`
 
 Data type: `String[1]`
 
@@ -2136,15 +2136,15 @@ The tag to identify mount operations in an audit record
 
 Default value: `'privileged-mount'`
 
-##### <a name="audit_local_account"></a>`audit_local_account`
+##### <a name="-auditd--config--audit_profiles--stig--audit_local_account"></a>`audit_local_account`
 
 Data type: `Boolean`
 
 Whether to audit local account changes
 
-Default value: ``true``
+Default value: `true`
 
-##### <a name="audit_local_account_tag"></a>`audit_local_account_tag`
+##### <a name="-auditd--config--audit_profiles--stig--audit_local_account_tag"></a>`audit_local_account_tag`
 
 Data type: `String[1]`
 
@@ -2152,15 +2152,15 @@ The tag to identify local account changes in an audit record
 
 Default value: `'identity'`
 
-##### <a name="audit_selinux_cmds"></a>`audit_selinux_cmds`
+##### <a name="-auditd--config--audit_profiles--stig--audit_selinux_cmds"></a>`audit_selinux_cmds`
 
 Data type: `Boolean`
 
 Whether to audit `chcon`, `semanage`, `setsebool`, and `setfiles` commands
 
-Default value: ``true``
+Default value: `true`
 
-##### <a name="audit_selinux_cmds_tag"></a>`audit_selinux_cmds_tag`
+##### <a name="-auditd--config--audit_profiles--stig--audit_selinux_cmds_tag"></a>`audit_selinux_cmds_tag`
 
 Data type: `String[1]`
 
@@ -2168,15 +2168,15 @@ The tag to identify selinux command execution in an audit record
 
 Default value: `'privileged-priv_change'`
 
-##### <a name="audit_login_files"></a>`audit_login_files`
+##### <a name="-auditd--config--audit_profiles--stig--audit_login_files"></a>`audit_login_files`
 
 Data type: `Boolean`
 
 Whether to audit changes to login files
 
-Default value: ``true``
+Default value: `true`
 
-##### <a name="audit_login_files_tag"></a>`audit_login_files_tag`
+##### <a name="-auditd--config--audit_profiles--stig--audit_login_files_tag"></a>`audit_login_files_tag`
 
 Data type: `String[1]`
 
@@ -2184,15 +2184,15 @@ The tag to identify login file changes in an audit record
 
 Default value: `'logins'`
 
-##### <a name="audit_cfg_sudoers"></a>`audit_cfg_sudoers`
+##### <a name="-auditd--config--audit_profiles--stig--audit_cfg_sudoers"></a>`audit_cfg_sudoers`
 
 Data type: `Boolean`
 
 Whether to audit changes to sudoers configuration files
 
-Default value: ``true``
+Default value: `true`
 
-##### <a name="audit_cfg_sudoers_tag"></a>`audit_cfg_sudoers_tag`
+##### <a name="-auditd--config--audit_profiles--stig--audit_cfg_sudoers_tag"></a>`audit_cfg_sudoers_tag`
 
 Data type: `String[1]`
 
@@ -2200,16 +2200,16 @@ The tag to identify sudoers configuration file changes in an audit record
 
 Default value: `'privileged-actions'`
 
-##### <a name="audit_passwd_cmds"></a>`audit_passwd_cmds`
+##### <a name="-auditd--config--audit_profiles--stig--audit_passwd_cmds"></a>`audit_passwd_cmds`
 
 Data type: `Boolean`
 
 Whether to audit the execution of password commands, i.e., `passwd`,
 `unix_chkpwd`, `gpasswd`, `chage`, `userhelper`
 
-Default value: ``true``
+Default value: `true`
 
-##### <a name="audit_passwd_cmds_tag"></a>`audit_passwd_cmds_tag`
+##### <a name="-auditd--config--audit_profiles--stig--audit_passwd_cmds_tag"></a>`audit_passwd_cmds_tag`
 
 Data type: `String[1]`
 
@@ -2217,16 +2217,16 @@ The tag to identify password command execution in an audit record
 
 Default value: `'privileged-passwd'`
 
-##### <a name="audit_priv_cmds"></a>`audit_priv_cmds`
+##### <a name="-auditd--config--audit_profiles--stig--audit_priv_cmds"></a>`audit_priv_cmds`
 
 Data type: `Boolean`
 
 Whether to audit the execution of privilege-related commands, i.e.,
 `su`, `sudo`, `newgrp`, `chsh`, and `sudoedit`
 
-Default value: ``true``
+Default value: `true`
 
-##### <a name="audit_priv_cmds_tag"></a>`audit_priv_cmds_tag`
+##### <a name="-auditd--config--audit_profiles--stig--audit_priv_cmds_tag"></a>`audit_priv_cmds_tag`
 
 Data type: `String[1]`
 
@@ -2234,16 +2234,16 @@ The tag to identify privilege-related command execution in an audit record
 
 Default value: `'privileged-priv_change'`
 
-##### <a name="audit_postfix_cmds"></a>`audit_postfix_cmds`
+##### <a name="-auditd--config--audit_profiles--stig--audit_postfix_cmds"></a>`audit_postfix_cmds`
 
 Data type: `Boolean`
 
 Whether to audit the execution of postfix-related commands, i.e.
 `postdrop` and `postqueue`
 
-Default value: ``true``
+Default value: `true`
 
-##### <a name="audit_postfix_cmds_tag"></a>`audit_postfix_cmds_tag`
+##### <a name="-auditd--config--audit_profiles--stig--audit_postfix_cmds_tag"></a>`audit_postfix_cmds_tag`
 
 Data type: `String[1]`
 
@@ -2251,15 +2251,15 @@ The tag to identify postfix-related command execution in an audit record
 
 Default value: `'privileged-postfix'`
 
-##### <a name="audit_ssh_keysign_cmd"></a>`audit_ssh_keysign_cmd`
+##### <a name="-auditd--config--audit_profiles--stig--audit_ssh_keysign_cmd"></a>`audit_ssh_keysign_cmd`
 
 Data type: `Boolean`
 
 Whether to audit the execution of the `ssh-keysign` command
 
-Default value: ``true``
+Default value: `true`
 
-##### <a name="audit_ssh_keysign_cmd_tag"></a>`audit_ssh_keysign_cmd_tag`
+##### <a name="-auditd--config--audit_profiles--stig--audit_ssh_keysign_cmd_tag"></a>`audit_ssh_keysign_cmd_tag`
 
 Data type: `String[1]`
 
@@ -2267,15 +2267,15 @@ The tag to identify `ssh-keysign` command execution in an audit record
 
 Default value: `'privileged-ssh'`
 
-##### <a name="audit_crontab_cmd"></a>`audit_crontab_cmd`
+##### <a name="-auditd--config--audit_profiles--stig--audit_crontab_cmd"></a>`audit_crontab_cmd`
 
 Data type: `Boolean`
 
 Whether to audit the execution of the `crontab` command
 
-Default value: ``true``
+Default value: `true`
 
-##### <a name="audit_crontab_cmd_tag"></a>`audit_crontab_cmd_tag`
+##### <a name="-auditd--config--audit_profiles--stig--audit_crontab_cmd_tag"></a>`audit_crontab_cmd_tag`
 
 Data type: `String[1]`
 
@@ -2283,15 +2283,15 @@ The tag to identify `crontab` command execution in an audit record
 
 Default value: `'privileged-cron'`
 
-##### <a name="audit_pam_timestamp_check_cmd"></a>`audit_pam_timestamp_check_cmd`
+##### <a name="-auditd--config--audit_profiles--stig--audit_pam_timestamp_check_cmd"></a>`audit_pam_timestamp_check_cmd`
 
 Data type: `Boolean`
 
 Whether to audit the execution of the `pam_timestamp_check` command
 
-Default value: ``true``
+Default value: `true`
 
-##### <a name="audit_pam_timestamp_check_cmd_tag"></a>`audit_pam_timestamp_check_cmd_tag`
+##### <a name="-auditd--config--audit_profiles--stig--audit_pam_timestamp_check_cmd_tag"></a>`audit_pam_timestamp_check_cmd_tag`
 
 Data type: `String[1]`
 
@@ -2300,7 +2300,7 @@ record
 
 Default value: `'privileged-pam'`
 
-### <a name="auditdconfiggrub"></a>`auditd::config::grub`
+### <a name="auditd--config--grub"></a>`auditd::config::grub`
 
 Enables/disables auditing at boot time.
 
@@ -2308,25 +2308,25 @@ Enables/disables auditing at boot time.
 
 The following parameters are available in the `auditd::config::grub` class:
 
-* [`enable`](#enable)
+* [`enable`](#-auditd--config--grub--enable)
 
-##### <a name="enable"></a>`enable`
+##### <a name="-auditd--config--grub--enable"></a>`enable`
 
 Data type: `Boolean`
 
 Enable auditing in the kernel at boot time.
 
-Default value: ``true``
+Default value: `true`
 
-### <a name="auditdconfiglogging"></a>`auditd::config::logging`
-
-NOTE: THIS IS A [PRIVATE](https://github.com/puppetlabs/puppetlabs-stdlib#assert_private) CLASS**
-
-### <a name="auditdinstall"></a>`auditd::install`
+### <a name="auditd--config--logging"></a>`auditd::config::logging`
 
 NOTE: THIS IS A [PRIVATE](https://github.com/puppetlabs/puppetlabs-stdlib#assert_private) CLASS**
 
-### <a name="auditdservice"></a>`auditd::service`
+### <a name="auditd--install"></a>`auditd::install`
+
+NOTE: THIS IS A [PRIVATE](https://github.com/puppetlabs/puppetlabs-stdlib#assert_private) CLASS**
+
+### <a name="auditd--service"></a>`auditd::service`
 
 NOTE: THIS IS A [PRIVATE](https://github.com/puppetlabs/puppetlabs-stdlib#assert_private) CLASS**
 
@@ -2334,12 +2334,12 @@ NOTE: THIS IS A [PRIVATE](https://github.com/puppetlabs/puppetlabs-stdlib#assert
 
 The following parameters are available in the `auditd::service` class:
 
-* [`ensure`](#ensure)
-* [`enable`](#enable)
-* [`bypass_kernel_check`](#bypass_kernel_check)
-* [`warn_if_reboot_required`](#warn_if_reboot_required)
+* [`ensure`](#-auditd--service--ensure)
+* [`enable`](#-auditd--service--enable)
+* [`bypass_kernel_check`](#-auditd--service--bypass_kernel_check)
+* [`warn_if_reboot_required`](#-auditd--service--warn_if_reboot_required)
 
-##### <a name="ensure"></a>`ensure`
+##### <a name="-auditd--service--ensure"></a>`ensure`
 
 Data type: `Variant[String[1],Boolean]`
 
@@ -2347,7 +2347,7 @@ Data type: `Variant[String[1],Boolean]`
 
 Default value: `pick(getvar('auditd::enable'), 'running')`
 
-##### <a name="enable"></a>`enable`
+##### <a name="-auditd--service--enable"></a>`enable`
 
 Data type: `Boolean`
 
@@ -2355,7 +2355,7 @@ Data type: `Boolean`
 
 Default value: `pick(getvar('auditd::enable'), true)`
 
-##### <a name="bypass_kernel_check"></a>`bypass_kernel_check`
+##### <a name="-auditd--service--bypass_kernel_check"></a>`bypass_kernel_check`
 
 Data type: `Boolean`
 
@@ -2365,20 +2365,20 @@ manage the service.
 * This may be required if auditing is not being actively managed in the
   kernel and someone has stopped the auditd service by hand.
 
-Default value: ``false``
+Default value: `false`
 
-##### <a name="warn_if_reboot_required"></a>`warn_if_reboot_required`
+##### <a name="-auditd--service--warn_if_reboot_required"></a>`warn_if_reboot_required`
 
 Data type: `Boolean`
 
 Add a ``reboot_notify`` warning if the system requires a reboot before the
 service can be managed.
 
-Default value: ``true``
+Default value: `true`
 
 ## Defined types
 
-### <a name="auditdrule"></a>`auditd::rule`
+### <a name="auditd--rule"></a>`auditd::rule`
 
 All rules must be uniquely named.  See ``auditctl(8)`` for more information
 on how to write the content for these rules.
@@ -2389,18 +2389,18 @@ on how to write the content for these rules.
 
 The following parameters are available in the `auditd::rule` defined type:
 
-* [`name`](#name)
-* [`content`](#content)
-* [`order`](#order)
-* [`first`](#first)
-* [`absolute`](#absolute)
-* [`prepend`](#prepend)
+* [`name`](#-auditd--rule--name)
+* [`content`](#-auditd--rule--content)
+* [`order`](#-auditd--rule--order)
+* [`first`](#-auditd--rule--first)
+* [`absolute`](#-auditd--rule--absolute)
+* [`prepend`](#-auditd--rule--prepend)
 
-##### <a name="name"></a>`name`
+##### <a name="-auditd--rule--name"></a>`name`
 
 A unique identifier for the audit rules.
 
-##### <a name="content"></a>`content`
+##### <a name="-auditd--rule--content"></a>`content`
 
 Data type: `Variant[Array[String[1]],String[1]]`
 
@@ -2408,42 +2408,42 @@ The content of the rules that should be added.
 
 * Arrays will be joined with a newline
 
-##### <a name="order"></a>`order`
+##### <a name="-auditd--rule--order"></a>`order`
 
 Data type: `Optional[String[1]]`
 
 An alphanumeric (file system ordering) order string
 
-Default value: ``undef``
+Default value: `undef`
 
-##### <a name="first"></a>`first`
+##### <a name="-auditd--rule--first"></a>`first`
 
 Data type: `Boolean`
 
 Set this to 'true' if you want to prepend your custom rules (numeric 10)
 
-Default value: ``false``
+Default value: `false`
 
-##### <a name="absolute"></a>`absolute`
+##### <a name="-auditd--rule--absolute"></a>`absolute`
 
 Data type: `Boolean`
 
 Set this to ``true`` if you want the added rules to be absolutely first or
 last depending on the setting of ``$first``.
 
-Default value: ``false``
+Default value: `false`
 
-##### <a name="prepend"></a>`prepend`
+##### <a name="-auditd--rule--prepend"></a>`prepend`
 
 Data type: `Boolean`
 
 Prepend this rule to all other rules (numeric 00).
 
-Default value: ``false``
+Default value: `false`
 
 ## Functions
 
-### <a name="auditdcalculate_space_left"></a>`auditd::calculate_space_left`
+### <a name="auditd--calculate_space_left"></a>`auditd::calculate_space_left`
 
 Type: Puppet Language
 
@@ -2461,7 +2461,7 @@ Data type: `Variant[Integer[0],Pattern['^\d+%$']]`
 
 
 
-### <a name="auditdget_array_index"></a>`auditd::get_array_index`
+### <a name="auditd--get_array_index"></a>`auditd::get_array_index`
 
 Type: Ruby 4.x API
 
@@ -2499,7 +2499,7 @@ Data type: `Optional[Integer]`
 The minimum number of digits the index should be. 
 It will be '0'-padded to meet this number.
 
-### <a name="auditdvalidate_init_params"></a>`auditd::validate_init_params`
+### <a name="auditd--validate_init_params"></a>`auditd::validate_init_params`
 
 Type: Puppet Language
 
@@ -2517,123 +2517,75 @@ Returns: `None`
 
 ## Data types
 
-### <a name="auditdauditprofile"></a>`Auditd::AuditProfile`
+### <a name="Auditd--AuditProfile"></a>`Auditd::AuditProfile`
 
 Matches the types of auditd profiles allowed
 
-Alias of
+Alias of `Enum['built_in', 'simp', 'stig', 'custom']`
 
-```puppet
-Enum['built_in', 'simp', 'stig', 'custom']
-```
-
-### <a name="auditddiskerroraction"></a>`Auditd::DiskErrorAction`
+### <a name="Auditd--DiskErrorAction"></a>`Auditd::DiskErrorAction`
 
 Matches disk error actions in auditd.conf
 
-Alias of
+Alias of `Enum['IGNORE', 'SYSLOG', 'EXEC', 'SUSPEND', 'SINGLE', 'HALT', 'ignore', 'syslog', 'exec', 'suspend', 'single', 'halt']`
 
-```puppet
-Enum['IGNORE', 'SYSLOG', 'EXEC', 'SUSPEND', 'SINGLE', 'HALT', 'ignore', 'syslog', 'exec', 'suspend', 'single', 'halt']
-```
-
-### <a name="auditddiskfullaction"></a>`Auditd::DiskFullAction`
+### <a name="Auditd--DiskFullAction"></a>`Auditd::DiskFullAction`
 
 Matches actions to take when disk is full (see auditd.conf)
 
-Alias of
+Alias of `Enum['IGNORE', 'SYSLOG', 'ROTATE', 'EXEC', 'SUSPEND', 'SINGLE', 'HALT', 'ignore', 'syslog', 'rotate', 'exec', 'suspend', 'single', 'halt']`
 
-```puppet
-Enum['IGNORE', 'SYSLOG', 'ROTATE', 'EXEC', 'SUSPEND', 'SINGLE', 'HALT', 'ignore', 'syslog', 'rotate', 'exec', 'suspend', 'single', 'halt']
-```
-
-### <a name="auditdflush"></a>`Auditd::Flush`
+### <a name="Auditd--Flush"></a>`Auditd::Flush`
 
 Matches actions flush in auditd.conf
 
-Alias of
+Alias of `Enum['NONE', 'INCREMENTAL', 'DATA', 'SYNC', 'INCREMENTAL_ASYNC', 'none', 'incremental', 'data', 'sync', 'incremental_async']`
 
-```puppet
-Enum['NONE', 'INCREMENTAL', 'DATA', 'SYNC', 'INCREMENTAL_ASYNC', 'none', 'incremental', 'data', 'sync', 'incremental_async']
-```
-
-### <a name="auditdlogfacility"></a>`Auditd::LogFacility`
+### <a name="Auditd--LogFacility"></a>`Auditd::LogFacility`
 
 Matches log facility that can be used in syslog.conf plugin
 
-Alias of
+Alias of `Enum['', 'LOG_LOCAL0', 'LOG_LOCAL1', 'LOG_LOCAL2', 'LOG_LOCAL3', 'LOG_LOCAL4', 'LOG_LOCAL5', 'LOG_LOCAL6', 'LOG_LOCAL7']`
 
-```puppet
-Enum['', 'LOG_LOCAL0', 'LOG_LOCAL1', 'LOG_LOCAL2', 'LOG_LOCAL3', 'LOG_LOCAL4', 'LOG_LOCAL5', 'LOG_LOCAL6', 'LOG_LOCAL7']
-```
-
-### <a name="auditdlogformat"></a>`Auditd::LogFormat`
+### <a name="Auditd--LogFormat"></a>`Auditd::LogFormat`
 
 Matches log formats that can be used in auditd.conf
 
-Alias of
+Alias of `Enum['RAW', 'ENRICHED', 'NOLOG', 'raw', 'enriched', 'nolog']`
 
-```puppet
-Enum['RAW', 'ENRICHED', 'NOLOG', 'raw', 'enriched', 'nolog']
-```
-
-### <a name="auditdlogpriority"></a>`Auditd::LogPriority`
+### <a name="Auditd--LogPriority"></a>`Auditd::LogPriority`
 
 Matches log priorities that can be used in syslog.conf plugin
 
-Alias of
+Alias of `Enum['LOG_DEBUG', 'LOG_INFO', 'LOG_NOTICE', 'LOG_WARNING', 'LOG_ERR', 'LOG_CRIT', 'LOG_ALERT', 'LOG_EMERG', 'LOG_AUTHPRIV']`
 
-```puppet
-Enum['LOG_DEBUG', 'LOG_INFO', 'LOG_NOTICE', 'LOG_WARNING', 'LOG_ERR', 'LOG_CRIT', 'LOG_ALERT', 'LOG_EMERG', 'LOG_AUTHPRIV']
-```
-
-### <a name="auditdmaxlogfileaction"></a>`Auditd::MaxLogFileAction`
+### <a name="Auditd--MaxLogFileAction"></a>`Auditd::MaxLogFileAction`
 
 Matches available matches for maxlogfileaction in auditd.conf
 
-Alias of
+Alias of `Enum['IGNORE', 'SYSLOG', 'SUSPEND', 'ROTATE', 'KEEP_LOGS', 'ignore', 'syslog', 'suspend', 'rotate', 'keep_logs']`
 
-```puppet
-Enum['IGNORE', 'SYSLOG', 'SUSPEND', 'ROTATE', 'KEEP_LOGS', 'ignore', 'syslog', 'suspend', 'rotate', 'keep_logs']
-```
-
-### <a name="auditdnameformat"></a>`Auditd::NameFormat`
+### <a name="Auditd--NameFormat"></a>`Auditd::NameFormat`
 
 Matche s available name formats in audotd.conf
 
-Alias of
+Alias of `Enum['NONE', 'HOSTNAME', 'FQD', 'NUMERIC', 'USER', 'none', 'hostname', 'fqd', 'numeric', 'user']`
 
-```puppet
-Enum['NONE', 'HOSTNAME', 'FQD', 'NUMERIC', 'USER', 'none', 'hostname', 'fqd', 'numeric', 'user']
-```
-
-### <a name="auditdoverflowaction"></a>`Auditd::OverflowAction`
+### <a name="Auditd--OverflowAction"></a>`Auditd::OverflowAction`
 
 Matches overflow_action settings in auditd.conf or audisp.conf
 
-Alias of
+Alias of `Enum['IGNORE', 'SYSLOG', 'SUSPEND', 'SINGLE', 'HALT', 'ignore', 'syslog', 'suspend', 'single', 'halt']`
 
-```puppet
-Enum['IGNORE', 'SYSLOG', 'SUSPEND', 'SINGLE', 'HALT', 'ignore', 'syslog', 'suspend', 'single', 'halt']
-```
-
-### <a name="auditdrootauditlevel"></a>`Auditd::RootAuditLevel`
+### <a name="Auditd--RootAuditLevel"></a>`Auditd::RootAuditLevel`
 
 Matches root audit level settings in auditd.conf
 
-Alias of
+Alias of `Enum['basic', 'aggressive', 'insane']`
 
-```puppet
-Enum['basic', 'aggressive', 'insane']
-```
-
-### <a name="auditdspaceleftaction"></a>`Auditd::SpaceLeftAction`
+### <a name="Auditd--SpaceLeftAction"></a>`Auditd::SpaceLeftAction`
 
 Matches spaceleftaction for auditd.conf
 
-Alias of
-
-```puppet
-Enum['IGNORE', 'SYSLOG', 'ROTATE', 'EMAIL', 'EXEC', 'SUSPEND', 'SINGLE', 'HALT', 'ignore', 'syslog', 'rotate', 'email', 'exec', 'suspend', 'single', 'halt']
-```
+Alias of `Enum['IGNORE', 'SYSLOG', 'ROTATE', 'EMAIL', 'EXEC', 'SUSPEND', 'SINGLE', 'HALT', 'ignore', 'syslog', 'rotate', 'email', 'exec', 'suspend', 'single', 'halt']`
 


### PR DESCRIPTION
This patch adds support for RockyLinux 8

The patch enforces a standardized asset baseline using simp/puppetsync,
and may also apply other updates to ensure conformity.