### PR TITLE
Remove calls to deprecated parameters

### DIFF
--- a/CHANGELOG
+++ b/CHANGELOG
@@ -1,3 +1,6 @@
+* Mon Jul 08 2024 Steven Pritchard <steve@sicura.us> - 8.14.2
+- Remove calls to deprecated parameters (for Puppet 8 compatibility)
+
 * Wed Jul 03 2024 Steven Pritchard <steve@sicura.us> - 8.14.1
 - Clean up legacy fact usage for Puppet 8 compatibility
 

--- a/SIMP/compliance_profiles/checks.yaml
+++ b/SIMP/compliance_profiles/checks.yaml
@@ -211,7 +211,7 @@ checks:
     - audit_rules_dac_modification_lchown
   oval:com.puppet.forge.simp.auditd.config.audit_profiles.simp.audit_grub:
     settings:
-      parameter: auditd::config::audit_profiles::simp::audit_grub
+      parameter: auditd::config::audit_profiles::simp::audit_cfg_grub
       value: true
     type: puppet-class-parameter
     controls:
@@ -332,7 +332,7 @@ checks:
       - AU-2
   oval:com.puppet.forge.simp.auditd.config.audit_profiles.simp.audit_sudoers:
     settings:
-      parameter: auditd::config::audit_profiles::simp::audit_sudoers
+      parameter: auditd::config::audit_profiles::simp::audit_cfg_sudoers
       value: true
     type: puppet-class-parameter
     controls:
@@ -387,7 +387,7 @@ checks:
       - AU-2
   oval:com.puppet.forge.simp.auditd.config.audit_profiles.simp.audit_yum:
     settings:
-      parameter: auditd::config::audit_profiles::simp::audit_yum
+      parameter: auditd::config::audit_profiles::simp::audit_cfg_yum
       value: true
     type: puppet-class-parameter
     controls:

