### PR TITLE
Add centos9 vagrant nodeset

### DIFF
--- a/spec/acceptance/nodesets/centos9.yml
+++ b/spec/acceptance/nodesets/centos9.yml
@@ -1,0 +1,19 @@
+---
+HOSTS:
+  centos9:
+    roles:
+    - default
+    - master
+    - server
+    - el9
+    platform: el-9-x86_64
+    box: generic/centos9s
+    hypervisor: "<%= ENV.fetch('BEAKER_HYPERVISOR', 'vagrant') %>"
+    vagrant_memsize: 2048
+    vagrant_cpus: 2
+    family: centos-cloud/centos-stream-9
+    gce_machine_type: n1-standard-2
+CONFIG:
+  log_level: verbose
+  type: aio
+  puppet_collection: "<%= ENV.fetch('BEAKER_PUPPET_COLLECTION', 'openvox8') %>"


### PR DESCRIPTION
## Summary

Followup to #256. The vagrant nodeset matrix had CentOS Stream 10 but not 9 — add `centos9.yml` for parity.

## Test plan
- [x] Unit tests are unaffected
- [ ] Acceptance CI exercises the new nodeset if invoked