### PR TITLE
Decouple and fix permissions for logs and configs

### DIFF
--- a/CHANGELOG
+++ b/CHANGELOG
@@ -1,3 +1,8 @@
+* Thu Jul 16 2026 Nicholas Markowski <nicholas.markowski@onyxpoint.com> - 10.1.0
+- Decouple log and config permissions, add new config_group parameter
+- Use symbolic mode for config file mode so directories are traversable
+- Add force parameter to purge on /etc/audit resource
+
 * Thu Jul 09 2026 Steven Pritchard <steve@sicura.us> - 10.0.1
 - Documented parameters, added data types, and resolved puppet-lint offenses
 

--- a/CHANGELOG
+++ b/CHANGELOG
@@ -1,7 +1,7 @@
 * Thu Jul 16 2026 Nicholas Markowski <nicholas.markowski@onyxpoint.com> - 10.1.0
 - Decouple log and config permissions, add new config_group parameter
-- Use symbolic mode for config file mode so directories are traversable
-- Add force parameter to purge on /etc/audit resource
+- Switch audit config file modes to symbolic notation for explicitness
+- Add force parameter to /etc/audit and /etc/audit/rules.d resources
 
 * Thu Jul 09 2026 Steven Pritchard <steve@sicura.us> - 10.0.1
 - Documented parameters, added data types, and resolved puppet-lint offenses