--- a/metadata.json
+++ b/metadata.json
@@ -1,6 +1,6 @@
 {
   "name": "simp-auditd",
-  "version": "8.14.1",
+  "version": "8.14.2",
   "author": "SIMP Team",
   "summary": "A SIMP puppet module for managing auditd and audispd",
   "license": "Apache-2.0",

--- a/spec/classes/config/audit_profiles/simp_spec.rb
+++ b/spec/classes/config/audit_profiles/simp_spec.rb
@@ -387,88 +387,128 @@ describe 'auditd' do
       context 'with deprecated parameters' do
         context 'disable audit_cfg_sudoers using deprecated audit_sudoers' do
           let(:hieradata) { 'simp_audit_profile/disable__audit_sudoers' }
+
           [
             %r{^-w /etc/sudoers -p wa -k CFG_sys$},
             %r{^-w /etc/sudoers.d/ -p wa -k CFG_sys$},
           ].each do |command_regex|
-            it {
-              is_expected.not_to contain_file('/etc/audit/rules.d/50_00_simp_base.rules').
-                with_content(command_regex)
-            }
+            it do
+              if Puppet[:strict] == :error
+                is_expected.to compile.and_raise_error(%r{'auditd::config::audit_profiles::simp::audit_sudoers' is deprecated\.})
+              else
+                is_expected.not_to contain_file('/etc/audit/rules.d/50_00_simp_base.rules').
+                  with_content(command_regex)
+              end
+            end
           end
         end
 
         context 'set audit_cfg_sudoers rule key using deprecated audit_sudoers_tag' do
           let(:hieradata) { 'simp_audit_profile/set__audit_sudoers_tag' }
+
           [
             %r{^-w /etc/sudoers -p wa -k old_sudoers_tag$},
             %r{^-w /etc/sudoers.d/ -p wa -k old_sudoers_tag$},
           ].each do |command_regex|
-            it {
-              is_expected.to contain_file('/etc/audit/rules.d/50_00_simp_base.rules').
-                with_content(command_regex)
-            }
+            it do
+              if Puppet[:strict] == :error
+                is_expected.to compile.and_raise_error(%r{'auditd::config::audit_profiles::simp::audit_sudoers_tag' is deprecated\.})
+              else
+                is_expected.to contain_file('/etc/audit/rules.d/50_00_simp_base.rules').
+                  with_content(command_regex)
+              end
+            end
           end
 
           [
             %r{^-w /etc/sudoers -p wa -k CFG_sys$},
             %r{^-w /etc/sudoers.d/ -p wa -k CFG_sys$},
           ].each do |command_regex|
-            it {
-              is_expected.not_to contain_file('/etc/audit/rules.d/50_00_simp_base.rules').
-                with_content(command_regex)
-            }
+            it do
+              if Puppet[:strict] == :error
+                is_expected.to compile.and_raise_error(%r{'auditd::config::audit_profiles::simp::audit_sudoers_tag' is deprecated\.})
+              else
+                is_expected.not_to contain_file('/etc/audit/rules.d/50_00_simp_base.rules').
+                  with_content(command_regex)
+              end
+            end
           end
         end
 
         context 'disable audit_cfg_grub using deprecated audit_grub' do
           let(:hieradata) { 'simp_audit_profile/disable__audit_grub' }
-          it {
-            is_expected.not_to contain_file('/etc/audit/rules.d/50_00_simp_base.rules').with_content(
-              %r{^.* -k CFG_grub$}
-            )
-          }
+
+          it do
+            if Puppet[:strict] == :error
+              is_expected.to compile.and_raise_error(%r{'auditd::config::audit_profiles::simp::audit_grub' is deprecated\.})
+            else
+              is_expected.not_to contain_file('/etc/audit/rules.d/50_00_simp_base.rules').with_content(
+                %r{^.* -k CFG_grub$}
+              )
+            end
+          end
         end
 
         context 'set audit_cfg_grub rule key using deprecated audit_grub_tag' do
           let(:hieradata) { 'simp_audit_profile/set__audit_grub_tag' }
 
-          it {
-            is_expected.to contain_file('/etc/audit/rules.d/50_00_simp_base.rules').with_content(
-              %r{^.*grub.(d|conf).* -k old_grub_tag$}
-            )
-          }
+          it do
+            if Puppet[:strict] == :error
+              is_expected.to compile.and_raise_error(%r{'auditd::config::audit_profiles::simp::audit_grub_tag' is deprecated\.})
+            else
+              is_expected.to contain_file('/etc/audit/rules.d/50_00_simp_base.rules').with_content(
+                %r{^.*grub.(d|conf).* -k old_grub_tag$}
+              )
+            end
+          end
 
-          it {
-            is_expected.not_to contain_file('/etc/audit/rules.d/50_00_simp_base.rules').with_content(
-              %r{^.* -k CFG_grub$}
-            )
-          }
+          it do
+            if Puppet[:strict] == :error
+              is_expected.to compile.and_raise_error(%r{'auditd::config::audit_profiles::simp::audit_grub_tag' is deprecated\.})
+            else
+              is_expected.not_to contain_file('/etc/audit/rules.d/50_00_simp_base.rules').with_content(
+                %r{^.* -k CFG_grub$}
+              )
+            end
+          end
         end
 
         context 'disable audit_cfg_yum using deprecated audit_yum' do
           let(:hieradata) { 'simp_audit_profile/disable__audit_yum' }
-          it {
-            is_expected.not_to contain_file('/etc/audit/rules.d/50_00_simp_base.rules').with_content(
-              %r{^.* -k yum_config$}
-            )
-          }
+
+          it do
+            if Puppet[:strict] == :error
+              is_expected.to compile.and_raise_error(%r{'auditd::config::audit_profiles::simp::audit_yum' is deprecated\.})
+            else
+              is_expected.not_to contain_file('/etc/audit/rules.d/50_00_simp_base.rules').with_content(
+                %r{^.* -k yum_config$}
+              )
+            end
+          end
         end
 
         context 'set audit_cfg_yum rule key using deprecated audit_yum_tag' do
           let(:hieradata) { 'simp_audit_profile/set__audit_yum_tag' }
 
-          it {
-            is_expected.to contain_file('/etc/audit/rules.d/50_00_simp_base.rules').with_content(
-              %r{^.*/etc/yum.* -k old_yum_tag$}
-            )
-          }
+          it do
+            if Puppet[:strict] == :error
+              is_expected.to compile.and_raise_error(%r{'auditd::config::audit_profiles::simp::audit_yum_tag' is deprecated\.})
+            else
+              is_expected.to contain_file('/etc/audit/rules.d/50_00_simp_base.rules').with_content(
+                %r{^.*/etc/yum.* -k old_yum_tag$}
+              )
+            end
+          end
 
-          it {
-            is_expected.not_to contain_file('/etc/audit/rules.d/50_00_simp_base.rules').with_content(
-              %r{^.* -k yum_config$}
-            )
-          }
+          it do
+            if Puppet[:strict] == :error
+              is_expected.to compile.and_raise_error(%r{'auditd::config::audit_profiles::simp::audit_yum_tag' is deprecated\.})
+            else
+              is_expected.not_to contain_file('/etc/audit/rules.d/50_00_simp_base.rules').with_content(
+                %r{^.* -k yum_config$}
+              )
+            end
+          end
         end
       end
     end

--- a/spec/classes/config_spec.rb
+++ b/spec/classes/config_spec.rb
@@ -149,26 +149,44 @@ describe 'auditd' do
 
         context 'with deprecated parameters' do
           context 'with default_audit_profile = true' do
-            let(:params) {{ :default_audit_profile => true }}
+            let(:params) {{ default_audit_profile: true }}
 
-            it { is_expected.to contain_class('auditd::config::audit_profiles') }
-            it { is_expected.to contain_class('auditd::config::audit_profiles::simp') }
+            it do
+              if Puppet[:strict] == :error
+                is_expected.to compile.and_raise_error(%r{'auditd::default_audit_profile' is deprecated\.})
+              else
+                is_expected.to contain_class('auditd::config::audit_profiles')
+                is_expected.to contain_class('auditd::config::audit_profiles::simp')
+              end
+            end
           end
 
           context 'with default_audit_profile = false' do
-            let(:params) {{ :default_audit_profile => false }}
+            let(:params) {{ default_audit_profile: false }}
 
-            it { is_expected.to compile.with_all_deps }
-            it { is_expected.to_not contain_class('auditd::config::audit_profiles') }
-            it { is_expected.to_not contain_class('auditd::config::audit_profiles::simp') }
+            it do
+              if Puppet[:strict] == :error
+                is_expected.to compile.and_raise_error(%r{'auditd::default_audit_profile' is deprecated\.})
+              else
+                is_expected.to compile.with_all_deps
+                is_expected.not_to contain_class('auditd::config::audit_profiles')
+                is_expected.not_to contain_class('auditd::config::audit_profiles::simp')
+              end
+            end
           end
-        end
 
-        context "with default_audit_profile = 'simp'" do
-          let(:params) {{ :default_audit_profile => 'simp' }}
+          context "with default_audit_profile = 'simp'" do
+            let(:params) {{ default_audit_profile: 'simp' }}
 
-          it { is_expected.to contain_class('auditd::config::audit_profiles') }
-          it { is_expected.to contain_class('auditd::config::audit_profiles::simp') }
+            it do
+              if Puppet[:strict] == :error
+                is_expected.to compile.and_raise_error(%r{'auditd::default_audit_profile' is deprecated\.})
+              else
+                is_expected.to contain_class('auditd::config::audit_profiles')
+                is_expected.to contain_class('auditd::config::audit_profiles::simp')
+              end
+            end
+          end
         end
 
         context "with default_audit_profiles = 'built_in'" do


### PR DESCRIPTION
On Puppet 8, [strict](https://www.puppet.com/docs/puppet/8/configuration.html#strict) is set to `error` by default.  This causes [`deprecation()`](https://forge.puppet.com/modules/puppetlabs/stdlib/reference#deprecation) to fail and output an error message.

This change avoids the calls to deprecated parameters where possible and checks the value of `strict` in tests where the deprecated parameters are used intentionally.