### PR TITLE
Adopt AGENTS.md gitignore standard and harden rspec coverage

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -25,4 +25,21 @@ dist
 /log
 /doc
 /Gemfile.lock
-CLAUDE.md
+
+## AI coding assistant-specific configuration
+## The standard is AGENTS.md
+# Claude Code
+/CLAUDE.md
+/.claude/
+# GitHub Copilot
+/.github/copilot-instructions.md
+# Cursor
+/.cursor/
+/.cursorrules
+# Windsurf
+/.windsurf/
+/.windsurfrules
+# Gemini CLI
+/GEMINI.md
+# Cline
+/.clinerules/

--- a/.pdkignore
+++ b/.pdkignore
@@ -55,3 +55,4 @@
 /spec/
 /.vscode/
 /tests/
+/AGENTS.md

--- a/spec/classes/config/audit_profiles/simp_spec.rb
+++ b/spec/classes/config/audit_profiles/simp_spec.rb
@@ -127,7 +127,7 @@ describe 'auditd' do
           let(:hieradata) { "simp_audit_profile/#{hiera_file}" }
 
           it {
-            is_expected.not_to contain_file('/etc/audit/rules.d/50_00_base.rules').with_content(
+            is_expected.not_to contain_file('/etc/audit/rules.d/50_00_simp_base.rules').with_content(
               %r{^.* -k #{key}$},
             )
           }

--- a/spec/classes/init_spec.rb
+++ b/spec/classes/init_spec.rb
@@ -55,6 +55,35 @@ describe 'auditd' do
           end
         end
 
+        # Exercises the SIMP business logic: with no parameters passed,
+        # $package_ensure and $syslog resolve through
+        # simplib::lookup('simp_options::package_ensure' / 'simp_options::syslog').
+        # The hieradata fixture sets both to values distinct from the class
+        # defaults ('installed' / false), so a pass proves the lookup path
+        # (not the default) supplied them.
+        # See spec/fixtures/hieradata/simp_options.yaml.
+        context 'with simp_options site keys set in hiera' do
+          let(:params) { {} }
+          let(:hieradata) { 'simp_options' }
+
+          it { is_expected.to compile.with_all_deps }
+          it { is_expected.to contain_package('audit').with(ensure: 'latest') }
+          it { is_expected.to contain_class('auditd').with_syslog(true) }
+        end
+
+        # manifests/service.pp branches on $warn_if_reboot_required: when true it
+        # emits a reboot_notify (warning that auditd cannot be (re)started until
+        # the kernel is enforcing auditing) INSTEAD of managing the service
+        # resource. Every other context exercises only the false branch, so this
+        # pins the true branch -- otherwise the reboot path has no unit coverage.
+        context 'with warn_if_reboot_required => true' do
+          let(:params) { { warn_if_reboot_required: true } }
+
+          it { is_expected.to compile.with_all_deps }
+          it { is_expected.to contain_reboot_notify('auditd service') }
+          it { is_expected.not_to contain_service('auditd') }
+        end
+
         context 'auditd with space_left < admin_space_left' do
           let(:params) do
             {

--- a/spec/fixtures/hieradata/simp_options.yaml
+++ b/spec/fixtures/hieradata/simp_options.yaml
@@ -1,0 +1,7 @@
+---
+# Exercises the simplib::lookup('simp_options::package_ensure', ...) and
+# simplib::lookup('simp_options::syslog', ...) fallbacks in manifests/init.pp.
+# The values are deliberately distinct from the class defaults ('installed' /
+# false) so the unit test proves the lookup path resolved them.
+simp_options::package_ensure: 'latest'
+simp_options::syslog: true


### PR DESCRIPTION
## Summary

Aligns this module's AI-assistant config handling with the vendor-neutral **AGENTS.md** standard (the module already ships an `AGENTS.md`) and repairs two dead/uncovered spots in the unit suite. No manifest/behavior changes.

## Changes

### AGENTS.md standard
- **`.gitignore`** — ignore all vendor-specific AI-assistant configs (`CLAUDE.md`, `.claude/`, copilot, cursor, windsurf, gemini, cline) while keeping the already-tracked `AGENTS.md`. (Contributors can keep a local, gitignored `CLAUDE.md -> AGENTS.md` symlink.)
- **`.pdkignore`** — exclude `AGENTS.md` from `pdk build` artifacts.

### Test hardening
- **`spec/classes/init_spec.rb`**
  - **Lookup-seam coverage:** new context proving `$package_ensure` and `$syslog` resolve through `simplib::lookup('simp_options::package_ensure' / 'simp_options::syslog')`. The new fixture `spec/fixtures/hieradata/simp_options.yaml` sets both to values *distinct* from the class defaults (`installed` / `false`), so a pass proves the lookup path — not the default — supplied them.
  - **Reboot-branch coverage:** cover `manifests/service.pp`'s `warn_if_reboot_required => true` branch, which emits a `reboot_notify` instead of managing the service resource. Previously only the `false` branch was exercised.
- **`spec/classes/config/audit_profiles/simp_spec.rb`** — **fix 25 vacuous assertions.** A loop asserted `not_to contain_file('/etc/audit/rules.d/50_00_base.rules')…`, but the real rendered file is `50_00_simp_base.rules` (every other assertion in the file uses that name; `50_00_base.rules` appears nowhere in `manifests/`). Because the file never existed, all 25 `not_to` checks passed trivially and tested nothing; they now assert against the real file and genuinely verify that disabling a profile key removes its `-k <key>` rule.

## Known / deferred
- One assertion-less test in `simp_spec.rb` (`'uses custom tags as rule keys'`) reads a golden fixture but asserts nothing. Wiring it up revealed the expected fixture `simp_el7_all_rules_custom_tags.txt` is **stale** (lists default tags, not the custom tags the manifest correctly renders). Regenerating a golden fixture is a judgement call that deserves its own review, so it is deferred to **#260** rather than fixed here.
- No noop-after-convergence acceptance check was added (unlike sibling modules): the default acceptance suite is intentionally non-convergent (it reboots and includes a `catch_failures: false` apply), so a noop "no changes" assertion would be misleading there.

## Testing
`bundle exec rake spec` — **4290 examples, 0 failures**; `rubocop` clean on changed specs.

🤖 Generated with [Claude Code](https://claude.com/claude-code)