### PR TITLE
Cleanup metadata for 10.0.0 release

### DIFF
--- a/CHANGELOG
+++ b/CHANGELOG
@@ -9,6 +9,7 @@
   puppet_collection default on openvox8 across all nodesets
 - Source Oracle Linux vagrant boxes from oracle.github.io upstream JSON
   metadata instead of the deprecated generic/oracle* boxes
+- Point `issues_url` at GitHub Issues; allow `simp-rsyslog` 9.x.
 
 * Mon Apr 27 2026 Mike Riddle <mike@sicura.us> - 9.0.2
 - Fixes broken kernel_parameter call with latest augeasproviders_grub

--- a/metadata.json
+++ b/metadata.json
@@ -6,7 +6,7 @@
   "license": "Apache-2.0",
   "source": "https://github.com/simp/pupmod-simp-auditd",
   "project_page": "https://github.com/simp/pupmod-simp-auditd",
-  "issues_url": "https://simp-project.atlassian.net",
+  "issues_url": "https://github.com/simp/pupmod-simp-auditd/issues",
   "tags": [
     "simp",
     "auditd",
@@ -30,7 +30,7 @@
     "optional_dependencies": [
       {
         "name": "simp/rsyslog",
-        "version_requirement": ">= 7.6.0 < 9.0.0"
+        "version_requirement": ">= 7.6.0 < 10.0.0"
       }
     ]
   },


### PR DESCRIPTION
## Summary

Small metadata cleanups on top of the 10.0.0 release work already in master:

- Point `issues_url` at GitHub Issues instead of the retired Atlassian instance.
- Allow `simp-rsyslog` 9.x as an optional dependency.

## Test plan
- [x] `bundle exec rake metadata_lint` (ruby:3.2 container)