### PR TITLE
Harden rspec coverage of lookup seams and repair dead assertions

### DIFF
--- a/spec/classes/config/audit_profiles/simp_spec.rb
+++ b/spec/classes/config/audit_profiles/simp_spec.rb
@@ -127,7 +127,7 @@ describe 'auditd' do
           let(:hieradata) { "simp_audit_profile/#{hiera_file}" }
 
           it {
-            is_expected.not_to contain_file('/etc/audit/rules.d/50_00_base.rules').with_content(
+            is_expected.not_to contain_file('/etc/audit/rules.d/50_00_simp_base.rules').with_content(
               %r{^.* -k #{key}$},
             )
           }

--- a/spec/classes/init_spec.rb
+++ b/spec/classes/init_spec.rb
@@ -55,6 +55,35 @@ describe 'auditd' do
           end
         end
 
+        # Exercises the SIMP business logic: with no parameters passed,
+        # $package_ensure and $syslog resolve through
+        # simplib::lookup('simp_options::package_ensure' / 'simp_options::syslog').
+        # The hieradata fixture sets both to values distinct from the class
+        # defaults ('installed' / false), so a pass proves the lookup path
+        # (not the default) supplied them.
+        # See spec/fixtures/hieradata/simp_options.yaml.
+        context 'with simp_options site keys set in hiera' do
+          let(:params) { {} }
+          let(:hieradata) { 'simp_options' }
+
+          it { is_expected.to compile.with_all_deps }
+          it { is_expected.to contain_package('audit').with(ensure: 'latest') }
+          it { is_expected.to contain_class('auditd').with_syslog(true) }
+        end
+
+        # manifests/service.pp branches on $warn_if_reboot_required: when true it
+        # emits a reboot_notify (warning that auditd cannot be (re)started until
+        # the kernel is enforcing auditing) INSTEAD of managing the service
+        # resource. Every other context exercises only the false branch, so this
+        # pins the true branch -- otherwise the reboot path has no unit coverage.
+        context 'with warn_if_reboot_required => true' do
+          let(:params) { { warn_if_reboot_required: true } }
+
+          it { is_expected.to compile.with_all_deps }
+          it { is_expected.to contain_reboot_notify('auditd service') }
+          it { is_expected.not_to contain_service('auditd') }
+        end
+
         context 'auditd with space_left < admin_space_left' do
           let(:params) do
             {

--- a/spec/fixtures/hieradata/simp_options.yaml
+++ b/spec/fixtures/hieradata/simp_options.yaml
@@ -1,0 +1,7 @@
+---
+# Exercises the simplib::lookup('simp_options::package_ensure', ...) and
+# simplib::lookup('simp_options::syslog', ...) fallbacks in manifests/init.pp.
+# The values are deliberately distinct from the class defaults ('installed' /
+# false) so the unit test proves the lookup path resolved them.
+simp_options::package_ensure: 'latest'
+simp_options::syslog: true


### PR DESCRIPTION
Unit-test hardening, split out of the original combined PR #261 per review feedback.

- `init_spec.rb`: add a lookup-seam context proving `$package_ensure` and `$syslog` resolve through `simplib::lookup('simp_options::*')` (fixture sets both to values distinct from the class defaults, so a pass proves the lookup path, not the default). New fixture `spec/fixtures/hieradata/simp_options.yaml`.
- `init_spec.rb`: cover `manifests/service.pp`'s `warn_if_reboot_required => true` branch (emits `reboot_notify` instead of managing the service); previously only the false branch was exercised.
- `config/audit_profiles/simp_spec.rb`: fix 25 vacuous assertions that referenced a nonexistent file `/etc/audit/rules.d/50_00_base.rules` (real file is `50_00_simp_base.rules`), so `not_to contain_file(...)` passed trivially and tested nothing.

See #260 for a related deferred finding (an assertion-less test whose expected golden fixture is stale). Branches off `master`; independent of the AGENTS.md PR (linked below).


## Related PRs (split from #261)
- AGENTS.md gitignore/pdkignore: #262
- rspec coverage: #263