--- a/REFERENCE.md
+++ b/REFERENCE.md
@@ -94,6 +94,7 @@ The following parameters are available in the `auditd` class:
 * [`local_events`](#-auditd--local_events)
 * [`log_format`](#-auditd--log_format)
 * [`log_group`](#-auditd--log_group)
+* [`config_group`](#-auditd--config_group)
 * [`loginuid_immutable`](#-auditd--loginuid_immutable)
 * [`max_log_file`](#-auditd--max_log_file)
 * [`max_log_file_action`](#-auditd--max_log_file_action)
@@ -380,9 +381,21 @@ Default value: `'raw'`
 
 Data type: `String`
 
-
+The group that owns `/var/log/audit` and the audit log files.
 
 Default value: `'root'`
+
+##### <a name="-auditd--config_group"></a>`config_group`
+
+Data type: `String`
+
+The group that owns `/etc/audit` and the audit configuration files.
+Setting this to a non-`root` group allows that group to read the audit
+configuration without having write access to the audit logs. Defaults
+to `$log_group` so existing deployments that set only `log_group`
+retain their prior `/etc/audit` ownership.
+
+Default value: `$log_group`
 
 ##### <a name="-auditd--loginuid_immutable"></a>`loginuid_immutable`
 

--- a/manifests/config.pp
+++ b/manifests/config.pp
@@ -45,7 +45,8 @@ class auditd::config {
     group   => $auditd::config_group,
     mode    => $config_file_mode,
     recurse => true,
-    purge   => $auditd::purge_auditd_rules
+    purge   => $auditd::purge_auditd_rules,
+    force   => true,
   }
 
   file { [

--- a/manifests/config.pp
+++ b/manifests/config.pp
@@ -20,8 +20,8 @@ class auditd::config {
   }
 
   $config_file_mode = $auditd::config_group ? {
-    'root'  => '0600',
-    default => '0640'
+    'root'  => 'u+rwX,g-rwx,o-rwx',
+    default => 'u+rwX,g+rX,g-w,o-rwx'
   }
 
   $log_file_mode = $auditd::log_group ? {

--- a/manifests/config.pp
+++ b/manifests/config.pp
@@ -19,7 +19,7 @@ class auditd::config {
     $profiles = $auditd::default_audit_profiles
   }
 
-  $config_file_mode = $auditd::log_group ? {
+  $config_file_mode = $auditd::config_group ? {
     'root'  => '0600',
     default => '0640'
   }
@@ -32,16 +32,17 @@ class auditd::config {
   file { '/etc/audit':
     ensure  => 'directory',
     owner   => 'root',
-    group   => $auditd::log_group,
+    group   => $auditd::config_group,
     mode    => $config_file_mode,
     recurse => true,
-    purge   => true
+    purge   => true,
+    force   => true,
   }
 
   file { '/etc/audit/rules.d':
     ensure  => 'directory',
     owner   => 'root',
-    group   => $auditd::log_group,
+    group   => $auditd::config_group,
     mode    => $config_file_mode,
     recurse => true,
     purge   => $auditd::purge_auditd_rules
@@ -52,8 +53,8 @@ class auditd::config {
       '/etc/audit/audit.rules.prev'
     ]:
       owner => 'root',
-      group => $auditd::log_group,
-      mode  => 'o-rwx'
+      group => $auditd::config_group,
+      mode  => $config_file_mode
   }
 
   # Build the auditd.conf from parts
@@ -78,7 +79,7 @@ class auditd::config {
 
   file { '/etc/audit/auditd.conf':
     owner   => 'root',
-    group   => $auditd::log_group,
+    group   => $auditd::config_group,
     mode    => $config_file_mode,
     content => "${_auditd_conf_common}${_auditd_conf_main}${_auditd_conf_last}\n",
     notify  => Class['auditd::service']
@@ -88,7 +89,7 @@ class auditd::config {
     file { $auditd::plugin_dir:
       ensure => 'directory',
       owner  => 'root',
-      group  => $auditd::log_group,
+      group  => $auditd::config_group,
       mode   => '0750'
     }
   }

--- a/manifests/init.pp
+++ b/manifests/init.pp
@@ -108,9 +108,9 @@
 # @param config_group
 #   The group that owns `/etc/audit` and the audit configuration files.
 #   Setting this to a non-`root` group allows that group to read the audit
-#   configuration without having write access to the audit logs. When this
-#   parameter is `root` (the default), the configuration files are restricted
-#   to `root`-only access.
+#   configuration without having write access to the audit logs. Defaults
+#   to `$log_group` so existing deployments that set only `log_group`
+#   retain their prior `/etc/audit` ownership.
 #
 # @param loginuid_immutable
 #   Sets the --loginuid-immutable option
@@ -258,7 +258,7 @@ class auditd (
   Stdlib::Absolutepath                    $log_file                 = '/var/log/audit/audit.log',
   Auditd::LogFormat                       $log_format               = 'raw',
   String                                  $log_group                = 'root',
-  String                                  $config_group             = 'root',
+  String                                  $config_group             = $log_group,
   Boolean                                 $loginuid_immutable       = true,
   Integer[0]                              $max_log_file             = 24,
   Auditd::MaxLogFileAction                $max_log_file_action      = 'rotate',

--- a/manifests/init.pp
+++ b/manifests/init.pp
@@ -103,6 +103,14 @@
 #   * 'ENRICHED' is only available in auditd >= 2.6.0
 #
 # @param log_group
+#   The group that owns `/var/log/audit` and the audit log files.
+#
+# @param config_group
+#   The group that owns `/etc/audit` and the audit configuration files.
+#   Setting this to a non-`root` group allows that group to read the audit
+#   configuration without having write access to the audit logs. When this
+#   parameter is `root` (the default), the configuration files are restricted
+#   to `root`-only access.
 #
 # @param loginuid_immutable
 #   Sets the --loginuid-immutable option

--- a/manifests/init.pp
+++ b/manifests/init.pp
@@ -250,6 +250,7 @@ class auditd (
   Stdlib::Absolutepath                    $log_file                 = '/var/log/audit/audit.log',
   Auditd::LogFormat                       $log_format               = 'raw',
   String                                  $log_group                = 'root',
+  String                                  $config_group             = 'root',
   Boolean                                 $loginuid_immutable       = true,
   Integer[0]                              $max_log_file             = 24,
   Auditd::MaxLogFileAction                $max_log_file_action      = 'rotate',

--- a/metadata.json
+++ b/metadata.json
@@ -1,6 +1,6 @@
 {
   "name": "simp-auditd",
-  "version": "10.0.1",
+  "version": "10.1.0",
   "author": "SIMP Team",
   "summary": "A SIMP puppet module for managing auditd and audispd",
   "license": "Apache-2.0",

--- a/spec/classes/config_spec.rb
+++ b/spec/classes/config_spec.rb
@@ -20,7 +20,7 @@ describe 'auditd' do
               ensure: 'directory',
               owner: 'root',
               group: 'root',
-              mode: '0600',
+              mode: 'u+rwX,g-rwx,o-rwx',
               recurse: true,
               purge: true,
             )
@@ -29,14 +29,14 @@ describe 'auditd' do
             is_expected.to contain_file('/etc/audit/audit.rules').with(
               owner: 'root',
               group: 'root',
-              mode: '0600',
+              mode: 'u+rwX,g-rwx,o-rwx',
             )
           }
           it {
             is_expected.to contain_file('/etc/audit/audit.rules.prev').with(
               owner: 'root',
               group: 'root',
-              mode: '0600',
+              mode: 'u+rwX,g-rwx,o-rwx',
             )
           }
           it {
@@ -44,7 +44,7 @@ describe 'auditd' do
               ensure: 'directory',
               owner: 'root',
               group: 'root',
-              mode: '0600',
+              mode: 'u+rwX,g-rwx,o-rwx',
               recurse: true,
               purge: true,
               force: true,
@@ -76,7 +76,7 @@ describe 'auditd' do
               ensure: 'directory',
               owner: 'root',
               group: 'root',
-              mode: '0600',
+              mode: 'u+rwX,g-rwx,o-rwx',
               recurse: true,
               purge: false,
             )
@@ -99,7 +99,7 @@ describe 'auditd' do
               ensure: 'directory',
               owner: 'root',
               group: 'root',
-              mode: '0600',
+              mode: 'u+rwX,g-rwx,o-rwx',
               recurse: true,
               purge: true,
               force: true,
@@ -110,7 +110,7 @@ describe 'auditd' do
               ensure: 'directory',
               owner: 'root',
               group: 'root',
-              mode: '0600',
+              mode: 'u+rwX,g-rwx,o-rwx',
               recurse: true,
               purge: true,
             )
@@ -119,14 +119,14 @@ describe 'auditd' do
             is_expected.to contain_file('/etc/audit/audit.rules').with(
               owner: 'root',
               group: 'root',
-              mode: '0600',
+              mode: 'u+rwX,g-rwx,o-rwx',
             )
           }
           it {
             is_expected.to contain_file('/etc/audit/audit.rules.prev').with(
               owner: 'root',
               group: 'root',
-              mode: '0600',
+              mode: 'u+rwX,g-rwx,o-rwx',
             )
           }
 
@@ -134,7 +134,7 @@ describe 'auditd' do
             is_expected.to contain_file('/etc/audit/auditd.conf').with(
               owner: 'root',
               group: 'root',
-              mode: '0600',
+              mode: 'u+rwX,g-rwx,o-rwx',
             )
           }
 
@@ -158,7 +158,7 @@ describe 'auditd' do
               ensure: 'directory',
               owner: 'root',
               group: 'rspec',
-              mode: '0640',
+              mode: 'u+rwX,g+rX,g-w,o-rwx',
               recurse: true,
               purge: true,
               force: true,
@@ -169,7 +169,7 @@ describe 'auditd' do
               ensure: 'directory',
               owner: 'root',
               group: 'rspec',
-              mode: '0640',
+              mode: 'u+rwX,g+rX,g-w,o-rwx',
               recurse: true,
               purge: true,
             )
@@ -178,14 +178,14 @@ describe 'auditd' do
             is_expected.to contain_file('/etc/audit/audit.rules').with(
               owner: 'root',
               group: 'rspec',
-              mode: '0640',
+              mode: 'u+rwX,g+rX,g-w,o-rwx',
             )
           }
           it {
             is_expected.to contain_file('/etc/audit/audit.rules.prev').with(
               owner: 'root',
               group: 'rspec',
-              mode: '0640',
+              mode: 'u+rwX,g+rX,g-w,o-rwx',
             )
           }
 
@@ -193,7 +193,7 @@ describe 'auditd' do
             is_expected.to contain_file('/etc/audit/auditd.conf').with(
               owner: 'root',
               group: 'rspec',
-              mode: '0640',
+              mode: 'u+rwX,g+rX,g-w,o-rwx',
             )
           }
 
@@ -345,7 +345,7 @@ describe 'auditd' do
                 is_expected.to contain_file('/etc/audit/auditd.conf').with(
                   owner: 'root',
                   group: 'root',
-                  mode: '0600',
+                  mode: 'u+rwX,g-rwx,o-rwx',
                   content: complete_content + "\n",
                 )
 

--- a/spec/classes/config_spec.rb
+++ b/spec/classes/config_spec.rb
@@ -23,6 +23,7 @@ describe 'auditd' do
               mode: 'u+rwX,g-rwx,o-rwx',
               recurse: true,
               purge: true,
+              force: true,
             )
           }
           it {
@@ -79,6 +80,7 @@ describe 'auditd' do
               mode: 'u+rwX,g-rwx,o-rwx',
               recurse: true,
               purge: false,
+              force: true,
             )
           }
         end
@@ -94,12 +96,15 @@ describe 'auditd' do
           let(:params) { { log_group: 'rspec' } }
 
           it { is_expected.to compile.with_all_deps }
+          # config_group defaults to log_group so existing deployments that
+          # set only log_group retain their pre-config_group /etc/audit
+          # ownership.
           it {
             is_expected.to contain_file('/etc/audit').with(
               ensure: 'directory',
               owner: 'root',
-              group: 'root',
-              mode: 'u+rwX,g-rwx,o-rwx',
+              group: 'rspec',
+              mode: 'u+rwX,g+rX,g-w,o-rwx',
               recurse: true,
               purge: true,
               force: true,
@@ -109,32 +114,33 @@ describe 'auditd' do
             is_expected.to contain_file('/etc/audit/rules.d').with(
               ensure: 'directory',
               owner: 'root',
-              group: 'root',
-              mode: 'u+rwX,g-rwx,o-rwx',
+              group: 'rspec',
+              mode: 'u+rwX,g+rX,g-w,o-rwx',
               recurse: true,
               purge: true,
+              force: true,
             )
           }
           it {
             is_expected.to contain_file('/etc/audit/audit.rules').with(
               owner: 'root',
-              group: 'root',
-              mode: 'u+rwX,g-rwx,o-rwx',
+              group: 'rspec',
+              mode: 'u+rwX,g+rX,g-w,o-rwx',
             )
           }
           it {
             is_expected.to contain_file('/etc/audit/audit.rules.prev').with(
               owner: 'root',
-              group: 'root',
-              mode: 'u+rwX,g-rwx,o-rwx',
+              group: 'rspec',
+              mode: 'u+rwX,g+rX,g-w,o-rwx',
             )
           }
 
           it {
             is_expected.to contain_file('/etc/audit/auditd.conf').with(
               owner: 'root',
-              group: 'root',
-              mode: 'u+rwX,g-rwx,o-rwx',
+              group: 'rspec',
+              mode: 'u+rwX,g+rX,g-w,o-rwx',
             )
           }
 
@@ -172,6 +178,7 @@ describe 'auditd' do
               mode: 'u+rwX,g+rX,g-w,o-rwx',
               recurse: true,
               purge: true,
+              force: true,
             )
           }
           it {

--- a/spec/classes/config_spec.rb
+++ b/spec/classes/config_spec.rb
@@ -29,14 +29,14 @@ describe 'auditd' do
             is_expected.to contain_file('/etc/audit/audit.rules').with(
               owner: 'root',
               group: 'root',
-              mode: 'o-rwx',
+              mode: '0600',
             )
           }
           it {
             is_expected.to contain_file('/etc/audit/audit.rules.prev').with(
               owner: 'root',
               group: 'root',
-              mode: 'o-rwx',
+              mode: '0600',
             )
           }
           it {
@@ -47,6 +47,7 @@ describe 'auditd' do
               mode: '0600',
               recurse: true,
               purge: true,
+              force: true,
             )
           }
           it { is_expected.not_to contain_augeas('auditd/USE_AUGENRULES') }
@@ -97,10 +98,70 @@ describe 'auditd' do
             is_expected.to contain_file('/etc/audit').with(
               ensure: 'directory',
               owner: 'root',
+              group: 'root',
+              mode: '0600',
+              recurse: true,
+              purge: true,
+              force: true,
+            )
+          }
+          it {
+            is_expected.to contain_file('/etc/audit/rules.d').with(
+              ensure: 'directory',
+              owner: 'root',
+              group: 'root',
+              mode: '0600',
+              recurse: true,
+              purge: true,
+            )
+          }
+          it {
+            is_expected.to contain_file('/etc/audit/audit.rules').with(
+              owner: 'root',
+              group: 'root',
+              mode: '0600',
+            )
+          }
+          it {
+            is_expected.to contain_file('/etc/audit/audit.rules.prev').with(
+              owner: 'root',
+              group: 'root',
+              mode: '0600',
+            )
+          }
+
+          it {
+            is_expected.to contain_file('/etc/audit/auditd.conf').with(
+              owner: 'root',
+              group: 'root',
+              mode: '0600',
+            )
+          }
+
+          it {
+            is_expected.to contain_file('/var/log/audit').with(
+              ensure: 'directory',
+              owner: 'root',
+              group: 'rspec',
+              mode: 'u+rX,g+rX,g-w,o-rwx',
+              recurse: true,
+            )
+          }
+        end
+
+        context 'with different config_group' do
+          let(:params) { { config_group: 'rspec' } }
+
+          it { is_expected.to compile.with_all_deps }
+          it {
+            is_expected.to contain_file('/etc/audit').with(
+              ensure: 'directory',
+              owner: 'root',
               group: 'rspec',
               mode: '0640',
               recurse: true,
               purge: true,
+              force: true,
             )
           }
           it {
@@ -117,14 +178,14 @@ describe 'auditd' do
             is_expected.to contain_file('/etc/audit/audit.rules').with(
               owner: 'root',
               group: 'rspec',
-              mode: 'o-rwx',
+              mode: '0640',
             )
           }
           it {
             is_expected.to contain_file('/etc/audit/audit.rules.prev').with(
               owner: 'root',
               group: 'rspec',
-              mode: 'o-rwx',
+              mode: '0640',
             )
           }
 
@@ -140,8 +201,8 @@ describe 'auditd' do
             is_expected.to contain_file('/var/log/audit').with(
               ensure: 'directory',
               owner: 'root',
-              group: 'rspec',
-              mode: 'u+rX,g+rX,g-w,o-rwx',
+              group: 'root',
+              mode: 'u+rX,g-rwx,o-rwx',
               recurse: true,
             )
           }


### PR DESCRIPTION
Fixes #167 
Fixes #194 

* Minor Gem update
* Decouple the permissions for logs and configs
* Add the force parameter to purge on /etc/audit