### PR TITLE
Add clean-state noop acceptance test

### DIFF
--- a/spec/acceptance/suites/default/00_base_spec.rb
+++ b/spec/acceptance/suites/default/00_base_spec.rb
@@ -40,6 +40,22 @@ describe 'auditd class with simp audit profile' do
 
   hosts.each do |host|
     context "on #{host}" do
+      # Exercise noop from a clean state: on a fresh node the Sicura console
+      # previews the module with `puppet apply --noop`, which must not error.
+      # This runs before the applies below configure auditd, so it is the
+      # genuine fresh-node preview. A post-convergence noop check is omitted
+      # (`--noop --detailed-exitcodes` always exits 0). No package removal (as
+      # with fips/ssh): a fresh node already has the base `audit` package, so
+      # the honest clean state is "installed but not yet SIMP-managed", which is
+      # exactly what a bare noop of the module's manifest previews. Unlike the
+      # real apply (`catch_failures: false`, since the auditd service cannot be
+      # manually restarted), noop triggers no restart, so failures are real.
+      context 'in noop mode from a clean state' do
+        it 'applies without errors in noop mode' do
+          apply_manifest_on(host, manifest, catch_failures: true, noop: true)
+        end
+      end
+
       context 'default parameters' do
         it 'works without errors' do
           set_hieradata_on(host, hieradata)


### PR DESCRIPTION
Exercises `puppet apply --noop` of the auditd manifest from a clean state (before the suite's applies configure anything), guarding the Sicura console's fresh-node --noop preview. No package removal — matches the fips/ssh approach; a fresh node already has the base `audit` package.