### PR TITLE
Add AGENTS.md gitignore/pdkignore plumbing and fix doc accuracy

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -25,4 +25,21 @@ dist
 /log
 /doc
 /Gemfile.lock
-CLAUDE.md
+
+## AI coding assistant-specific configuration
+## The standard is AGENTS.md
+# Claude Code
+/CLAUDE.md
+/.claude/
+# GitHub Copilot
+/.github/copilot-instructions.md
+# Cursor
+/.cursor/
+/.cursorrules
+# Windsurf
+/.windsurf/
+/.windsurfrules
+# Gemini CLI
+/GEMINI.md
+# Cline
+/.clinerules/

--- a/.pdkignore
+++ b/.pdkignore
@@ -55,3 +55,4 @@
 /spec/
 /.vscode/
 /tests/
+/AGENTS.md

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -87,7 +87,7 @@ The module supports auditd v2 and v3, which have different `auditd.conf` configu
 
 Module defaults live in `data/`:
 - `common.yaml` — module-wide defaults and deep merge lookup options
-- `auditd/version-2.yaml` / `auditd/version-3.yaml` — auditd-version-specific defaults
+- `auditd/version-2.yaml` / `auditd/version-3.yaml` / `auditd/version-4.yaml` — auditd-version-specific defaults
 - `os/<distro>-<major>.yaml` — OS-specific overrides (mainly `plugin_dir` paths)
 
 Many array parameters (e.g., syscall lists, ignore lists) use `lookup_options: merge: unique` to allow Hiera to combine values from multiple layers rather than replacing them.
@@ -115,8 +115,8 @@ Many array parameters (e.g., syscall lists, ignore lists) use `lookup_options: m
 
 **Required**: `puppetlabs/stdlib`, `simp/simplib`, `puppet/augeasproviders_grub`
 
-**Optional**: `simp/rsyslog` (syslog forwarding), `simp/pki`, `simp/compliance_markup`
+**Optional**: `simp/rsyslog` — pulled in only when audisp→syslog forwarding is enabled (`auditd::config::audisp::syslog` calls `simplib::assert_optional_dependency($module_name, 'simp/rsyslog')`). Not declared in `metadata.json` dependencies.
 
 ## Supported Platforms
 
-RHEL-family OS versions 8, 9, and 10 (CentOS, RedHat, AlmaLinux, Rocky, OracleLinux, Amazon Linux 2). Puppet 8.x.
+RHEL-family: RedHat/AlmaLinux/Rocky/OracleLinux 8, 9, and 10, plus CentOS 9 and 10. OpenVox 8.x.

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -115,7 +115,7 @@ Many array parameters (e.g., syscall lists, ignore lists) use `lookup_options: m
 
 **Required**: `puppetlabs/stdlib`, `simp/simplib`, `puppet/augeasproviders_grub`
 
-**Optional**: `simp/rsyslog` — pulled in only when audisp→syslog forwarding is enabled (`auditd::config::audisp::syslog` calls `simplib::assert_optional_dependency($module_name, 'simp/rsyslog')`). Not declared in `metadata.json` dependencies.
+**Optional**: `simp/rsyslog` — pulled in only when audisp→syslog forwarding is enabled (`manifests/config/audisp/syslog.pp` calls `simplib::assert_optional_dependency` for `'simp/rsyslog'`). Not declared in `metadata.json` dependencies.
 
 ## Supported Platforms
 


### PR DESCRIPTION
Two AGENTS.md-related changes — no manifest or behavior changes:

**AI-assistant plumbing** — the module already ships an `AGENTS.md`; this adds the supporting ignore rules.
- **.gitignore** — ignore vendor-specific AI-assistant configs (`CLAUDE.md`, `.claude/`, copilot, cursor, windsurf, gemini, cline) while keeping the tracked `AGENTS.md` (`CLAUDE.md` is a local, uncommitted symlink to it).
- **.pdkignore** — exclude `/AGENTS.md` from `pdk build` artifacts.

**AGENTS.md accuracy fix** — reconcile the doc with `metadata.json`: runtime is OpenVox 8 (not Puppet); supported platforms are RedHat/AlmaLinux/Rocky/OracleLinux 8–10 plus CentOS 9–10 (drop the unsupported Amazon Linux 2 and CentOS 8); add `version-4.yaml` to the Hiera data list; and list only `simp/rsyslog` as optional (the manifests never reference `simp/pki` or `simp/compliance_markup`).

Split out of the original combined PR #261 (now closed); the rspec hardening lives in #263.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
