### PR TITLE
Add option to not purge unmanages files under /etc/audit/rules.d/ - SIMP-10744

### DIFF
--- a/CHANGELOG
+++ b/CHANGELOG
@@ -1,3 +1,6 @@
+* Wed Nov 22 2023 ben <benrobertson9876@gmail.com> - 8.14.0
+- (SIMP-10744) Add purge behaviour for auditd rules
+
 * Tue Oct 24 2023 Joshua Hoblitt <josh@hoblitt.com> - 8.13.0
 - Add EL9 support
 

--- a/REFERENCE.md
+++ b/REFERENCE.md
@@ -116,6 +116,7 @@ The following parameters are available in the `auditd` class:
 * [`uid_min`](#-auditd--uid_min)
 * [`verify_email`](#-auditd--verify_email)
 * [`write_logs`](#-auditd--write_logs)
+* [`purge_auditd_rules`](#-auditd--purge_auditd_rules)
 
 ##### <a name="-auditd--enable"></a>`enable`
 
@@ -592,6 +593,14 @@ Whether or not to write logs to disk.
   set to `NOLOG` for legacy support.
 
 Default value: `$log_format ? { /^(?i:nolog)$/ => false, default => true`
+
+##### <a name="-auditd--purge_auditd_rules"></a>`purge_auditd_rules`
+
+Data type: `Boolean`
+
+Whether or not to purge existing auditd rules under /etc/audit/rules.d
+
+Default value: `true`
 
 ### <a name="auditd--config"></a>`auditd::config`
 

--- a/manifests/config.pp
+++ b/manifests/config.pp
@@ -44,7 +44,7 @@ class auditd::config {
     group   => $auditd::log_group,
     mode    => $config_file_mode,
     recurse => true,
-    purge   => true
+    purge   => $auditd::purge_auditd_rules
   }
 
   file { [

--- a/manifests/init.pp
+++ b/manifests/init.pp
@@ -261,7 +261,7 @@ class auditd (
   Integer[0]                              $uid_min                  = Integer(pick(fact('uid_min'), 1000)),
   Optional[Boolean]                       $verify_email             = undef,
   Boolean                                 $write_logs               = $log_format ? { /^(?i:nolog)$/ => false, default => true },
-  Boolean                                 $purge_auditd_rules       = false,
+  Boolean                                 $purge_auditd_rules       = true,
 ) {
 
   include 'auditd::service'

--- a/manifests/init.pp
+++ b/manifests/init.pp
@@ -198,6 +198,9 @@
 #     of `auditd` so this attempts to do "the right thing" when `log_format` is
 #     set to `NOLOG` for legacy support.
 #
+# @param purge_auditd_rules
+#   Whether or not to purge existing auditd rules under /etc/audit/rules.d
+#
 # @author https://github.com/simp/pupmod-simp-auditd/graphs/contributors
 #
 class auditd (
@@ -257,7 +260,8 @@ class auditd (
   Optional[Array[Pattern['^.*_t$']]]      $target_selinux_types     = undef,
   Integer[0]                              $uid_min                  = Integer(pick(fact('uid_min'), 1000)),
   Optional[Boolean]                       $verify_email             = undef,
-  Boolean                                 $write_logs               = $log_format ? { /^(?i:nolog)$/ => false, default => true }
+  Boolean                                 $write_logs               = $log_format ? { /^(?i:nolog)$/ => false, default => true },
+  Boolean                                 $purge_auditd_rules       = false,
 ) {
 
   include 'auditd::service'

--- a/metadata.json
+++ b/metadata.json
@@ -1,6 +1,6 @@
 {
   "name": "simp-auditd",
-  "version": "8.13.0",
+  "version": "8.14.0",
   "author": "SIMP Team",
   "summary": "A SIMP puppet module for managing auditd and audispd",
   "license": "Apache-2.0",

--- a/spec/classes/config_spec.rb
+++ b/spec/classes/config_spec.rb
@@ -69,6 +69,7 @@ describe 'auditd' do
         context 'with purge behaviour false' do
           let(:params) {{ :purge_auditd_rules => false }}
 
+          it { is_expected.to compile.with_all_deps }
           it {
             is_expected.to contain_file('/etc/audit').with({
               :ensure  => 'directory',

--- a/spec/classes/config_spec.rb
+++ b/spec/classes/config_spec.rb
@@ -71,7 +71,7 @@ describe 'auditd' do
 
           it { is_expected.to compile.with_all_deps }
           it {
-            is_expected.to contain_file('/etc/audit').with({
+            is_expected.to contain_file('/etc/audit/rules.d').with({
               :ensure  => 'directory',
               :owner   => 'root',
               :group   => 'root',

--- a/spec/classes/config_spec.rb
+++ b/spec/classes/config_spec.rb
@@ -66,6 +66,21 @@ describe 'auditd' do
           it { is_expected.to_not contain_class('auditd::config::audisp::syslog') }
         end   # Default params
 
+        context 'with purge behaviour false' do
+          let(:params) {{ :purge_auditd_rules => false }}
+
+          it {
+            is_expected.to contain_file('/etc/audit').with({
+              :ensure  => 'directory',
+              :owner   => 'root',
+              :group   => 'root',
+              :mode    => '0600',
+              :recurse => true,
+              :purge   => false
+            })
+          }
+        end
+
         context 'with empty default_audit_profiles' do
           let(:params) {{ :default_audit_profiles => [] }}
 


### PR DESCRIPTION
Module currently purges unmanaged files from /etc/audit/rules.d
This cannot be customised. Adding boolean to specify behaviour as required.
Default remains unchanged.

Fixes #186 

https://simp-project.atlassian.net/browse/SIMP-10744

Unit tests + beaker passing. Additional unit test added for new parameter. 
